### PR TITLE
NAP-207 CKAN styles update

### DIFF
--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
@@ -578,12 +578,13 @@ body {
     text-transform: uppercase;
     text-align: center;
     letter-spacing: .5px;
-    height: 36px;
+    min-height: 36px;
     font-size: 1rem;
     font-weight: normal;
     outline: 0;
     box-shadow: 0 1px 4px rgba(0, 0, 0, .6);
     transition: background-color .3s;
+    word-wrap: break-word;
 }
 
 .homepage .btn:hover {
@@ -631,6 +632,15 @@ body {
 }
 
 /** HOME **/
+.homepage .box.box--spaced {
+    box-sizing: border-box;
+    display: flex;
+    min-height: 300px;
+    padding: 25px 25px 40px 25px;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
 .homepage .box.box--gradient {
     border: #d5d5d5 solid 1px;
     background: #ffffff; /* Old browsers */

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
@@ -566,9 +566,8 @@ body {
 }
 
 /** NOTE: Some btn style rules are from materializecss.com **/
-.homepage .btn {
+.homepage [role=main] .btn {
     border: none;
-    color: #ffffff;
     padding: 0 2rem;
     border-radius: 2px;
     overflow: hidden;
@@ -587,15 +586,16 @@ body {
     word-wrap: break-word;
 }
 
-.homepage .btn:hover {
-    background: #2f97dd;
+.homepage [role=main] .btn:hover {
+    background: #d3d3d3;
 }
 
-.homepage .btn.btn-primary {
+.homepage [role=main] .btn.btn-primary {
     background: #2D75B4;
+    color: #ffffff;
 }
 
-.homepage .btn.btn-primary:hover {
+.homepage [role=main] .btn.btn-primary:hover {
     background: #2f97dd;
 }
 
@@ -603,6 +603,13 @@ body {
 .site-footer {
     background: #444444; /** LIVI lisäväri, harmaat 5. **/
     color: #ffffff;
+}
+
+/** Modules **/
+
+.module .module-heading {
+    color: #ffffff;
+    background-color: #2D75B4;
 }
 
 /*

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
@@ -648,3 +648,11 @@ body {
     background: -webkit-linear-gradient(top, #ffffff 0%,#f5f5f5 100%);
     background: linear-gradient(to bottom, #ffffff 0%,#f5f5f5 100%);
 }
+
+/**
+  Buttons
+ */
+
+.btn.btn--transparent {
+    background: transparent;
+}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
@@ -45,13 +45,14 @@
                                 {% if c.userobj %}
                                     <div class="dropdown account avatar authed" data-module="me"
                                          data-me="{{ c.userobj.id }}">
-                                        <button class="btn btn-primary dropdown-toggle" type="button"
+                                        <button class="btn btn-primary btn--transparent dropdown-toggle"
+                                                type="button"
                                                 data-toggle="dropdown">
                         <span class="image" title="{{ _('View profile') }}">
                                 {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=22) }}
                                 <span class="username">{{ c.userobj.display_name }}</span>
                         </span>
-                                            <span class="caret"></span></button>
+                                            <i class="fa fa-caret-down" aria-hidden="true"></i></button>
                                         <ul class="dropdown-menu">
                                             {% block header_account_logged %}
                                                 <li>

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
@@ -33,7 +33,7 @@
                         {% block header_site_navigation %}
                             <ul class="nav nav-pills">
                                 {% block header_site_navigation_tabs %}
-                                    {{ h.build_nav_main(('home', _('Home')),('search', _('Palvelukatalogi')),('organizations_index', _('Organizations')) ) }}
+                                    {{ h.build_nav_main(('home', _('Home')),('search', _('Datasets')),('organizations_index', _('Organizations')) ) }}
                                 {% endblock %}
                             </ul>
                         {% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
@@ -33,12 +33,8 @@
                         {% block header_site_navigation %}
                             <ul class="nav nav-pills">
                                 {% block header_site_navigation_tabs %}
-                                    {{ h.build_nav_main(('home', _('Home')),('search', _('Datasets')),('organizations_index', _('Organizations')) ) }}
+                                    {{ h.build_nav_main(('home', _('Home')),('search', _('Palvelukatalogi')),('organizations_index', _('Organizations')) ) }}
                                 {% endblock %}
-
-                                {% if c.userobj %}
-                                    <li><a href="/ote/index.html">OTE</a></li>
-                                {% endif %}
                             </ul>
                         {% endblock %}
                     </nav>
@@ -89,6 +85,15 @@
                                                            title="{{ _('Edit settings') }}">
                                                             <i class="fa fa-cog" aria-hidden="true"></i>
                                                             <span class="text">{{ _('Settings') }}</span>
+                                                        </a>
+                                                    </li>
+                                                {% endblock %}
+                                                {% block header_account_nap_manager_link %}
+                                                    <li>
+                                                        <a href="/ote/index.html"
+                                                           title="{{ _('NAP-tietojen hallinta') }}">
+                                                            <i class="fa fa-edit" aria-hidden="true"></i>
+                                                            <span class="text">{{ _('NAP-tietojen hallinta') }}</span>
                                                         </a>
                                                     </li>
                                                 {% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
@@ -33,7 +33,7 @@
                 </div>
                 <div class="span6">
                     <div class="module-content box box--spaced box--gradient text-center">
-                        <p>{% trans %}Haluatko tallentaa tai päivittää linja-autoreittejä ja aikataulu-tietoja
+                        <p>{% trans %}Haluatko tallentaa tai päivittää linja-autoreittejä ja aikataulutietoja
                             RAE-palvelussa?{% endtrans %}</p>
 
                         <div>

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
@@ -12,44 +12,45 @@
 
             <div class="row row2 module">
                 <div class="span12">
-                    <h2>Liikkumispalveluiden julkaisu</h2>
+                    <h2>Liikkumispalveluiden tallennus ja julkaisu</h2>
                 </div>
-                <div class="span12">
-                    <div class="module-content box box--gradient text-center">
-                        <p>{% trans %}Haluatko julkaista uusia tai päivittää aiemmin julkaisemiasi rajapintoja
-                            palvelukatalogiin?
-                            Rajapinnat ovat joko itse ylläpidettyjä, Liikenneviraston OTE-palvelussa ylläpidettyjä tai
-                            RAE-palvelussa ylläpidettyjä.{% endtrans %}</p>
+                <div class="span6">
+                    <div class="module-content box box--spaced box--gradient text-center">
+                        <p>{% trans %}Liikkumispalvelusi olennaisten tietojen kirjaaminen, muokkaaminen ja julkaisu
+                            hoituu kätevästi NAP-tietojen hallintapaneelissa.{% endtrans %}</p>
 
-                        <p>{% link_for _('Siirry palvelukatalogiin'), controller='user', action='login', class_='btn btn-primary' %}</p>
+                        <div>
+                            <p>
+                                <a class="btn btn-primary"
+                                   href="/ote/index.html">{{ _('Siirry tietojen hallintapalveluun') }}</a>
+                            </p>
+                            <p>
+                                <small>(Aukeaa uuteen välilehteen)</small>
+                            </p>
+                        </div>
                     </div>
                 </div>
-            </div>
-
-            <div class="row row3">
-                <div class="span12">
-                    <h2>Liikkumispalveluiden digitointi</h2>
-                </div>
-                <div class="span4">
-                    <div class="box box--gradient text-center">
-                        <p>{% trans %}Sinulla on jo oma, itse ylläpidetty rajapinta (esimerkiksi GTFS-muodossa), jonka
-                            kuvailutietoja haluat julkaista.{% endtrans %}</p>
-                        <p>{% link_for _('Siirry palvelukatalogiin'), controller='user', action='login', class_='btn btn-primary' %}</p>
-                    </div>
-                </div>
-                <div class="span4">
-                    <div class="box box--gradient text-center">
-                        <p>{% trans %}Sinulla ei ole omaa itse ylläpidettyä rajapintaa ja haluat digitoida tai päivittää
-                            liikkumispalvelusi tietoja Liikenneviraston olennaisten tietojen editorilla
-                            (OTE)?{% endtrans %}</p>
-                        <p>{% link_for _('Avaa OTE-palvelu'), controller='user', action='login', class_='btn btn-primary' %}</p>
-                    </div>
-                </div>
-                <div class="span4">
-                    <div class="box box--gradient text-center">
+                <div class="span6">
+                    <div class="module-content box box--spaced box--gradient text-center">
                         <p>{% trans %}Haluatko tallentaa tai päivittää linja-autoreittejä ja aikataulu-tietoja
                             RAE-palvelussa?{% endtrans %}</p>
-                        <p>{% link_for _('Avaa RAE-palvelu'), controller='user', action='login', class_='btn btn-primary' %}</p>
+
+                        <div>
+                            <p>
+                                {# NOTE: https://mathiasbynens.github.io/rel-noopener/ Avoid a browser vulnerability by using noopener noreferrer. #}
+
+                                <a class="btn btn-primary"
+                                   href="https://extranet.liikennevirasto.fi/extranet/web/f/rae?kategoria=1955433"
+                                   target="_blank" rel="noopener noreferrer">{{ _('Avaa RAE-palvelu') }}</a>
+                            </p>
+                            <p>
+                                <small>(Aukeaa uuteen välilehteen ja vaatii erillisen <br /> kirjautumisen
+                                    Liikenneviraston
+                                    Extranetiin)
+                                </small>
+                            </p>
+                        </div>
+
                     </div>
                 </div>
             </div>

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
@@ -3,16 +3,17 @@
         <div class="container">
             <div class="row row1 module">
                 <div class="span12">
-                    <p>Hei {{ c.userobj.display_name }}!</p>
-                    <b>Palvelukatalogi</b>-sivulla voit tarkastella ja hakea palvelussa julkaistuja
-                    rajapintoja.<br />
-                    <b>Organisaatiot</b>-sivulla on listattuna palveluun rekisteröityneet organisaatiot.
+                    <p>{{ _('Hei') }} {{ c.userobj.display_name }}!</p>
+                    <b>{{ _('Datasets') }}</b>-{% trans %}sivulla voit tarkastella ja hakea palvelussa julkaistuja
+                    rajapintoja.{% endtrans %}<br />
+                    <b>{{ _('Organizations') }}</b>{% trans %}-sivulla on listattuna palveluun rekisteröityneet
+                    organisaatiot.{% endtrans %}
                 </div>
             </div>
 
             <div class="row row2 module">
                 <div class="span12">
-                    <h2>Liikkumispalveluiden tallennus ja julkaisu</h2>
+                    <h2>{% trans %}Liikkumispalveluiden tallennus ja julkaisu{% endtrans %}</h2>
                 </div>
                 <div class="span6">
                     <div class="module-content box box--spaced box--gradient text-center">
@@ -25,7 +26,7 @@
                                    href="/ote/index.html">{{ _('Siirry tietojen hallintapalveluun') }}</a>
                             </p>
                             <p>
-                                <small>(Aukeaa uuteen välilehteen)</small>
+                                <small>({% trans %}Aukeaa uuteen välilehteen{% endtrans %})</small>
                             </p>
                         </div>
                     </div>
@@ -44,9 +45,9 @@
                                    target="_blank" rel="noopener noreferrer">{{ _('Avaa RAE-palvelu') }}</a>
                             </p>
                             <p>
-                                <small>(Aukeaa uuteen välilehteen ja vaatii erillisen <br /> kirjautumisen
+                                <small>({% trans %}Aukeaa uuteen välilehteen ja vaatii erillisen <br /> kirjautumisen
                                     Liikenneviraston
-                                    Extranetiin)
+                                    Extranetiin{% endtrans %})
                                 </small>
                             </p>
                         </div>


### PR DESCRIPTION
Updating CKAN plugin templates and styles to conform with the newest UI proto.

* Note for later development: Strings "Tietoaineistot" and "Aloitussivu" are not yet changed to "Palvelukatalogi" or "Etusivu" in the template files. We will change the finnish translation of "Datasets" to "Palvelukatalogi" and so on, but that requires generating custom translation files for this plugin. That should be a different ticket, due the amount of work required. 
Additionally, we should use english as the base language in our template files, so we don't get strange mixed language translation files when we eventually generate them. 
This is not a blocker for this pull request, as this mainly concerns template style changes. The text string fixes and translating will be a separate ticket.