### PR TITLE
Nginx docker

### DIFF
--- a/nap/docker/.env
+++ b/nap/docker/.env
@@ -1,6 +1,8 @@
 # NOTE: Prefer to README.md if you encounter any weird problems with your env variables.
 # Verify variable substitution with "docker-compose config"
 
+DOCKER_HOST_IP=172.17.0.1
+
 # CKAN
 
 CKAN_PORT=5555

--- a/nap/docker/.env
+++ b/nap/docker/.env
@@ -5,4 +5,4 @@
 
 CKAN_PORT=5555
 CKAN_SITE_ID=default
-CKAN_SITE_URL=http://localhost:5555
+CKAN_SITE_URL=http://localhost:8080

--- a/nap/docker/docker-compose.yml
+++ b/nap/docker/docker-compose.yml
@@ -67,3 +67,10 @@ services:
       - napote
     ports:
       - "6379:6379"
+
+  napote-nginx:
+    restart: always
+    container_name: napote-nginx
+    build: ./nginx
+    #image: solita/napote-nginx:latest
+    network_mode: "host"

--- a/nap/docker/docker-compose.yml
+++ b/nap/docker/docker-compose.yml
@@ -73,4 +73,9 @@ services:
     container_name: napote-nginx
     build: ./nginx
     #image: solita/napote-nginx:latest
-    network_mode: "host"
+    networks:
+      - napote
+    links:
+      - napote-ckan
+    ports:
+      - "8080:8080"

--- a/nap/docker/docker-compose.yml
+++ b/nap/docker/docker-compose.yml
@@ -77,5 +77,7 @@ services:
       - napote
     links:
       - napote-ckan
+    extra_hosts:
+      - "dockerhost:${DOCKER_HOST_IP}"
     ports:
       - "8080:8080"

--- a/nap/docker/nginx/Dockerfile
+++ b/nap/docker/nginx/Dockerfile
@@ -1,0 +1,14 @@
+# centos 7 image for Redis database
+# Is used from ckan image.
+
+FROM centos:centos7
+
+RUN yum -y --setopt=tsflags=nodocs update && \
+    yum -y --setopt=tsflags=nodocs install epel-release && \
+    yum -y --setopt=tsflags=nodocs install nginx && \
+    yum clean all
+
+COPY ./proxy.conf /etc/nginx/nginx.conf
+
+# Start nginx and tail its log
+CMD nginx && echo "Nginx started" && tail -F /var/log/nginx/access.log

--- a/nap/docker/nginx/Dockerfile
+++ b/nap/docker/nginx/Dockerfile
@@ -1,6 +1,3 @@
-# centos 7 image for Redis database
-# Is used from ckan image.
-
 FROM centos:7
 
 RUN yum -y --setopt=tsflags=nodocs update && \
@@ -9,6 +6,9 @@ RUN yum -y --setopt=tsflags=nodocs update && \
     yum clean all
 
 COPY ./proxy.conf /etc/nginx/nginx.conf
+
+
+EXPOSE 8080
 
 # Start nginx and tail its log
 CMD nginx && echo "Nginx started" && tail -F /var/log/nginx/access.log

--- a/nap/docker/nginx/Dockerfile
+++ b/nap/docker/nginx/Dockerfile
@@ -1,7 +1,7 @@
 # centos 7 image for Redis database
 # Is used from ckan image.
 
-FROM centos:centos7
+FROM centos:7
 
 RUN yum -y --setopt=tsflags=nodocs update && \
     yum -y --setopt=tsflags=nodocs install epel-release && \

--- a/nap/docker/nginx/proxy.conf
+++ b/nap/docker/nginx/proxy.conf
@@ -1,0 +1,47 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+
+    upstream ckan {
+      server localhost:5555;
+    }
+
+    upstream ote {
+      server localhost:3000;
+    }
+
+    server {
+      listen 8080;
+      location /ote {
+        proxy_pass http://ote;
+      }
+      location / {
+        proxy_pass http://ckan;
+      }
+    }
+}

--- a/nap/docker/nginx/proxy.conf
+++ b/nap/docker/nginx/proxy.conf
@@ -32,7 +32,7 @@ http {
     }
 
     upstream ote {
-      server localhost:3000;
+      server dockerhost:3000;
     }
 
     server {

--- a/nap/docker/nginx/proxy.conf
+++ b/nap/docker/nginx/proxy.conf
@@ -28,7 +28,7 @@ http {
 
 
     upstream ckan {
-      server localhost:5555;
+      server napote-ckan:5000;
     }
 
     upstream ote {
@@ -37,11 +37,19 @@ http {
 
     server {
       listen 8080;
-      location /ote {
-        proxy_pass http://ote;
+
+      location /ote/ {
+        proxy_pass http://ote/;
       }
+
       location / {
-        proxy_pass http://ckan;
+        proxy_pass http://ckan/;
+        #proxy_set_header X-Real-IP $remote_addr;
+        #proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        #proxy_set_header X-Forwarded-Proto $scheme;
+        #proxy_set_header X-Forwarded-Server $host;
+        #proxy_set_header X-Forwarded-Host $host;
+        #proxy_set_header Host $host;
       }
     }
 }


### PR DESCRIPTION
This feature adds a new docker container for nginx.
NGINX serves ckan and ote under a single host localhost:8080.
Local CKAN is accessible through localhost:8080/ and OTE is accessible through localhost:8080/ote/index.html (if ote server is running).