### PR TITLE
152670109 Better service search page

### DIFF
--- a/database/src/main/resources/db/migration/V1_14__service_search_view.sql
+++ b/database/src/main/resources/db/migration/V1_14__service_search_view.sql
@@ -42,3 +42,25 @@ EXECUTE PROCEDURE transport_service_operation_area_array();
 CREATE INDEX transport_service_subtype_idx
     ON "transport-service" ("sub-type")
  WHERE "published?"=TRUE;
+
+
+CREATE TYPE external_interface_search_result AS (
+  "external-interface" service_link,
+  format TEXT,
+  "ckan-resource-id" TEXT
+);
+
+
+-- Create view for search results
+CREATE VIEW transport_service_search_result AS
+SELECT t.*,
+       (SELECT op.name
+          FROM "transport-operator" op
+         WHERE op.id = t."transport-operator-id") as "operator-name",
+       (SELECT array_agg(oaf."operation-area")
+          FROM "operation-area-facet" oaf
+         WHERE oaf."transport-service-id" = t.id) AS "operation-area-description",
+       (SELECT array_agg(ROW(ei."external-interface", ei.format, ei."ckan-resource-id")::external_interface_search_result)
+          FROM "external-interface-description" ei
+         WHERE ei."transport-service-id" = t.id)::external_interface_search_result[] AS "external-interface-links"
+  FROM "transport-service" t;

--- a/database/src/main/resources/db/migration/V1_14__service_search_view.sql
+++ b/database/src/main/resources/db/migration/V1_14__service_search_view.sql
@@ -36,3 +36,9 @@ ON "transport-service"
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW
 EXECUTE PROCEDURE transport_service_operation_area_array();
+
+
+--- Create index for subtype (also used as a search facet)
+CREATE INDEX transport_service_subtype_idx
+    ON "transport-service" ("sub-type")
+ WHERE "published?"=TRUE;

--- a/database/src/main/resources/db/migration/V1_14__service_search_view.sql
+++ b/database/src/main/resources/db/migration/V1_14__service_search_view.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "operation-area-facet" (
+ "transport-service-id" INTEGER REFERENCES "transport-service" (id) ON DELETE CASCADE,
+ "operation-area" TEXT
+);
+
+CREATE INDEX operation_area_id_idx ON "operation-area-facet" ("transport-service-id");
+CREATE INDEX operation_area_text_idx ON "operation-area-facet" ("operation-area");
+
+CREATE FUNCTION transport_service_operation_area_array () RETURNS TRIGGER AS $$
+BEGIN
+
+  -- Delete all previous entries for this service
+  DELETE
+    FROM "operation-area-facet"
+   WHERE "transport-service-id" = NEW.id;
+
+  IF NEW."published?" = TRUE THEN
+    -- Insert new values (for published only)
+    INSERT
+      INTO "operation-area-facet"
+           ("transport-service-id", "operation-area")
+    SELECT NEW.id, oad.text
+      FROM operation_area oa
+      JOIN LATERAL unnest(oa.description) AS oad ON TRUE
+     WHERE oa."transport-service-id" = NEW.id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE CONSTRAINT TRIGGER tg_transport_service_operation_area_array
+AFTER INSERT OR UPDATE
+ON "transport-service"
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW
+EXECUTE PROCEDURE transport_service_operation_area_array();

--- a/ote/project.clj
+++ b/ote/project.clj
@@ -14,7 +14,7 @@
                  [com.zaxxer/HikariCP "2.6.1"]
                  [org.clojure/java.jdbc "0.7.1"]
                  [webjure/jeesql "0.4.7"]
-                 [specql "0.7.0-alpha7"]
+                 [specql "0.7.0-alpha8"]
 
                  ;; http-kit HTTP server (and client)
                  [http-kit "2.2.0"]

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -389,5 +389,8 @@
  {:label "Liikkumispalvelukatalogi"
   :filters-label "Hakuehdot"
   :text-search "Haku"
-  :text-search-placeholder "Hae nimellä tai sen osalla"}
+  :text-search-placeholder "Hae nimellä tai sen osalla"
+  :no-results "Hae palveluita syöttämällä hakuehdot yllä"
+  :one-result "Hakuehdoilla löytyi yksi palvelu"
+  :many-results ["Hakuehdoilla löytyi " :count " palvelua"]}
  }

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -95,7 +95,8 @@
 
 
   :transport-service
-  {:ote.db.transport-service/name "Palvelun mimi"
+  {:ote.db.transport-service/name "Palvelun nimi"
+   :ote.db.transport-service/type "Liikkumispalvelun tyyppi"
    :ote.db.transport-service/sub-type "Liikkumispavelun alatyyppi"
    :ote.db.transport-service/published? "NAP-tila"
    :ote.db.transport-service/published?-values {true "Julkaistu"
@@ -104,7 +105,11 @@
   ;; Common fields
   :ote.db.common/street                               "Osoite"
   :ote.db.common/post_office                          "Postitoimipaikka"
-  :ote.db.common/postal_code                          "Postinumero"}
+  :ote.db.common/postal_code                          "Postinumero"
+
+
+
+  }
 
 
  ;; Add form info elements here, these are textual help texts in the form
@@ -380,4 +385,9 @@
                    }}
 
 
+ :service-search
+ {:label "Liikkumispalvelukatalogi"
+  :filters-label "Hakuehdot"
+  :text-search "Haku"
+  :text-search-placeholder "Hae nimellä tai sen osalla"}
  }

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -390,7 +390,10 @@
   :filters-label "Hakuehdot"
   :text-search "Haku"
   :text-search-placeholder "Hae nimellä tai sen osalla"
-  :no-results "Hae palveluita syöttämällä hakuehdot yllä"
+  :no-filters "Hae palveluita syöttämällä hakuehdot yllä"
+  :no-results "Hakuehdoilla ei löytynyt palveluita"
   :one-result "Hakuehdoilla löytyi yksi palvelu"
-  :many-results ["Hakuehdoilla löytyi " :count " palvelua"]}
+  :many-results ["Hakuehdoilla löytyi " :count " palvelua"]
+  :interfaces "Rajapinnat: "}
+
  }

--- a/ote/src/clj/ote/main.clj
+++ b/ote/src/clj/ote/main.clj
@@ -9,6 +9,7 @@
             [ote.services.localization :as localization-service]
             [ote.services.places :as places]
             [ote.services.viewer :as viewer]
+            [ote.services.service-search :as service-search]
 
             [ote.integration.export.geojson :as export-geojson]
             [taoensso.timbre :as log])
@@ -34,6 +35,10 @@
    ;; OpenStreetMap Overpass API queries
    :places (component/using (places/->Places (:places config)) [:http :db])
 
+   ;; Service search
+   :service-search (component/using
+                    (service-search/->ServiceSearch)
+                    [:http :db])
 
    ;; Integration: export GeoJSON
    :export-geojson (component/using (export-geojson/->GeoJSONExport) [:db :http])))

--- a/ote/src/clj/ote/services/service_search.clj
+++ b/ote/src/clj/ote/services/service_search.clj
@@ -1,0 +1,100 @@
+(ns ote.services.service-search
+  "Backend services for transport service search."
+  (:require [com.stuartsierra.component :as component]
+            [ote.components.http :as http]
+            [specql.core :as specql]
+            [taoensso.timbre :as log]
+            [compojure.core :refer [routes GET]]
+            [jeesql.core :refer [defqueries]]
+            [ote.db.transport-service :as t-service]
+            [ote.db.service-search :as search]
+            [specql.op :as op]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+(defqueries "ote/services/service_search.sql")
+
+(defn search-facets [db]
+  {::t-service/operation-area (vec (operation-area-facet db))
+   ::t-service/sub-type
+   (into []
+         (map #(update % :sub-type keyword))
+         (sub-type-facet db))})
+
+
+
+;; FIXME: define better result set
+(def search-result-columns
+  #{:ote.db.transport-service/contact-email
+    :ote.db.transport-service/sub-type
+    :ote.db.transport-service/parking
+    :ote.db.modification/modified-by
+    :ote.db.transport-service/ckan-resource-id
+    :ote.db.transport-service/brokerage
+    :ote.db.transport-service/id
+    :ote.db.modification/created
+    :ote.db.transport-service/contact-gsm
+    :ote.db.transport-service/ckan-dataset-id
+    :ote.db.transport-service/terminal
+    :ote.db.transport-service/contact-address
+    :ote.db.transport-service/rental
+    :ote.db.modification/modified
+    :ote.db.modification/created-by
+    :ote.db.transport-service/homepage
+    :ote.db.transport-service/name
+    :ote.db.transport-service/type
+    :ote.db.transport-service/transport-operator-id ;; FIXME: join operator
+    :ote.db.transport-service/contact-phone
+    :ote.db.transport-service/passenger-transportation})
+
+(defn- ids [key query-result]
+  (into #{} (map key) query-result))
+
+(defn- operation-area-ids [db operation-area]
+  (when-not (empty? operation-area)
+    (ids ::search/transport-service-id
+         (specql/fetch db ::search/operation-area-facet
+                       #{::search/transport-service-id}
+                       {::search/operation-area (op/in operation-area)}))))
+
+(defn- text-search-ids [db text]
+  (when-not (str/blank? text)
+    (let [text (str/trim text)]
+      (ids ::t-service/id
+           (specql/fetch db ::t-service/transport-service
+                         #{::t-service/id}
+                         {::t-service/name (op/ilike (str "%" text "%"))})))))
+
+(defn- search [db filters]
+  (let [ids (apply set/intersection
+                   (remove nil?
+                           [(operation-area-ids db (:operation-area filters))
+                            (text-search-ids db (:text params))]))]
+    (specql/fetch db ::t-service/transport-service
+                  search-result-columns
+                  {::t-service/id (op/in ids)})))
+
+(defn- service-search-routes [db]
+  (routes
+   (GET "/service-search/facets" []
+        (http/transit-response (search-facets db)))
+
+   (GET "/service-search" {params :query-params}
+        (http/transit-response
+         (search {:operation-area (some-> (params "operation_area")
+                                                  (str/split #","))
+                  :text (params "text")})))
+   ))
+
+(defrecord ServiceSearch []
+  component/Lifecycle
+  (start [{db :db
+           http :http
+           :as this}]
+    (assoc this ::stop
+           (http/publish! http {:authenticated? false}
+                          (service-search-routes db))))
+
+  (stop [{stop ::stop :as this}]
+    (stop)
+    (dissoc this ::stop)))

--- a/ote/src/clj/ote/services/service_search.clj
+++ b/ote/src/clj/ote/services/service_search.clj
@@ -23,27 +23,22 @@
 
 
 
-;; FIXME: define better result set
 (def search-result-columns
   #{::t-service/contact-email
     ::t-service/sub-type
     ::t-service/parking
-    :ote.db.modification/modified-by
     ::t-service/ckan-resource-id
     ::t-service/brokerage
     ::t-service/id
-    :ote.db.modification/created
     ::t-service/contact-gsm
     ::t-service/ckan-dataset-id
     ::t-service/terminal
     ::t-service/contact-address
     ::t-service/rental
-    :ote.db.modification/modified
-    :ote.db.modification/created-by
     ::t-service/homepage
     ::t-service/name
     ::t-service/type
-    ::t-service/transport-operator-id ;; FIXME: join operator
+    ::t-service/transport-operator-id
     ::t-service/contact-phone
     ::t-service/passenger-transportation
 

--- a/ote/src/clj/ote/services/service_search.clj
+++ b/ote/src/clj/ote/services/service_search.clj
@@ -14,7 +14,10 @@
 
 (defqueries "ote/services/service_search.sql")
 
-(defn search-facets [db]
+(defn search-facets
+  "Return facet information for the search page (selections and their counts)
+  using queries defined in `service_search.sql` file."
+  [db]
   {::t-service/operation-area (vec (operation-area-facet db))
    ::t-service/sub-type
    (into []

--- a/ote/src/clj/ote/services/service_search.clj
+++ b/ote/src/clj/ote/services/service_search.clj
@@ -25,27 +25,32 @@
 
 ;; FIXME: define better result set
 (def search-result-columns
-  #{:ote.db.transport-service/contact-email
-    :ote.db.transport-service/sub-type
-    :ote.db.transport-service/parking
+  #{::t-service/contact-email
+    ::t-service/sub-type
+    ::t-service/parking
     :ote.db.modification/modified-by
-    :ote.db.transport-service/ckan-resource-id
-    :ote.db.transport-service/brokerage
-    :ote.db.transport-service/id
+    ::t-service/ckan-resource-id
+    ::t-service/brokerage
+    ::t-service/id
     :ote.db.modification/created
-    :ote.db.transport-service/contact-gsm
-    :ote.db.transport-service/ckan-dataset-id
-    :ote.db.transport-service/terminal
-    :ote.db.transport-service/contact-address
-    :ote.db.transport-service/rental
+    ::t-service/contact-gsm
+    ::t-service/ckan-dataset-id
+    ::t-service/terminal
+    ::t-service/contact-address
+    ::t-service/rental
     :ote.db.modification/modified
     :ote.db.modification/created-by
-    :ote.db.transport-service/homepage
-    :ote.db.transport-service/name
-    :ote.db.transport-service/type
-    :ote.db.transport-service/transport-operator-id ;; FIXME: join operator
-    :ote.db.transport-service/contact-phone
-    :ote.db.transport-service/passenger-transportation})
+    ::t-service/homepage
+    ::t-service/name
+    ::t-service/type
+    ::t-service/transport-operator-id ;; FIXME: join operator
+    ::t-service/contact-phone
+    ::t-service/passenger-transportation
+
+    ;; Information JOINed from other tables
+    ::t-service/operation-area-description
+    ::t-service/external-interface-links
+    ::t-service/operator-name})
 
 (defn- ids [key query-result]
   (into #{} (map key) query-result))
@@ -80,7 +85,7 @@
                            [(operation-area-ids db (:operation-area filters))
                             (sub-type-ids db (:sub-type filters))
                             (text-search-ids db (:text filters))]))]
-    (specql/fetch db ::t-service/transport-service
+    (specql/fetch db ::t-service/transport-service-search-result
                   search-result-columns
                   {::t-service/id (op/in ids)})))
 

--- a/ote/src/clj/ote/services/service_search.sql
+++ b/ote/src/clj/ote/services/service_search.sql
@@ -1,0 +1,18 @@
+-- name: operation-area-facet
+SELECT "operation-area" as text, COUNT(*) as count
+  FROM "operation-area-facet"
+ GROUP BY text
+ ORDER BY count DESC;
+
+-- name: sub-type-facet
+SELECT type."sub-type", COALESCE(count.count, 0) AS count
+  FROM (SELECT UNNEST(enum_range(NULL::transport_service_subtype)) "sub-type") type
+       LEFT JOIN (SELECT t."sub-type", COUNT(*) as count
+                    FROM "transport-service" t
+                   WHERE t."published?" = true
+                   GROUP BY t."sub-type") count ON type."sub-type" = count."sub-type"
+ ORDER BY count DESC
+
+-- name: search
+-- Search for transport services by name, operation area or subtype
+SELECT t.id, t.name, t.type, t."sub-type",

--- a/ote/src/cljc/ote/db/service_search.cljc
+++ b/ote/src/cljc/ote/db/service_search.cljc
@@ -1,0 +1,17 @@
+(ns ote.db.service-search
+  "Transport service search facet tables"
+  (:require [clojure.spec.alpha :as s]
+            #?(:clj [ote.tietokanta.specql-db :refer [define-tables]])
+            [specql.rel :as rel]
+            [specql.transform :as xf]
+            [specql.impl.registry]
+            [ote.db.common]
+            [specql.data-types]
+            [ote.time]
+            [ote.db.modification])
+  #?(:cljs
+     (:require-macros [ote.tietokanta.specql-db :refer [define-tables]])))
+
+
+(define-tables
+  ["operation-area-facet" ::operation-area-facet])

--- a/ote/src/cljc/ote/db/transport_service.cljc
+++ b/ote/src/cljc/ote/db/transport_service.cljc
@@ -58,7 +58,11 @@
                                                ::external-interface-description
                                                ::transport-service-id)}]
   ["operation_area" ::operation_area]
-  ["operation_area_geojson" ::operation_area_geojson])
+  ["operation_area_geojson" ::operation_area_geojson]
+
+  ["external_interface_search_result" ::external-interface-search-result]
+  ["transport_service_search_result" ::transport-service-search-result
+   ote.db.modification/modification-fields])
 
 ;; Create order for transport_type
 (def transport-service-types [:terminal :passenger-transportation :rentals :parking :brokerage])
@@ -100,3 +104,6 @@
     :rentals ::rentals
     :parking ::parking
     :brokerage ::brokerage))
+
+(defn localized-text-for [language localized-text]
+  (some #(when (= (::lang %) language) (::text %)) localized-text))

--- a/ote/src/cljc/ote/localization.cljc
+++ b/ote/src/cljc/ote/localization.cljc
@@ -82,7 +82,7 @@
    (tr #?(:clj *language* :cljs @selected-language)
        message-path {}))
   ([message-path parameters]
-   (tr #?(:clj *language* :cljs @selected-language) message-path {}))
+   (tr #?(:clj *language* :cljs @selected-language) message-path parameters))
   ([language message-path parameters]
    (let [language (get @loaded-languages language)]
      (assert language (str "Language " language " has not been loaded."))

--- a/ote/src/cljs/ote/app/controller/service_search.cljs
+++ b/ote/src/cljs/ote/app/controller/service_search.cljs
@@ -11,6 +11,7 @@
 (defrecord SearchResponse [results])
 (defrecord InitServiceSearch [])
 (defrecord FacetsResponse [facets])
+(defrecord OpenInterfaceInCKAN [operator-id service-id ckan-resource-id])
 
 (defn- search-params [{oa ::t-service/operation-area
                        text :text-search
@@ -62,5 +63,12 @@
 
   SearchResponse
   (process-event [{results :results} app]
-    (.log js/console "RESULTS: " (pr-str results))
-    (assoc-in app [:service-search :results] results)))
+    (assoc-in app [:service-search :results] results))
+
+  OpenInterfaceInCKAN
+  (process-event [{:keys [operator-id service-id ckan-resource-id]} app]
+    (let [url (str "dataset/org-" operator-id "-service-" service-id "/resource/" ckan-resource-id)
+          location (.-location js/window)]
+      (set! (.-pathname location) url)
+      (set! (.-hash location) "")
+      app)))

--- a/ote/src/cljs/ote/app/controller/service_search.cljs
+++ b/ote/src/cljs/ote/app/controller/service_search.cljs
@@ -1,0 +1,63 @@
+(ns ote.app.controller.service-search
+  "Service search controller"
+  (:require [tuck.core :as tuck]
+            [ote.communication :as comm]
+            [ote.db.transport-service :as t-service]))
+
+
+(defrecord UpdateSearchFilters [filters])
+(defrecord Search [])
+(defrecord SearchResponse [results])
+(defrecord InitServiceSearch [])
+(defrecord FacetsResponse [facets])
+
+(defn- search-params [filters]
+  {:foo "fixme"})
+
+(defn- search [{service-search :service-search :as app}]
+  (let [on-success (tuck/send-async! ->SearchResponse)]
+    ;; Clear old timeout, if any
+    (when-let [search-timeout (:search-timeout service-search)]
+      (.clearTimeout js/window search-timeout))
+
+    (assoc-in
+     app
+     [:service-search :search-timeout]
+     (.setTimeout js/window
+                  #(comm/get! "service-search"
+                              {:params (search-params (:filters service-search))
+                               :on-success on-success})
+                  100))))
+
+(extend-protocol tuck/Event
+
+  InitServiceSearch
+  (process-event [_ app]
+    (comm/get! "service-search/facets"
+               {:on-success (tuck/send-async! ->FacetsResponse)})
+    app
+    #_(update app :service-search merge
+            ;; FIXME: fetch from server
+            {:facets
+             {::t-service/operation-area
+              [{:name "Oulu (5)" :value "Oulu"}
+               {:name "Helsinki (12)" :value "Helsinki"}]
+              ::t-service/type
+              [{:name "Henkilöstön kuljetus (69)" :value :passenger-transportation}
+               ]}
+             }))
+
+  FacetsResponse
+  (process-event [{facets :facets} app]
+    (assoc-in app [:service-search :facets] facets))
+
+  UpdateSearchFilters
+  (process-event [{filters :filters} app]
+    (-> app
+        (update-in [:service-search :filters] merge filters)
+        search))
+
+  SearchResponse
+  (process-event [{results :results} app]
+    (.log js/console "RESULTS: " (pr-str results))
+    (assoc-in app [:service-search :results] results)))

--- a/ote/src/cljs/ote/app/controller/service_search.cljs
+++ b/ote/src/cljs/ote/app/controller/service_search.cljs
@@ -67,7 +67,7 @@
 
   OpenInterfaceInCKAN
   (process-event [{:keys [operator-id service-id ckan-resource-id]} app]
-    (let [url (str "dataset/org-" operator-id "-service-" service-id "/resource/" ckan-resource-id)
+    (let [url (str "/dataset/org-" operator-id "-service-" service-id "/resource/" ckan-resource-id)
           location (.-location js/window)]
       (set! (.-pathname location) url)
       (set! (.-hash location) "")

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -14,7 +14,8 @@
     ["/brokerage" :brokerage]
     ["/parking" :parking]
     ["/new-service" :transport-service]
-    ["/edit-service/:id" :edit-service]]))
+    ["/edit-service/:id" :edit-service]
+    ["/services" :services]]))
 
 (defn- on-navigate [name params query]
   (swap! state/app merge {:page name

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -50,3 +50,19 @@
 (def title {:font-weight "bold"})
 
 (def large-title (merge title {:font-size "150%"}))
+
+(defn flex-container [dir]
+  {:display "flex" :flex-direction dir})
+
+(def item-list-container
+  (merge (flex-container "row")
+         {:flex-wrap "wrap"}))
+
+(def item-list-row-margin
+  {:margin-right "1em"})
+
+(def item-list-item
+  (merge inline-block
+         {:position "relative"
+          :margin-left "0.2em"
+          :top "-0.5em"}))

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -46,3 +46,7 @@
                   :font-weight "600"})
 
 (def flash-message {:top "100px"})
+
+(def title {:font-weight "bold"})
+
+(def large-title (merge title {:font-size "150%"}))

--- a/ote/src/cljs/ote/style/form.cljs
+++ b/ote/src/cljs/ote/style/form.cljs
@@ -1,20 +1,20 @@
 (ns ote.style.form
   "Form layout styles"
   (:require [stylefy.core :as stylefy]
-            [garden.units :refer [pt px em]]))
+            [garden.units :refer [pt px em]]
+            [ote.style.base :as base]))
 
 ;; FIXME: use garden unit helpers (currently stylefy has a bug and they don't work)
 
-(defn- flex-container [dir]
-  {:display "flex" :flex-direction dir})
+
 
 (def form-group-base {:margin-bottom "1em" ;(em 1)
                       ::stylefy/sub-styles {:form-field {:margin "1em" #_(em 1)}}})
 
 (def form-group-column (merge form-group-base
-                              (flex-container "column")))
+                              (base/flex-container "column")))
 (def form-group-row (merge form-group-base
-                           (flex-container "row")
+                           (base/flex-container "row")
                            {:flex-wrap "wrap"}))
 
 (def form-group-container {:padding-bottom "0.33em"})

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -133,20 +133,26 @@
        options))]))
 
 
-(defmethod field :multiselect-selection [{:keys [update! label name style show-option show-option-short options form? error] :as field} data]
+(defmethod field :multiselect-selection
+  [{:keys [update! label name style show-option show-option-short options form? error auto-width?]
+    :as field}
+   data]
   ;; Because material-ui selection value can't be an arbitrary JS object, use index
   (let [selected-set (set (or data #{}))
         option-idx (zipmap options (range))]
-    [ui/select-field {:style style
-                      :floating-label-text label
-                      :multiple true
-                      :value (clj->js (map option-idx selected-set))
-                      :selection-renderer (fn [values]
-                                            (str/join ", " (map (comp (or show-option-short show-option) (partial nth options)) values)))
-                      :on-change (fn [event index values]
-                                   (update! (into #{}
-                                                  (map (partial nth options))
-                                                  values)))} ;; Add selected value to vector
+    [ui/select-field
+     {:auto-width (boolean auto-width?)
+      :style style
+      :floating-label-text label
+      :multiple true
+      :value (clj->js (map option-idx selected-set))
+      :selection-renderer (fn [values]
+                            (str/join ", " (map (comp (or show-option-short show-option) (partial nth options)) values)))
+      :on-change (fn [event index values]
+                   (update! (into #{}
+                                  (map (partial nth options))
+                                  values)))}
+     ;; Add selected value to vector
      (doall
       (map-indexed
        (fn [i option]

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -19,7 +19,8 @@
             [stylefy.core :as stylefy]
             [ote.style.base :as style-base]
             [ote.app.controller.transport-service :as ts]
-            [ote.views.theme :refer [theme]]))
+            [ote.views.theme :refer [theme]]
+            [ote.views.service-search :as service-search]))
 
 (defn- is-topnav-active [give-page nav-page]
   (when (= give-page nav-page)
@@ -107,6 +108,7 @@
         :parking [parking/parking e! (:transport-service app)]
         :brokerage [brokerage/brokerage e! (:transport-service app)]
         :edit-service [t-service/edit-service e! app]
+        :services [service-search/service-search e! (:service-search app)]
         [:div "ERROR: no such page " (pr-str (:page app))])
       ]
 

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -31,10 +31,57 @@
 (defn- format-address [{::common/keys [street postal_code post_office]}]
   (str street ", " postal_code " " post_office))
 
-(defn results-listing [e! results]
+(defn- external-interface-links [e! {::t-service/keys [id external-interface-links name
+                                                       transport-operator-id ckan-resource-id]}]
+  [:div
+   (tr [:service-search :interfaces])
+   [ui/flat-button
+    {:style {:margin-left "1em"}
+     :primary true
+     :on-click #(e! (ss/->OpenInterfaceInCKAN transport-operator-id id ckan-resource-id))}
+    (str name " GeoJSON")]
+   (doall
+    (for [{::t-service/keys [external-interface format ckan-resource-id]} external-interface-links
+          :let [description (::t-service/description external-interface)]]
+      [ui/flat-button
+       {:style {:margin-left "1em"}
+        :primary true
+        :on-click #(e! (ss/->OpenInterfaceInCKAN transport-operator-id id ckan-resource-id))}
+       (str (t-service/localized-text-for "FI" description)
+            " (" format ")")]))])
+
+(defn- result-card [e! {::t-service/keys [id name sub-type contact-address
+                                          operation-area-description contact-phone contact-email
+                                          operator-name] :as service}]
+
   (let [sub-type-tr (tr-key [:enums ::t-service/sub-type]
-                            [:enums ::t-service/type])
-        result-count (count results)]
+                            [:enums ::t-service/type])]
+    [ui/card {:z-depth 1}
+     [ui/card-header {:title name :style style-base/title
+                      :subtitle (sub-type-tr sub-type)}]
+     [ui/card-text
+      [data-items
+
+       [ic/action-home]
+       (format-address contact-address)
+
+       [ic/maps-map]
+       (str/join ", " operation-area-description)
+
+       [ic/communication-phone]
+       contact-phone
+
+       [ic/communication-email]
+       contact-email
+
+       [ic/communication-business]
+       operator-name]]
+     [ui/card-actions
+      (r/as-element
+       [external-interface-links e! service])]]))
+
+(defn results-listing [e! results]
+  (let [result-count (count results)]
     [:div.col-xs-12.col-md-12.col-lg-12
      [:h2 (stylefy/use-style style-base/large-title)
       (tr [:service-search (case result-count
@@ -43,50 +90,9 @@
                              :many-results)]
           {:count result-count})]
      (doall
-      (for [{::t-service/keys [id name sub-type contact-address operation-area-description
-                               contact-phone contact-email external-interface-links operator-name
-                               transport-operator-id ckan-resource-id]
-             :as service}
-            results]
-        ^{:key id}
-        [ui/card {:z-depth 1}
-         [ui/card-header {:title name :style style-base/title
-                          :subtitle (sub-type-tr sub-type)}]
-         [ui/card-text
-          [data-items
-
-           [ic/action-home]
-           (format-address contact-address)
-
-           [ic/maps-map]
-           (str/join ", " operation-area-description)
-
-           [ic/communication-phone]
-           contact-phone
-
-           [ic/communication-email]
-           contact-email
-
-           [ic/communication-business]
-           operator-name]]
-         [ui/card-actions
-          (r/as-element
-           [:div
-            (tr [:service-search :interfaces])
-            [ui/flat-button
-             {:style {:margin-left "1em"}
-              :primary true
-              :on-click #(e! (ss/->OpenInterfaceInCKAN transport-operator-id id ckan-resource-id))}
-             (str name " GeoJSON")]
-            (doall
-             (for [{::t-service/keys [external-interface format ckan-resource-id]} external-interface-links
-                   :let [description (::t-service/description external-interface)]]
-               [ui/flat-button
-                {:style {:margin-left "1em"}
-                 :primary true
-                 :on-click #(e! (ss/->OpenInterfaceInCKAN transport-operator-id id ckan-resource-id))}
-                (str (t-service/localized-text-for "FI" description)
-                     " (" format ")")]))])]]))]))
+      (for [result results]
+        ^{:key (::t-service/id result)}
+        [result-card e! result]))]))
 
 (defn filters-form [e! {filters :filters
                         facets :facets

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -108,13 +108,11 @@
          :type :string
          :placeholder (tr [:service-search :text-search-placeholder])}
 
-        ;; ekaksi tämä
         {:name ::t-service/operation-area
          :type :multiselect-selection
          :show-option #(str (:text %) " (" (:count %) ")")
          :options (::t-service/operation-area facets)}
 
-        ;; subtypet tässä listassa, jos niitä on
         {:name ::t-service/sub-type
          :type :multiselect-selection
          :show-option #(str (sub-type (:sub-type %)) " (" (:count %) ")")

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -79,8 +79,8 @@
               :on-click #(e! (ss/->OpenInterfaceInCKAN transport-operator-id id ckan-resource-id))}
              (str name " GeoJSON")]
             (doall
-             (for [{::t-service/keys [url description format
-                                      ckan-resource-id]} external-interface-links]
+             (for [{::t-service/keys [external-interface format ckan-resource-id]} external-interface-links
+                   :let [description (::t-service/description external-interface)]]
                [ui/flat-button
                 {:style {:margin-left "1em"}
                  :primary true

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -8,15 +8,32 @@
             [ote.ui.buttons :as buttons]
             [ote.ui.form :as form]
             [cljs-react-material-ui.reagent :as ui]
-            [ote.app.controller.service-search :as ss]))
+            [ote.app.controller.service-search :as ss]
+            [ote.style.base :as style-base]
+            [stylefy.core :as stylefy]))
 
 
 (defn results-listing [e! results]
-  [ui/grid-list
-   (doall
-    (for [{::t-service/keys [id name] :as service} results]
-      [ui/grid-tile {:key id}
-       [:div "resultti on " (pr-str service)]]))])
+  (let [sub-type-tr (tr-key [:enums ::t-service/sub-type]
+                            [:enums ::t-service/type])
+        result-count (count results)]
+    [:div.col-xs-12.col-md-12.col-lg-12
+     [:h2 (stylefy/use-style style-base/large-title)
+      (tr [:service-search (if (> result-count 1)
+                             :many-results
+                             :one-result)]
+          {:count result-count})]
+     (doall
+      (for [{::t-service/keys [id name sub-type] :as service} results]
+        ^{:key id}
+        [ui/card {:z-depth 1}
+         [ui/card-header {:title name :style style-base/title
+                          :subtitle (sub-type-tr sub-type)}]
+         [ui/card-text
+          [:div "resultti on " (pr-str service)]]
+         [ui/card-actions
+          (r/as-element
+           [ui/flat-button {:primary true} "Avaa rajapinta"])]]))]))
 
 (defn filters-form [e! {filters :filters
                         facets :facets
@@ -58,6 +75,7 @@
            :as service-search}]
     [:div.service-search
      [filters-form e! service-search]
+     [ui/divider]
      (if (empty? results)
-       [:div "tee vähän hakuja"]
+       [:div (tr [:service-search :no-results])]
        [results-listing e! results])]))

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -1,0 +1,63 @@
+(ns ote.views.service-search
+  "A service search page that allows filtering and listing published services."
+  (:require [reagent.core :as r]
+            [ote.db.transport-service :as t-service]
+            [ote.db.transport-operator :as t-operator]
+            [ote.localization :refer [tr tr-key]]
+            [ote.ui.form-fields :as form-fields]
+            [ote.ui.buttons :as buttons]
+            [ote.ui.form :as form]
+            [cljs-react-material-ui.reagent :as ui]
+            [ote.app.controller.service-search :as ss]))
+
+
+(defn results-listing [e! results]
+  [ui/grid-list
+   (doall
+    (for [{::t-service/keys [id name] :as service} results]
+      [ui/grid-tile {:key id}
+       [:div "resultti on " (pr-str service)]]))])
+
+(defn filters-form [e! {filters :filters
+                        facets :facets
+                        :as service-search}]
+  (let [sub-type (tr-key [:enums ::t-service/sub-type]
+                         [:enums ::t-service/type])]
+    [:div
+     [:h3 (tr [:service-search :label])]
+     [form/form {:update! #(e! (ss/->UpdateSearchFilters %))
+                 :name->label (tr-key [:service-search]
+                                      [:field-labels :transport-service-common]
+                                      [:field-labels :transport-service])}
+      [(form/group
+        {:label (tr [:service-search :filters-label])
+         :columns 3
+         :layout :row}
+
+        {:name :text-search
+         :type :string
+         :placeholder (tr [:service-search :text-search-placeholder])}
+
+        ;; ekaksi tämä
+        {:name ::t-service/operation-area
+         :type :multiselect-selection
+         :show-option #(str (:text %) " (" (:count %) ")")
+         :options (::t-service/operation-area facets)}
+
+        ;; subtypet tässä listassa, jos niitä on
+        {:name ::t-service/sub-type
+         :type :multiselect-selection
+         :show-option #(str (sub-type (:sub-type %)) " (" (:count %) ")")
+         :options (::t-service/sub-type facets)
+         :auto-width? true})]
+      filters]]))
+
+(defn service-search [e! _]
+  (e! (ss/->InitServiceSearch))
+  (fn [e! {results :results
+           :as service-search}]
+    [:div.service-search
+     [filters-form e! service-search]
+     (if (empty? results)
+       [:div "tee vähän hakuja"]
+       [results-listing e! results])]))


### PR DESCRIPTION
A new custom search page that can be used instead of the
CKAN default dataset page.

Supports our two facets: service type and operation area as well as free text search on name.