### PR TITLE
Muu kutsuun perustuva liikenne

### DIFF
--- a/database/src/main/resources/db/migration/v1_18__other_sub_type.sql
+++ b/database/src/main/resources/db/migration/v1_18__other_sub_type.sql
@@ -1,0 +1,3 @@
+-- Add fourth passenger transportation sub type
+
+ALTER TYPE transport_service_subtype ADD VALUE 'other';

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -155,7 +155,8 @@
 
   :ote.db.transport-service/sub-type
   {:taxi     "Taksiliikenne"
-   :request  "Muu kutsuun perustuva liikenne"
+   :request  "Tilausajoliikenne, linja-auto"
+   :other  "Muu kutsuun perustuva liikenne"
    :schedule "Säännöllinen aikataulun mukainen liikenne"}
 
   :ote.db.transport-service/payment-methods
@@ -238,6 +239,7 @@
  {:terminal                 "Asemat, satamat ja muut terminaalit"
   :passenger-transportation-taxi "Taksiliikenne (henkilöiden kuljetuspalvelut)"
   :passenger-transportation-request "Tilausajoliikenne, linja-auto (henkilöiden kuljetuspalvelut)"
+  :passenger-transportation-other "Muu kutsuun perustuva liikenne (henkilöiden kuljetuspalvelut)"
   :passenger-transportation-schedule "Säännöllinen aikataulun mukainen liikenne (henkilöiden kuljetuspalvelut)"
   :rentals                  "Ajoneuvojen vuokrauspalvelut ja kaupalliset yhteiskäyttöpalvelut"
   :parking                  "Yleiset kaupalliset pysäköintipalvelut"

--- a/ote/src/cljc/ote/db/transport_service.cljc
+++ b/ote/src/cljc/ote/db/transport_service.cljc
@@ -68,7 +68,7 @@
 (def transport-service-types [:terminal :passenger-transportation :rentals :parking :brokerage])
 
 ;; Create order for transport_type
-(def passenger-transportation-sub-types [:taxi :request :schedule])
+(def passenger-transportation-sub-types [:taxi :request :other :schedule])
 
 ;; Create order for payment_method
 (def payment-methods [:cash :debit-card :credit-card :mobilepay :contactless-payment :invoice :other])

--- a/ote/src/cljs/ote/app/controller/transport_service.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_service.cljs
@@ -29,6 +29,7 @@
   (case type
     :passenger-transportation-taxi :passenger-transportation
     :passenger-transportation-request :passenger-transportation
+    :passenger-transportation-other :passenger-transportation
     :passenger-transportation-schedule :passenger-transportation
     :terminal :terminal
     :rentals :rentals
@@ -41,6 +42,7 @@
   (case type
     :passenger-transportation-taxi :taxi
     :passenger-transportation-request :request
+    :passenger-transportation-other :other
     :passenger-transportation-schedule :schedule
     :terminal :terminal ;; No subtype for terminals - but it is still saved to database
     :rentals :rentals

--- a/ote/src/cljs/ote/views/transport_service.cljs
+++ b/ote/src/cljs/ote/views/transport_service.cljs
@@ -23,6 +23,7 @@
   ;; Create order for service type selection dropdown
    [:passenger-transportation-taxi
     :passenger-transportation-request
+    :passenger-transportation-other
     :passenger-transportation-schedule
     :terminal
     :rentals


### PR DESCRIPTION
Add Muu kutsuun perustuva liikenne transport service sub type to database and to ui.

Ensure that same sub types are used in search page, passenger-tranportation form and service type selection page.