### PR TITLE
152601235 Read BigDecimals with parseFloat on frontend

### DIFF
--- a/ote/src/cljc/ote/transit.cljc
+++ b/ote/src/cljc/ote/transit.cljc
@@ -9,7 +9,13 @@
 
 (def read-options
   {:handlers {"time" #?(:clj (t/read-handler time/parse-time)
-                        :cljs time/parse-time)}})
+                        :cljs time/parse-time)
+
+              ;; Transit "f" tag is an arbitrary precision decimal number that has no native
+              ;; JS equivalent, for now we simply map it to parseFloat in JS as we are not doing
+              ;; calculations with money
+              "f" #?(:clj (t/read-handler #(BigDecimal. %))
+                     :cljs js/parseFloat)}})
 
 (defn clj->transit
   "Convert given Clojure `data` to transit+json string."


### PR DESCRIPTION
NUMERIC values in the database are read as BigDecimal instances on the backend. JS has no native arbitrary precision decimal number so we convert them to numbers for now. If we ever do calculations with money, we need to revisit this decision.