### PR TITLE
152884765 Fix service delete and add confirmation

### DIFF
--- a/database/src/main/resources/db/migration/V1_20__cascade_service_delete.sql
+++ b/database/src/main/resources/db/migration/V1_20__cascade_service_delete.sql
@@ -11,3 +11,24 @@ ALTER TABLE "external-interface-description"
       FOREIGN KEY ("transport-service-id")
       REFERENCES "transport-service" (id)
       ON DELETE CASCADE;
+
+-- When CKAN dataset is deleted, remove OTE information as well
+ALTER TABLE "transport-service"
+ DROP CONSTRAINT "transport-service_ckan-dataset-id_fkey",
+  ADD CONSTRAINT "transport-service_ckan-dataset-id_fkey"
+      FOREIGN KEY ("ckan-dataset-id")
+      REFERENCES package (id)
+      ON DELETE CASCADE;
+
+ALTER TABLE "external-interface-description"
+ DROP CONSTRAINT "external-interface-description_ckan-resource-id_fkey",
+  ADD CONSTRAINT "external-interface-description_ckan-resource-id_fkey"   FOREIGN KEY ("ckan-resource-id")
+      REFERENCES resource (id)
+      ON DELETE CASCADE;
+
+ALTER TABLE "transport-service"
+ DROP CONSTRAINT "transport-service_ckan-resource-id_fkey",
+  ADD CONSTRAINT "transport-service_ckan-resource-id_fkey"
+      FOREIGN KEY ("ckan-resource-id")
+      REFERENCES  resource (id)
+      ON DELETE CASCADE;

--- a/database/src/main/resources/db/migration/V1_20__cascade_service_delete.sql
+++ b/database/src/main/resources/db/migration/V1_20__cascade_service_delete.sql
@@ -1,0 +1,13 @@
+ALTER TABLE operation_area
+ DROP CONSTRAINT "operation_area_transport-service-id_fkey",
+  ADD CONSTRAINT "operation_area_transport-service-id_fkey"
+      FOREIGN KEY ("transport-service-id")
+      REFERENCES "transport-service" (id)
+      ON DELETE CASCADE;
+
+ALTER TABLE "external-interface-description"
+ DROP CONSTRAINT "external-interface-description_transport-service-id_fkey",
+  ADD CONSTRAINT "external-interface-description_transport-service-id_fkey"
+      FOREIGN KEY ("transport-service-id")
+      REFERENCES "transport-service" (id)
+      ON DELETE CASCADE;

--- a/database/src/main/resources/db/migration/V1_20__cascade_service_delete.sql
+++ b/database/src/main/resources/db/migration/V1_20__cascade_service_delete.sql
@@ -22,7 +22,8 @@ ALTER TABLE "transport-service"
 
 ALTER TABLE "external-interface-description"
  DROP CONSTRAINT "external-interface-description_ckan-resource-id_fkey",
-  ADD CONSTRAINT "external-interface-description_ckan-resource-id_fkey"   FOREIGN KEY ("ckan-resource-id")
+  ADD CONSTRAINT "external-interface-description_ckan-resource-id_fkey"
+      FOREIGN KEY ("ckan-resource-id")
       REFERENCES resource (id)
       ON DELETE CASCADE;
 

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/plugin.py
@@ -56,7 +56,7 @@ authenticator.UsernamePasswordAuthenticator.authenticate = authenticate_monkey_p
 
 ### MONKEY PATCH CKAN AUTHENTICATION END ###
 
-def dataset_purge_custon_auth(context, data_dict):
+def dataset_purge_custom_auth(context, data_dict):
     # Defer authorization for package_pruge to package_update
     # This authorization is similar to editing package fields.
 
@@ -128,7 +128,7 @@ class NapoteThemePlugin(plugins.SingletonPlugin, DefaultTranslation, tk.DefaultD
     plugins.implements(plugins.IResourceView, inherit=True)
 
     def get_auth_functions(self):
-        return {'dataset_purge': dataset_purge_custon_auth}
+        return {'dataset_purge': dataset_purge_custom_auth}
 
     def get_helpers(self):
         return {

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -333,8 +333,12 @@
   :footer-livi-url                            "Liikennevirasto.fi"
   :footer-ckan-software                       "CKAN-ohjelmistolla"
   :footer-made-width                          "Toteutettu"
-
   }
+
+ :dialog
+ {:delete-transport-service
+  {:title "Poista liikkumispalvelun tiedot?"
+   :confirm ["Haluatko varmasti poistaa \"" :name "\" liikkumispalvelun pysyvästi?"]}}
 
  :organization-viewer-page
  {:contact-types  "Yhteystavat"

--- a/ote/src/clj/ote/nap/ckan.clj
+++ b/ote/src/clj/ote/nap/ckan.clj
@@ -129,4 +129,4 @@
     (action ckan resource)))
 
 (defn delete-dataset! [ckan dataset-id]
-  (ckan-post ckan "action/package_delete" {:ckan/id dataset-id}))
+  (ckan-post ckan "action/dataset_purge" {:ckan/id dataset-id}))

--- a/ote/src/clj/ote/nap/ckan.clj
+++ b/ote/src/clj/ote/nap/ckan.clj
@@ -127,3 +127,6 @@
                  update-dataset-resource!
                  add-dataset-resource!)]
     (action ckan resource)))
+
+(defn delete-dataset! [ckan dataset-id]
+  (ckan-post ckan "action/package_delete" {:ckan/id dataset-id}))

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -30,15 +30,17 @@
       {:open true
        :title (tr [:dialog :delete-transport-service :title])
        :actions [(r/as-element
-                  [ui/raised-button
+                  [ui/flat-button
                    {:label (tr [:buttons :cancel])
                     :primary true
                     :on-click #(e! (ts/->CancelDeleteTransportService id))}])
                  (r/as-element
                   [ui/raised-button
                    {:label (tr [:buttons :delete])
+                    :icon (ic/action-delete-forever)
                     :secondary true
                     :on-click #(e! (ts/->ConfirmDeleteTransportService id))}])]}
+
       (tr [:dialog :delete-transport-service :confirm] {:name name})])
    ])
 (defn transport-services-table-rows [e! services transport-operator-id]

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -16,8 +16,30 @@
             [ote.db.modification :as modification]
             [ote.time :as time]
             [stylefy.core :as stylefy]
-            [ote.style.base :as style-base]))
+            [ote.style.base :as style-base]
+            [reagent.core :as r]))
 
+(defn- delete-service-action [e! {::t-service/keys [id name]
+                                  :keys [show-delete-modal?]
+                                  :as service}]
+  [:span
+   [ui/icon-button {:on-click #(e! (ts/->DeleteTransportService id))}
+    [ic/action-delete]]
+   (when show-delete-modal?
+     [ui/dialog
+      {:open true
+       :title (tr [:dialog :delete-transport-service :title])
+       :actions [(r/as-element
+                  [ui/flat-button
+                   {:label (tr [:buttons :cancel])
+                    :primary true
+                    :on-click #(e! (ts/->CancelDeleteTransportService id))}])
+                 (r/as-element
+                  [ui/flat-button {:label (tr [:buttons :delete])
+                                   :secondary true
+                                   :on-click #(e! (ts/->ConfirmDeleteTransportService id))}])]}
+      (tr [:dialog :delete-transport-service :confirm] {:name name})])
+   ])
 (defn transport-services-table-rows [e! services transport-operator-id]
   [ui/table-body {:display-row-checkbox false}
    (doall
@@ -42,8 +64,7 @@
             [ui/table-row-column
              [ui/icon-button {:href edit-service-url  }
               [ic/content-create]]
-             [ui/icon-button {:on-click #(e! (ts/->DeleteTransportService id))}
-              [ic/action-delete]]]]))
+             [delete-service-action e! row]]]))
        services))])
 
 (defn transport-services-listing [e! transport-operator-id services section-label]

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -41,8 +41,8 @@
                     :secondary true
                     :on-click #(e! (ts/->ConfirmDeleteTransportService id))}])]}
 
-      (tr [:dialog :delete-transport-service :confirm] {:name name})])
-   ])
+      (tr [:dialog :delete-transport-service :confirm] {:name name})])])
+
 (defn transport-services-table-rows [e! services transport-operator-id]
   [ui/table-body {:display-row-checkbox false}
    (doall

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -30,14 +30,15 @@
       {:open true
        :title (tr [:dialog :delete-transport-service :title])
        :actions [(r/as-element
-                  [ui/flat-button
+                  [ui/raised-button
                    {:label (tr [:buttons :cancel])
                     :primary true
                     :on-click #(e! (ts/->CancelDeleteTransportService id))}])
                  (r/as-element
-                  [ui/flat-button {:label (tr [:buttons :delete])
-                                   :secondary true
-                                   :on-click #(e! (ts/->ConfirmDeleteTransportService id))}])]}
+                  [ui/raised-button
+                   {:label (tr [:buttons :delete])
+                    :secondary true
+                    :on-click #(e! (ts/->ConfirmDeleteTransportService id))}])]}
       (tr [:dialog :delete-transport-service :confirm] {:name name})])
    ])
 (defn transport-services-table-rows [e! services transport-operator-id]


### PR DESCRIPTION
When deleting a published service, call CKAN API to do the delete (via "dataset_purge" API call) which cascades to all OTE resources.

When deleting an unpublished, delete from OTE database directly.