### PR TITLE
NAP 176 Embed OTE in CKAN org info view

### DIFF
--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/about.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/about.html
@@ -1,0 +1,5 @@
+{%  ckan_extends %}
+
+{% block primary_content_inner %}
+    {%  snippet 'organization/snippets/transport_operator_view.html' %}
+{% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/snippets/transport_operator_view.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/snippets/transport_operator_view.html
@@ -1,0 +1,13 @@
+<style id="_stylefy-constant-styles_"></style>
+<style id="_stylefy-styles_"></style>
+
+<div id="nap_viewer">
+
+</div>
+
+<script src="/ote/js/out/goog/base.js"></script>
+<script src="/ote/js/ote.js"></script>
+<script>goog.require("ote.main")</script>
+<script>
+    ote.main.org_view();
+</script>

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/snippets/transport_operator_view.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/snippets/transport_operator_view.html
@@ -1,9 +1,9 @@
+{% set organization=c.group_dict %}
+
 <style id="_stylefy-constant-styles_"></style>
 <style id="_stylefy-styles_"></style>
 
-<div id="nap_viewer">
-
-</div>
+<div id="nap_viewer" data-group-id={{ organization.id }}></div>
 
 <script src="/ote/js/out/goog/base.js"></script>
 <script src="/ote/js/ote.js"></script>

--- a/ote/src/clj/ote/services/localization.clj
+++ b/ote/src/clj/ote/services/localization.clj
@@ -12,10 +12,11 @@
   component/Lifecycle
   (start [{http :http :as this}]
     (assoc
-     this ::stop
-     (http/publish! http (routes
-                          (GET "/language/:lang" [lang]
-                               (fetch-language lang))))))
+      this ::stop
+           (http/publish! http {:authenticated? false}
+                          (routes
+                            (GET "/language/:lang" [lang]
+                              (fetch-language lang))))))
   (stop [{stop ::stop :as this}]
     (stop)
     (dissoc this ::stop)))

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -181,8 +181,9 @@
                         ::t-service/id transport-service-id}))))
 
 
-(defn- transport-routes-auth [db nap-config]
+(defn- transport-routes-auth
   "Routes that require authentication"
+  [db nap-config]
   (routes
 
    (GET "/transport-service/:id" [id]
@@ -219,8 +220,9 @@
    (GET "/transport-service/delete/:id" [id]
      (http/transit-response (delete-transport-service db (Long/parseLong id))))))
 
-(defn- transport-routes [db nap-config]
+(defn- transport-routes
   "Unauthenticated routes"
+  [db nap-config]
   (routes
     (GET "/transport-operator/:ckan-group-id" [ckan-group-id]
       (http/transit-response (get-transport-operator db {::transport-operator/ckan-group-id ckan-group-id})))))

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -181,8 +181,8 @@
                         ::t-service/id transport-service-id}))))
 
 
-(defn- transport-routes
-  [db nap-config]
+(defn- transport-routes-auth [db nap-config]
+  "Routes that require authentication"
   (routes
 
    (GET "/transport-service/:id" [id]
@@ -219,12 +219,19 @@
    (GET "/transport-service/delete/:id" [id]
      (http/transit-response (delete-transport-service db (Long/parseLong id))))))
 
+(defn- transport-routes [db nap-config]
+  "Unauthenticated routes"
+  (routes
+    (GET "/transport-operator/:ckan-group-id" [ckan-group-id]
+      (http/transit-response (get-transport-operator db {::transport-operator/ckan-group-id ckan-group-id})))))
+
 (defrecord Transport [nap-config]
   component/Lifecycle
   (start [{:keys [db http] :as this}]
     (assoc
       this ::lopeta
-           (http/publish! http (transport-routes db nap-config))))
+           (http/publish! http (transport-routes-auth db nap-config))
+           (http/publish! http {:authenticated? false} (transport-routes db nap-config))))
   (stop [{lopeta ::lopeta :as this}]
     (lopeta)
     (dissoc this ::lopeta)))

--- a/ote/src/cljs/ote/app/controller/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/app/controller/ckan_org_viewer.cljs
@@ -1,0 +1,19 @@
+(ns ote.app.controller.ckan-org-viewer
+  "Controller and events for org edit mode (CKAN embedded view)."
+  (:require [tuck.core :as tuck]
+            [ote.communication :as comm]
+            [taoensso.timbre :as log]
+            [ote.app.controller.front-page :as fp-ctrl]))
+
+
+
+(defrecord StartViewer [])
+
+(extend-protocol tuck/Event
+
+  StartViewer
+  (process-event [_ app]
+    ; Trigger transport operator data fetch action
+    (tuck/action!
+      (fn [e!]
+        (e! (fp-ctrl/->GetTransportOperatorData))))))

--- a/ote/src/cljs/ote/main.cljs
+++ b/ote/src/cljs/ote/main.cljs
@@ -10,6 +10,7 @@
             [ote.app.state :as state]
             [ote.views.main :as main]
             [ote.views.viewer :as viewer]
+            [ote.views.ckan-org-viewer :as ckan-org-viewer]
             [ote.localization :as localization]
             [ote.app.routes :as routes]
             [stylefy.core :as stylefy]
@@ -37,3 +38,13 @@
      (stylefy/init)
      (r/render-component [tuck/tuck state/viewer viewer/viewer]
                          (.getElementById js/document "nap_viewer")))))
+
+(defn ^:export org_view []
+  (comm/set-base-url! "/ote/")
+  (localization/load-language!
+    :fi
+    (fn [lang _]
+      (reset! localization/selected-language lang)
+      (stylefy/init)
+      (r/render-component [tuck/tuck state/app ckan-org-viewer/viewer]
+                          (.getElementById js/document "nap_viewer")))))

--- a/ote/src/cljs/ote/views/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_viewer.cljs
@@ -10,8 +10,9 @@
             [ote.style.ckan :as style-ckan]
             [ote.localization :refer [tr tr-or]]))
 
-(defn transform-val [key value]
+(defn transform-val
   "Translate and transform value."
+  [key value]
   (tr-or (tr [key value]) (str value)))
 
 (defn basic-info [operator]

--- a/ote/src/cljs/ote/views/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_viewer.cljs
@@ -52,6 +52,7 @@
   ;; init
   (e! (org-viewer/->StartViewer))
   (fn [e! {:keys [transport-operator] :as app}]
-    [:div.container
-     [basic-info transport-operator]
-     [contact-info transport-operator]]))
+    (when transport-operator
+      [:div.container
+       [basic-info transport-operator]
+       [contact-info transport-operator]])))

--- a/ote/src/cljs/ote/views/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_viewer.cljs
@@ -1,0 +1,57 @@
+(ns ote.views.ckan-org-viewer
+  "OTE organization edit form for CKAN organization edit page. (CKAN embedded view)
+  Note that this view uses CKAN css classes, mainly bootstrap 2.x."
+  (:require [ote.app.controller.ckan-org-viewer :as org-viewer]
+            [clojure.string :as str]
+            [ote.app.controller.transport-operator :as to]
+            [ote.db.transport-operator :as to-definitions]
+            [ote.db.common :as common]
+            [stylefy.core :as stylefy]
+            [ote.style.ckan :as style-ckan]
+            [ote.localization :refer [tr tr-or]]))
+
+(defn transform-val [key value]
+  "Translate and transform value."
+  (tr-or (tr [key value]) (str value)))
+
+(defn basic-info [operator]
+  [:div.row
+   [:div.span12 [:h2 (transform-val :common-texts :title-operator-basic-details)]]
+
+   [:div.span2 [:b (transform-val :field-labels ::to-definitions/name)]]
+   [:div.span10 (operator ::to-definitions/name "N/A")]
+
+   [:div.span2 [:b (transform-val :field-labels ::to-definitions/business-id)]]
+   [:div.span10 (operator ::to-definitions/business-id "N/A")]
+
+   [:div.span2 [:b (transform-val :field-labels ::to-definitions/visiting-address)]]
+   (let [address (operator ::to-definitions/visiting-address)]
+     [:div.span10
+      (if address
+        (interpose ", " (vals (select-keys address [::common/street, ::common/postal_code, ::common/post_office])))
+        "N/A")])])
+
+(defn contact-methods [] [::to-definitions/phone
+                          ::to-definitions/gsm
+                          ::to-definitions/email
+                          ::to-definitions/facebook
+                          ::to-definitions/twitter
+                          ::to-definitions/instant-message])
+
+(defn contact-info [operator]
+  [:div.row
+   [:div.span12 [:h2 "Yhteystavat"]]                        ;FIXME: Translate
+
+   (doall
+     (map (fn [key]
+            ^{:key key} [:row
+                         [:div.span2 [:b (transform-val :field-labels key)]]
+                         [:div.span10 (operator key "N/A")]]) (contact-methods)))])
+
+(defn viewer [e! status]
+  ;; init
+  (e! (org-viewer/->StartViewer))
+  (fn [e! {:keys [transport-operator] :as app}]
+    [:div.container
+     [basic-info transport-operator]
+     [contact-info transport-operator]]))

--- a/ote/src/cljs/ote/views/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_viewer.cljs
@@ -32,12 +32,12 @@
         (interpose ", " (vals (select-keys address [::common/street, ::common/postal_code, ::common/post_office])))
         "N/A")])])
 
-(defn contact-methods [] [::to-definitions/phone
-                          ::to-definitions/gsm
-                          ::to-definitions/email
-                          ::to-definitions/facebook
-                          ::to-definitions/twitter
-                          ::to-definitions/instant-message])
+(def contact-methods [::to-definitions/phone
+                      ::to-definitions/gsm
+                      ::to-definitions/email
+                      ::to-definitions/facebook
+                      ::to-definitions/twitter
+                      ::to-definitions/instant-message])
 
 (defn contact-info [operator]
   [:div.row
@@ -47,7 +47,7 @@
      (map (fn [key]
             ^{:key key} [:row
                          [:div.span2 [:b (transform-val :field-labels key)]]
-                         [:div.span10 (operator key "N/A")]]) (contact-methods)))])
+                         [:div.span10 (operator key "N/A")]]) contact-methods))])
 
 (defn viewer [e! status]
   ;; init


### PR DESCRIPTION
This pull request adds:
* Custom CKAN template for Organization info tab that embeds OTE  app in a org-view mode.
* OTE org view component shows basic organization data, styled with CKAN supported styles