### PR TITLE
NAP-141 CKAN custom dataset fields

### DIFF
--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
@@ -1,44 +1,121 @@
 # encoding: utf-8
 
 import ckan.plugins as plugins
-import ckan.plugins.toolkit as toolkit
+import ckan.plugins.toolkit as tk
 from ckan.lib.plugins import DefaultTranslation
 
+# TODO: We should get these from the database
+municipalitys = (
+    u'Helsinki', u'Ii', u'Joensuu', u'Kempele', u'Muhos', u'Oulu', u'Pieksämäki', u'Salo', u'Seinäjoki', u'Vantaa')
+transport_services = (u'Terminal', u'Passenger Transportation', u'Rental', u'Parking', u'Brokerage')
 
-class NapoteThemePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
+
+def create_transport_service_types():
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
+    context = {'user': user['name']}
+
+    try:
+        data = {'id': 'transport_service_types'}
+        tk.get_action('vocabulary_show')(context, data)
+    except tk.ObjectNotFound:
+        data = {'name': 'transport_service_types'}
+        vocab = tk.get_action('vocabulary_create')(context, data)
+
+        for tag in transport_services:
+            data = {'name': tag, 'vocabulary_id': vocab['id']}
+            tk.get_action('tag_create')(context, data)
+
+
+def transport_service_types():
+    create_transport_service_types()
+
+    try:
+        tag_list = tk.get_action('tag_list')
+        service_types = tag_list(data_dict={'vocabulary_id': 'transport_service_types'})
+        return service_types
+    except tk.ObjectNotFound:
+        return None
+
+
+def create_mock_operation_areas():
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
+    context = {'user': user['name']}
+
+    try:
+        data = {'id': 'operation_areas'}
+        tk.get_action('vocabulary_show')(context, data)
+    except tk.ObjectNotFound:
+        data = {'name': 'operation_areas'}
+        vocab = tk.get_action('vocabulary_create')(context, data)
+
+        for tag in municipalitys:
+            data = {'name': tag, 'vocabulary_id': vocab['id']}
+            tk.get_action('tag_create')(context, data)
+
+
+def operation_areas():
+    create_mock_operation_areas()
+
+    try:
+        tag_list = tk.get_action('tag_list')
+        service_types = tag_list(data_dict={'vocabulary_id': 'operation_areas'})
+        return service_types
+    except tk.ObjectNotFound:
+        return None
+
+
+def tags_to_select_options(tags=None):
+    if tags is None:
+        tags = []
+    return [{'name': tag, 'value': tag} for tag in tags]
+
+
+class NapoteThemePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
     # http://docs.ckan.org/en/latest/extensions/translating-extensions.html
     # Enable after translations have been generated
-    #plugins.implements(plugins.ITranslation)
+    # plugins.implements(plugins.ITranslation)
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IDatasetForm)
+    plugins.implements(plugins.ITemplateHelpers)
+
+    def get_helpers(self):
+        return {
+            'transport_service_types': transport_service_types,
+            'operation_areas': operation_areas,
+            'tags_to_select_options': tags_to_select_options}
 
     def update_config(self, config):
         # Add this plugin's templates dir to CKAN's extra_template_paths, so
         # that CKAN will use this plugin's custom templates.
         # 'templates' is the path to the templates dir, relative to this
         # plugin.py file.
-        toolkit.add_template_directory(config, 'templates')
+        tk.add_template_directory(config, 'templates')
 
         # Register this plugin's fanstatic directory with CKAN.
         # Here, 'fanstatic' is the path to the fanstatic directory
         # (relative to this plugin.py file), and 'napote_theme' is the name
         # that we'll use to refer to this fanstatic directory from CKAN
         # templates.
-        toolkit.add_resource('fanstatic', 'napote_theme')
+        tk.add_resource('fanstatic', 'napote_theme')
 
         # Public directory for static images
-        toolkit.add_public_directory(config, 'public')
+        tk.add_public_directory(config, 'public')
 
     def nap_package_schema(self):
         # Take default schema
         schema = super(NapoteThemePlugin, self).create_package_schema()
+
         # add custom fields
         schema.update({
             'transport_service_type': [tk.get_validator('ignore_missing'),
-                                       tk.get_converter('convert_to_extras')],
-            'operation_area': [tk.get_validator('ignore_missing'),
-                               tk.get_converter('convert_to_extras')]
+                                       tk.get_converter('convert_to_tags')('transport_service_types')]
         })
+
+        schema.update({
+            'operation_area': [tk.get_validator('ignore_missing'),
+                               tk.get_converter('convert_to_tags')('operation_areas')]
+        })
+
         return schema
 
     def create_package_schema(self):
@@ -49,12 +126,20 @@ class NapoteThemePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     def show_package_schema(self):
         schema = super(NapoteThemePlugin, self).show_package_schema()
+
+        # Prevent listing vocabulary tags mixed in with normal tags
+        schema['tags']['__extras'].append(tk.get_converter('free_tags_only'))
+
         schema.update({
-            'transport_service_type': [tk.get_converter('convert_from_extras'),
+            'transport_service_type': [tk.get_converter('convert_from_tags')('transport_service_types'),
                                        tk.get_validator('ignore_missing')],
-            'operation_area': [tk.get_converter('convert_from_extras'),
+        })
+
+        schema.update({
+            'operation_area': [tk.get_converter('convert_from_tags')('operation_areas'),
                                tk.get_validator('ignore_missing')]
         })
+
         return schema
 
     def is_fallback(self):

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
@@ -5,11 +5,12 @@ import ckan.plugins.toolkit as toolkit
 from ckan.lib.plugins import DefaultTranslation
 
 
-class NapoteThemePlugin(plugins.SingletonPlugin):
+class NapoteThemePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     # http://docs.ckan.org/en/latest/extensions/translating-extensions.html
     # Enable after translations have been generated
     #plugins.implements(plugins.ITranslation)
     plugins.implements(plugins.IConfigurer)
+    plugins.implements(plugins.IDatasetForm)
 
     def update_config(self, config):
         # Add this plugin's templates dir to CKAN's extra_template_paths, so
@@ -27,3 +28,31 @@ class NapoteThemePlugin(plugins.SingletonPlugin):
 
         # Public directory for static images
         toolkit.add_public_directory(config, 'public')
+
+    def nap_package_schema(self):
+        # Take default schema
+        schema = super(NapoteThemePlugin, self).create_package_schema()
+        # add custom fields
+        schema.update({
+            'transport_service_type': [tk.get_validator('ignore_missing'),
+                                       tk.get_converter('convert_to_extras')],
+            'operation_area': [tk.get_validator('ignore_missing'),
+                               tk.get_converter('convert_to_extras')]
+        })
+        return schema
+
+    def create_package_schema(self):
+        return self.nap_package_schema()
+
+    def update_package_schema(self):
+        return self.nap_package_schema()
+
+    def show_package_schema(self):
+        schema = super(NapoteThemePlugin, self).show_package_schema()
+        schema.update({
+            'transport_service_type': [tk.get_converter('convert_from_extras'),
+                                       tk.get_validator('ignore_missing')],
+            'operation_area': [tk.get_converter('convert_from_extras'),
+                               tk.get_converter('ignore_missing')]
+        })
+        return schema

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
@@ -53,6 +53,12 @@ class NapoteThemePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'transport_service_type': [tk.get_converter('convert_from_extras'),
                                        tk.get_validator('ignore_missing')],
             'operation_area': [tk.get_converter('convert_from_extras'),
-                               tk.get_converter('ignore_missing')]
+                               tk.get_validator('ignore_missing')]
         })
         return schema
+
+    def is_fallback(self):
+        return True
+
+    def package_types(self):
+        return []

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
@@ -77,6 +77,7 @@ class NapoteThemePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IFacets)
 
     def get_helpers(self):
         return {
@@ -101,6 +102,17 @@ class NapoteThemePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
         # Public directory for static images
         tk.add_public_directory(config, 'public')
 
+    def dataset_facets(self, facets_dict, package_type):
+        facets_dict.clear()
+
+        facets_dict['organization'] = tk._('Organizations')
+        facets_dict['vocab_transport_service_types'] = tk._('Transport Service Type')
+        facets_dict['vocab_operation_areas'] = tk._('Operation Area')
+        facets_dict['tags'] = tk._('Tags')
+        facets_dict['res_format'] = tk._('Formats')
+        facets_dict['license'] = tk._('License')
+
+        return facets_dict
 
     def _modify_package_schema(self, schema):
         # add custom fields
@@ -115,7 +127,6 @@ class NapoteThemePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
         })
 
         return schema
-
 
     def show_package_schema(self):
         schema = super(NapoteThemePlugin, self).show_package_schema()

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
@@ -101,10 +101,8 @@ class NapoteThemePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
         # Public directory for static images
         tk.add_public_directory(config, 'public')
 
-    def nap_package_schema(self):
-        # Take default schema
-        schema = super(NapoteThemePlugin, self).create_package_schema()
 
+    def _modify_package_schema(self, schema):
         # add custom fields
         schema.update({
             'transport_service_type': [tk.get_validator('ignore_missing'),
@@ -118,11 +116,6 @@ class NapoteThemePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
 
         return schema
 
-    def create_package_schema(self):
-        return self.nap_package_schema()
-
-    def update_package_schema(self):
-        return self.nap_package_schema()
 
     def show_package_schema(self):
         schema = super(NapoteThemePlugin, self).show_package_schema()
@@ -139,6 +132,18 @@ class NapoteThemePlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
             'operation_area': [tk.get_converter('convert_from_tags')('operation_areas'),
                                tk.get_validator('ignore_missing')]
         })
+
+        return schema
+
+    def create_package_schema(self):
+        schema = super(NapoteThemePlugin, self).create_package_schema()
+        schema = self._modify_package_schema(schema)
+
+        return schema
+
+    def update_package_schema(self):
+        schema = super(NapoteThemePlugin, self).update_package_schema()
+        schema = self._modify_package_schema(schema)
 
         return schema
 

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/read.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/read.html
@@ -1,0 +1,19 @@
+{% ckan_extends %}
+
+{% block package_description %}
+    {{ super() }}
+
+    {# Add custom fields to the dataset read page #}
+    {% if pkg.get('transport_service_type') %}
+        <section id="dataset-transport_service_type" class="resources module-content">
+            <p><strong>Transport Service Type</strong>: {{ pkg.transport_service_type[0] }}</p>
+        </section>
+    {% endif %}
+
+    {% if pkg.get('operation_area') %}
+        <section id="dataset-operation_area" class="resources module-content">
+            <p><strong>Operation Area</strong>: {{ pkg.operation_area[0] }}</p>
+        </section>
+    {% endif %}
+
+{% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
@@ -3,9 +3,9 @@
 {% block package_basic_fields_custom %}
     {{ form.select('transport_service_type', label=_('Service Type'),
         options=h.tags_to_select_options(h.transport_service_types()),
-        selected=data.transport_service_type[0], is_required=True) }}
+        selected=data.get('transport_service_type', [])[0], is_required=True) }}
 
     {{ form.select('operation_area', label=_('Operation Area'),
         options=h.tags_to_select_options(h.operation_areas()),
-        selected=data.operation_area[0] , is_required=True) }}
+        selected=data.get('operation_area', [])[0] , is_required=True) }}
 {% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
@@ -1,11 +1,29 @@
 {% ckan_extends %}
 
 {% block package_basic_fields_custom %}
-    {{ form.select('transport_service_type', label=_('Service Type'),
-        options=h.tags_to_select_options(h.transport_service_types()),
-        selected=data.get('transport_service_type', [])[0], is_required=True) }}
+    {%- set extra_html = caller() if caller -%}
+    {% call form.input_block('transport_service_type', _('Service Type'), errors.transport_service_type, ['control-select'], extra_html=extra_html, is_required=True) %}
+        <select id="transport_service_type" name="transport_service_type" data-module="autocomplete">
+            {% set current_transport_service_type = data.get('transport_service_type', [])[0] %}
+            {% for transport_service_type in h.transport_service_types() %}
+                <option value="{{ transport_service_type }}"
+                        {% if current_transport_service_type == transport_service_type %}
+                        selected="selected"{% endif %}>
+                    {{ transport_service_type }}</option>
+            {% endfor %}
+        </select>
+    {% endcall %}
 
-    {{ form.select('operation_area', label=_('Operation Area'),
-        options=h.tags_to_select_options(h.operation_areas()),
-        selected=data.get('operation_area', [])[0] , is_required=True) }}
+    {%- set extra_html = caller() if caller -%}
+    {% call form.input_block('operation_area', _('Operation Area'), errors.operation_area, ['control-select'], extra_html=extra_html, is_required=True) %}
+        <select id="operation_area" name="operation_area" data-module="autocomplete">
+            {% set current_operation_area = data.get('operation_area', [])[0] %}
+            {% for operation_area in h.operation_areas() %}
+                <option value="{{ operation_area }}"
+                        {% if current_operation_area == operation_area %}
+                        selected="selected"{% endif %}>
+                    {{ operation_area }}</option>
+            {% endfor %}
+        </select>
+    {% endcall %}
 {% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block package_basic_fields_custom %}
+    {{ form.select('transport_service_type', label=_('Service Type'),
+        options=h.tags_to_select_options(h.transport_service_types()),
+        selected=data.get('transport_service_type', []), is_required=True) }}
+
+    {{ form.select('operation_area', label=_('Operation Area'),
+        options=h.tags_to_select_options(h.operation_areas()),
+        selected=data.get('operation_area', []) , is_required=True) }}
+{% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_basic_fields.html
@@ -3,9 +3,9 @@
 {% block package_basic_fields_custom %}
     {{ form.select('transport_service_type', label=_('Service Type'),
         options=h.tags_to_select_options(h.transport_service_types()),
-        selected=data.get('transport_service_type', []), is_required=True) }}
+        selected=data.transport_service_type[0], is_required=True) }}
 
     {{ form.select('operation_area', label=_('Operation Area'),
         options=h.tags_to_select_options(h.operation_areas()),
-        selected=data.get('operation_area', []) , is_required=True) }}
+        selected=data.operation_area[0] , is_required=True) }}
 {% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_metadata_fields.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/package/snippets/package_metadata_fields.html
@@ -1,0 +1,32 @@
+{% ckan_extends %}
+
+{% block package_metadata_fields %}
+
+    {% block package_metadata_fields_url %}
+        {{ form.input('url', label=_('Source'), id='field-url', placeholder=_('http://example.com/dataset.json'), value=data.url, error=errors.url, classes=['control-medium']) }}
+    {% endblock %}
+
+    {% block package_metadata_fields_version %}
+        {{ form.input('version', label=_('Version'), id='field-version', placeholder=_('1.0'), value=data.version, error=errors.version, classes=['control-medium']) }}
+    {% endblock %}
+
+    {% block package_metadata_author %}
+        {{ form.input('author', label=_('Author'), id='field-author', placeholder=_('Joe Bloggs'), value=data.author, error=errors.author, classes=['control-medium']) }}
+
+        {{ form.input('author_email', label=_('Author Email'), id='field-author-email', placeholder=_('joe@example.com'), value=data.author_email, error=errors.author_email, classes=['control-medium']) }}
+    {% endblock %}
+
+    {% block package_metadata_fields_maintainer %}
+        {{ form.input('maintainer', label=_('Maintainer'), id='field-maintainer', placeholder=_('Joe Bloggs'), value=data.maintainer, error=errors.maintainer, classes=['control-medium']) }}
+
+        {{ form.input('maintainer_email', label=_('Maintainer Email'), id='field-maintainer-email', placeholder=_('joe@example.com'), value=data.maintainer_email, error=errors.maintainer_email, classes=['control-medium']) }}
+    {% endblock %}
+
+    {# Remove CKAN provided custom fields #}
+    {% block package_metadata_fields_custom %}
+    {% endblock %}
+
+    {% block dataset_fields %}
+    {% endblock %}
+
+{% endblock %}


### PR DESCRIPTION
This pull request will add the following new features for the ckan theme plugin:
* Two custom mandatory datafields for the dataset creation form: Transport service type and operation area.
* Display the selected field values on the dataset info page.
* Two custom facet categories for the datasets page: Transport Service Type and Operation Area.