### PR TITLE
152791688 remove frontpages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,3 +11,7 @@ The 0.19.x branch contains some bugs that need to be worked around.
 Upgrade to 1.0 branch when it is released and remove any ugly workarounds.
 
 * `ote.views.place-search/monkey-patch-chip-backspace`
+
+
+#### Responsive header
+Currently listening window resize event. Change to css media query.

--- a/TODO.md
+++ b/TODO.md
@@ -15,3 +15,7 @@ Upgrade to 1.0 branch when it is released and remove any ugly workarounds.
 
 #### Responsive header
 Currently listening window resize event. Change to css media query.
+
+#### Refactor OTE - front page
+Currently we do not have a front page in OTE. When we are sure that
+it is not needed, remove all front-page instances away from OTE.

--- a/ote/resources/public/css/omat_tyylit.css
+++ b/ote/resources/public/css/omat_tyylit.css
@@ -94,7 +94,6 @@ html {
 
 .topnav li a {
   bottom: 0;
-
   color: #ffffff;
   text-align: center;
   padding: 10px 15px 0px 15px;
@@ -102,6 +101,7 @@ html {
   font-size: 14px;
   font-weight: 700;
   line-height: 38px;
+  cursor: pointer;
 }
 
 .topnav li a.main-icon  {

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -290,6 +290,12 @@
   :header-accessibility-description         "Kuvaus esteettömyyspalveluista"
   }
 
+ :select-service-type-page
+ {:title-required-data               "Aloita liikkumispalvelun lisääminen valitsemalla liikkumispalvelun tyyppi"
+  :transport-service-type-selection-help-text "Voit tallentaa liikkumispalvelusi olennaiset tiedot valitsemalla
+                ensin liikkumispalvelutyypin sekä organisaation ja täyttämällä sen jälkeen näytölle avautuneen lomakkeen.
+                Jos tarjoat useita liikkumispalveluita, voit täyttää jokaisesta oman lomakkeen."}
+
  :common-texts
  {:front-page-help-text                       "Et ole vielä kirjannut liikkumispalvelutietoja NAP-palveluun.
         Voit lisätä olemassaolevan palvelurajapintasi tai täyttää palvelusi olennaiset tiedot käyttämällä
@@ -310,11 +316,6 @@
   :user-menu-service-operator                 "Organisaation perustiedot"
   :user-menu-log-out                          "Kirjaudu ulos"
   :user-menu-profile                          "Näytä profiili"
-
-  :title-required-data-with-OTE               "Olennaisten tietojen kirjaaminen OTE:lla"
-  :transport-service-type-selection-help-text "Voit tallentaa liikkumispalvelusi olennaiset tiedot valitsemalla
-                ensin liikkumispalvelutyypin sekä organisaation ja täyttämällä sen jälkeen näytölle avautuneen lomakkeen.
-                Jos tarjoat useita liikkumispalveluita, voit täyttää jokaisesta oman lomakkeen."
   :title-operator-basic-details               "Perustiedot"
   :required-field                             "Tieto vaaditaan"
   :invalid-postal-code                        "Tarkista postinumero (5 numeroa)"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -317,6 +317,10 @@
   :transport-service-saved "Liikkumispalvelun tiedot tallennettu!"
   }
 
+ :organization-viewer-page
+ {:contact-types  "Yhteystavat"
+  }
+
  ;; Translations for GeoJSON keys (unnamespaced), in the CKAN viewer plugin.
  ;; This is unfortunate duplication, but GeoJSON may have arbitrary keys (not just the ones we defined)
  ;; and we must show those as is.

--- a/ote/src/cljs/ote/views/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_viewer.cljs
@@ -48,7 +48,7 @@
 
 (defn contact-info [operator]
   [:div.row
-   [:div.span12 (stylefy/use-style style-ckan/content-title)  [:h2 (tr [:organization-viewer-page :contact-types])]]                        ;FIXME: Translate
+   [:div.span12 (stylefy/use-style style-ckan/content-title)  [:h2 (tr [:organization-viewer-page :contact-types])]]
 
    (doall
      (map (fn [key]

--- a/ote/src/cljs/ote/views/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_viewer.cljs
@@ -33,7 +33,7 @@
      [:div.span9
       (if address
         (interpose ", " (vals (select-keys address [::common/street, ::common/postal_code, ::common/post_office])))
-        "N/A")])
+        "-")])
 
    [:div.span3 [:b (transform-val :field-labels ::to-definitions/homepage)]]
    [:div.span9 (operator ::to-definitions/homepage " - ")]])
@@ -48,7 +48,7 @@
 
 (defn contact-info [operator]
   [:div.row
-   [:div.span12 (stylefy/use-style style-ckan/content-title)  [:h2 "Yhteystavat"]]                        ;FIXME: Translate
+   [:div.span12 (stylefy/use-style style-ckan/content-title)  [:h2 (tr [:organization-viewer-page :contact-types])]]                        ;FIXME: Translate
 
    (doall
      (map (fn [key]

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -8,6 +8,7 @@
             [ote.ui.buttons :as buttons]
             [ote.app.controller.front-page :as fp]
             [ote.app.controller.transport-service :as ts]
+            [ote.views.transport-service :as transport-service]
             [ote.db.common :as common]
             [ote.localization :refer [tr tr-key]]
             [ote.db.transport-service :as t-service]
@@ -64,41 +65,7 @@
 
        (transport-services-table-rows e! services transport-operator-id)]]]))
 
-(defn empty-header-for-front-page [e!]
-  [:div
-  [:div.row
-   [:div {:class "col-xs-12"}
-    [:div {:class "main-notification-panel"}
-     [:div {:class "col-xs-1"}
-      [ic/action-info-outline]]
-     [:div {:class "col-xs-11"}
-      [:p (tr [:common-texts :front-page-help-text])]]]]]
 
-
-   [:div.row {:style {:margin-top "50px"}}
-    [:div (stylefy/use-style style-base/front-page-add-service {::stylefy/with-classes ["col-xs-12 col-md-offset-1 col-md-5"]})
-     [:div.row {:style {:height "100px"}}
-      [:p (tr [:front-page :do-you-want-to-publish-service])]
-      ]
-     [:div.row {:style {:text-align "center"}}
-     [ui/raised-button {:label    (tr [:buttons :link-add-new-api])
-                        :on-click #(e! (fp/->ChangePage :transport-service))
-                        :primary  true
-                        }]]
-     [:div (stylefy/use-style style-base/header-font {::stylefy/with-classes ["row"]})
-      (tr [:front-page :header-explain-more])]
-     [:div.row
-      [:p (tr [:front-page :help-more-explanation1])]
-     [:p (tr [:front-page :help-more-explanation2])]
-     ]]
-    [:div {:class "col-xs-12 col-md-6" :style {:padding-left "20px"} }
-     [:div.row {:style {:padding-left "40px" :height "100px"}}
-      [:p (tr [:common-texts :front-page-start-ote-query-header])]
-      ]
-     [:div.row {:style {:text-align "center"}}
-     [ui/raised-button {:label    (tr [:buttons :add-transport-service])
-                        :on-click #(e! (fp/->ChangePage :transport-service))
-                        :primary  true}]]]]])
 
 (defn table-container-for-front-page [e! services status]
   [:div
@@ -125,32 +92,6 @@
         services
         (tr [:titles type])])]]])
 
-(defn front-page [e! app]
-  ;; init
-  (e! (fp/->GetTransportOperatorData))
-
-  (fn [e! {services :transport-services :as app}]
-    [:div
-     [:div.row.col-xs-12
-      [:h2 (str (tr [:front-page :hello]) (get-in app [:user :name]) " !")]]
-     [:diw.row.col-xs-12
-      [:p (tr [:front-page :NAP-service-short-description])]]
-     [:diw.row.col-xs-12
-      [:p [:strong (tr [:common-texts :navigation-own-service-list])]
-       (tr [:front-page :own-services-short-description])]]
-     [:diw.row.col-xs-12
-      [:p (tr [:front-page :right-corner-description])
-       [:strong (tr [:common-texts :user-menu-service-operator])]
-       (tr [:front-page :service-operator-short-description])]]
-
-     [:div.row.col-xs-12 {:style {:text-align "center" :padding-top "40px"}}
-      [:p (tr [:front-page :publish-new-service])]]
-     [:div.row.col-xs-12 {:style {:text-align "center"}}
-      [ui/raised-button {:style {:margin-top "20px"}
-                         :label    (tr [:front-page :move-to-services-page])
-                         :on-click #(e! (fp/->ChangePage :own-services))
-                         :primary  true}]]]))
-
 (defn own-services [e! status]
   ;; init
   (e! (fp/->GetTransportOperatorData))
@@ -159,5 +100,5 @@
     [:div
 
      (if (empty? services)
-       (empty-header-for-front-page e!)
+       [transport-service/select-service-type e! (:transport-service status)] ;; Render service type selection page if no services added
        (table-container-for-front-page e! services status))]))

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -44,7 +44,7 @@
                    :on-click #(e! (fp-controller/->GoToUrl (str "/user/edit/" username)))}]
     [ui/menu-item {:style {:color "#FFFFFF"}
                    :primary-text (tr [:common-texts :user-menu-service-guide])
-                   :on-click #(e! (fp-controller/->ChangePage :front-page))} ]
+                   :on-click #(e! (fp-controller/->ChangePage :own-services))} ]
     [ui/menu-item {:style {:color "#FFFFFF"}
                    :primary-text (tr [:common-texts :user-menu-service-operator])
                    :on-click #(e! (fp-controller/->ChangePage :transport-operator))}]
@@ -73,16 +73,13 @@
       [:a.main-icon {:on-click #(e! (fp-controller/->GoToUrl "/"))}
        [:img {:src "img/icons/nap-logo.svg"}]]])
     [:li
-     [:a.ote-nav {:class    (is-topnav-active :front-page (:page app))
-                  :on-click #(e! (fp-controller/->GoToUrl "/"))}
+     [:a.ote-nav {:on-click #(e! (fp-controller/->GoToUrl "/"))}
       (tr [:common-texts :navigation-front-page])]]
     [:li
-     [:a.ote-nav {:class    (is-topnav-active :front-page (:page app))
-                  :on-click #(e! (fp-controller/->GoToUrl "/dataset"))}
+     [:a.ote-nav {:on-click #(e! (fp-controller/->GoToUrl "/dataset"))}
       (tr [:common-texts :navigation-dataset])]]
     [:li
-     [:a.ote-nav {:class    (is-topnav-active :front-page (:page app))
-                  :on-click #(e! (fp-controller/->GoToUrl "/organization"))}
+     [:a.ote-nav {:on-click #(e! (fp-controller/->GoToUrl "/organization"))}
       (tr [:common-texts :navigation-organizations])]]
     [:li
      [:a.ote-nav {:class    (is-topnav-active :own-services (:page app))

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -70,27 +70,22 @@
     [:ul
      (when (> (:width app) style-base/mobile-width-px)
      [:li
-      [:a.main-icon {:href     "#"
-                     :on-click (fn [_] (set! (.-location js/document) "/"))}
+      [:a.main-icon {:on-click #(e! (fp-controller/->GoToUrl "/"))}
        [:img {:src "img/icons/nap-logo.svg"}]]])
     [:li
      [:a.ote-nav {:class    (is-topnav-active :front-page (:page app))
-                  :href     "#"
-                  :on-click (fn [_] (set! (.-location js/document) "/"))}
+                  :on-click #(e! (fp-controller/->GoToUrl "/"))}
       (tr [:common-texts :navigation-front-page])]]
     [:li
      [:a.ote-nav {:class    (is-topnav-active :front-page (:page app))
-                  :href     "#"
-                  :on-click (fn [_] (set! (.-location js/document) "/dataset"))}
+                  :on-click #(e! (fp-controller/->GoToUrl "/dataset"))}
       (tr [:common-texts :navigation-dataset])]]
     [:li
      [:a.ote-nav {:class    (is-topnav-active :front-page (:page app))
-                  :href     "#"
-                  :on-click (fn [_] (set! (.-location js/document) "/organization"))}
+                  :on-click #(e! (fp-controller/->GoToUrl "/organization"))}
       (tr [:common-texts :navigation-organizations])]]
     [:li
      [:a.ote-nav {:class    (is-topnav-active :own-services (:page app))
-                  :href     "#"
                   :on-click #(e! (fp-controller/->ChangePage :own-services))}
       (tr [:common-texts :navigation-own-service-list])]]
    ]
@@ -157,7 +152,7 @@
 
      [:div.container-fluid.wrapper
       (case (:page app)
-        :front-page [fp/front-page e! app]
+        :front-page [fp/own-services e! app]
         :own-services [fp/own-services e! app]
         :transport-service [t-service/select-service-type e! (:transport-service app)]
         :transport-operator [to/operator e! (:transport-operator app)]

--- a/ote/src/cljs/ote/views/transport_service.cljs
+++ b/ote/src/cljs/ote/views/transport_service.cljs
@@ -37,9 +37,9 @@
   [:div.row
    [:div {:class "col-sx-12 col-md-9"}
     [:div
-     [:h3 (tr [:common-texts :title-required-data-with-OTE])]]
+     [:h3 (tr [:select-service-type-page :title-required-data])]]
     [:div.row
-     [:p (tr [:common-texts :transport-service-type-selection-help-text])]]
+     [:p (tr [:select-service-type-page :transport-service-type-selection-help-text])]]
     [:div.row
      [form/form (service-form-options e!)
       [


### PR DESCRIPTION
Remove 2 pages from OTE.
Now "Omat palvelutiedot" page opens transport service type selection page automatically if no transport services are added to ote.

I also added cursor element for header links and translated one title in organization viewer.