### PR TITLE
152797367 Don't require modification for save

### DIFF
--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -87,6 +87,7 @@
 
    {:name        ::common/postal_code
     :type        :string
+    :regex #"\d{0,5}"
     :read (comp ::common/postal_code ::t-service/contact-address)
     :write (fn [data postal-code]
              (assoc-in data [::t-service/contact-address ::common/postal_code] postal-code))

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -117,11 +117,11 @@
     [:div.row
      (if published?
        [buttons/save {:on-click #(e! (ts/->SaveTransportService true))
-                      :disabled (form/disable-save? data)}
+                      :disabled (not (form/can-save? data))}
         (tr [:buttons :save-updated])]
        [:span
         [buttons/save {:on-click #(e! (ts/->SaveTransportService true))
-                       :disabled (form/disable-save? data)}
+                       :disabled (not (form/can-save? data))}
          (tr [:buttons :save-and-publish])]
         [buttons/save  {:on-click #(e! (ts/->SaveTransportService false))
                         :disabled name-missing?}


### PR DESCRIPTION
Form `disable-save?` checks that form is valid and has been modified. We don't need to check for modification, so changed the check to just use `can-save?`