### PR TITLE
153097659 Save notification

### DIFF
--- a/ote/src/cljs/ote/app/controller/front_page.cljs
+++ b/ote/src/cljs/ote/app/controller/front_page.cljs
@@ -9,7 +9,6 @@
 (defrecord GoToUrl [url])
 (defrecord OpenUserMenu [])
 (defrecord OpenHeader [])
-(defrecord ToggleDebugState [])
 (defrecord Logout [])
 (defrecord SetLanguage [lang])
 
@@ -33,13 +32,6 @@
   (process-event [{url :url} app]
     (set! (.-location js/window) url )
     app)
-
-  ToggleDebugState
-  (process-event [_ app]
-    (cond
-      (get-in app [:ote-service-flags :show-debug]) (assoc-in app [:ote-service-flags :show-debug] false)
-      :default (assoc-in app [:ote-service-flags :show-debug] true)
-      ))
 
   OpenUserMenu
   (process-event [_ app]

--- a/ote/src/cljs/ote/ui/debug.cljs
+++ b/ote/src/cljs/ote/ui/debug.cljs
@@ -68,6 +68,7 @@
   [:span (pr-str data)])
 
 (def debug-style {:position "fixed"
+                  :left "0"
                   :bottom "0"
                   :max-height "200"
                   :overflow-y "scroll"

--- a/ote/src/cljs/ote/ui/validation.cljs
+++ b/ote/src/cljs/ote/ui/validation.cljs
@@ -13,6 +13,8 @@
             [ote.localization :refer [tr tr-key]]
             [ote.format :as fmt]))
 
+;; max length 16 chars (optional plus followed by digits)
+(def phone-number-regex #"^((\+?\d{0,15})|(\d{0,16}))$")
 
 (defn empty-value? [arvo]
   (or (nil? arvo)

--- a/ote/src/cljs/ote/views/ckan_org_editor.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_editor.cljs
@@ -13,14 +13,12 @@
             [ote.localization :refer [tr tr-or]]
             [ote.views.transport-operator :as to-view]))
 
-(defn editor [e! {ckan-organization-id :ckan-organization-id :as state}]
+(defn editor [e! _]
   ;; init
   (e! (org-edit/->StartEditor))
   (fn [e! state]
+    [theme state
+     [:div.ote-sovellus
       (if (get-in state [:transport-operator :loading?])
-      [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
-
-      [theme
-       [:div.ote-sovellus
-        [:div
-         [to-view/operator e! state]]]])))
+        [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
+        [to-view/operator e! state])]]))

--- a/ote/src/cljs/ote/views/ckan_org_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_org_viewer.cljs
@@ -58,7 +58,7 @@
   (e! (org-viewer/->StartViewer))
   (fn [e! {:keys [transport-operator] :as app}]
     (if (not-empty transport-operator)
-      [theme
+      [theme status
        [:div.container
         [basic-info transport-operator]
         [contact-info transport-operator]]]

--- a/ote/src/cljs/ote/views/ckan_service_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_service_viewer.cljs
@@ -152,7 +152,7 @@
 
       [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
 
-      [theme
+      [theme app
         [:div.transport-service-view
           [:div.row.pull-right
             (if (and logged-in? authorized?)

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -15,7 +15,6 @@
             [ote.views.brokerage :as brokerage]
             [ote.localization :refer [tr tr-key] :as localization]
             [ote.views.place-search :as place-search]
-            [ote.ui.debug :as debug]
             [stylefy.core :as stylefy]
             [ote.style.base :as style-base]
             [ote.style.topnav :as style-topnav]
@@ -33,14 +32,6 @@
 (defn- is-user-menu-active [app]
   (when (= true (get-in app [:ote-service-flags :user-menu-open]))
     "active"))
-
-
-
-(defn- flash-message [msg]
-  [ui/snackbar {:open (boolean msg)
-                :message (or msg "")
-                :style style-base/flash-message
-                :auto-hide-duration 5000}])
 
 (defn header-links [app]
   (filter some?
@@ -98,9 +89,6 @@
                    :on-click #(do
                                 (.preventDefault %)
                                 (e! (fp-controller/->ChangePage :transport-operator)))}]
-    [ui/menu-item {:style {:color "#FFFFFF"}
-                   :primary-text " Näytä debug state"
-                   :on-click #(e! (fp-controller/->ToggleDebugState))} ]
     [ui/menu-item {:style {:color "#FFFFFF"}
                    :primary-text (tr [:common-texts :user-menu-log-out])
                    :on-click #(do (.preventDefault %)
@@ -202,25 +190,7 @@
        [:li
         [:a {:href "https://www.liikennevirasto.fi/"} (tr [:common-texts :footer-livi-url])]]]]]]])
 
-(defonce debug-state-toggle-listener (atom false))
 
-(defn- debug-state [e! app]
-  (when-not @debug-state-toggle-listener
-    (reset! debug-state-toggle-listener true)
-    (.addEventListener
-     js/window "keypress"
-     (fn [e]
-       (when (and (.-ctrlKey e)
-                  (= "d" (.-key e)))
-         (e! (fp-controller/->ToggleDebugState))))))
-  (r/create-class
-   ;; NOTE: debug state is VERY slow if app state is HUGE
-   ;; (it tries to pr-str it)
-   {:reagent-render
-    (fn [_ app]
-      (when (= true (get-in app [:ote-service-flags :show-debug]))
-        [:div.row
-         [debug/debug app]]))}))
 
 (defn ote-application
   "OTE application main view"
@@ -234,9 +204,9 @@
       [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
 
     [:div {:style (stylefy/use-style style-base/body)}
-     [theme
+     [theme app
       [:div.ote-sovellus
-       (top-nav e! app)
+       [top-nav e! app]
 
 
        [:div.container-fluid.wrapper (stylefy/use-style style-base/wrapper)
@@ -255,6 +225,4 @@
           :services [service-search/service-search e! (:service-search app)]
           [:div (tr [:common-texts :no-such-page]) (pr-str (:page app))])]
 
-     (when-let [msg (:flash-message app)] [flash-message msg])
-     [debug-state e! app]
-     [footer]]]])))
+       [footer]]]])))

--- a/ote/src/cljs/ote/views/theme.cljs
+++ b/ote/src/cljs/ote/views/theme.cljs
@@ -1,10 +1,37 @@
 (ns ote.views.theme
   (:require [cljs-react-material-ui.reagent :as ui]
-            [cljs-react-material-ui.core :refer [get-mui-theme color]]))
+            [cljs-react-material-ui.core :refer [get-mui-theme color]]
+            [ote.ui.debug :as debug]
+            [ote.style.base :as style-base]
+            [reagent.core :as r]))
+
+(defn- flash-message [msg]
+  [ui/snackbar {:open (boolean msg)
+                :message (or msg "")
+                :style style-base/flash-message
+                :auto-hide-duration 5000}])
+
+(defonce debug-state-toggle-listener (atom false))
+
+(defn- debug-state [_]
+  (let [visible? (r/atom false)]
+    (when-not @debug-state-toggle-listener
+      (reset! debug-state-toggle-listener true)
+      (.addEventListener
+       js/window "keypress"
+       (fn [e]
+         (when (or (and (.-ctrlKey e) (= "d" (.-key e)))
+                   (and (.-ctrlKey e) (= "b" (.-key e))))
+           (swap! visible? not)))))
+    (fn [app]
+      [:span
+       (when @visible?
+         [:div.row
+          [debug/debug app]])])))
 
 (defn theme
-  "Wrap the given content in OTE Material UI theme provider."
-  [content]
+  "App container that sets the theme and common elements like flash message."
+  [{msg :flash-message :as app} content]
   [ui/mui-theme-provider
    {:mui-theme
     (get-mui-theme
@@ -29,4 +56,8 @@
        :button    {:labelColor "#fff"}
        ;; Change drop down list items selected color
        :menu-item {:selected-text-color (color :blue700)}})}
-   content])
+   [:span
+    (when msg
+      [flash-message msg])
+    content
+    [debug-state app]]])

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -1,85 +1,90 @@
 (ns ote.views.transport-operator
-  "Olennaisten tietojen lomakenäkymä"
+  "Form to edit transport operator information."
   (:require [ote.ui.form :as form]
             [ote.ui.form-groups :as form-groups]
             [ote.ui.buttons :as buttons]
+            [ote.ui.validation :as ui-validation]
             [ote.app.controller.transport-operator :as to]
             [ote.db.transport-operator :as t-operator]
             [ote.db.common :as common]
             [ote.localization :refer [tr tr-key]]
-            [ote.ui.form-fields :as form-fields]))
+            [ote.ui.form-fields :as form-fields]
+            [reagent.core :as r]))
 
-(defn operator [e! state]
-  [:div
-  [:div.row
-   [:div  {:class "col-xs-12 col-sm-4 col-md-4"}
-    [:h1 (tr [:organization-page :organization-form-title])]]]
-   (if (second (:transport-operators-with-services state))
-   [:div.row
-    [:div  {:class "col-xs-12 col-sm-4 col-md-4"}
-      [form-fields/field
-       {:label (tr [:field-labels :select-transport-operator])
-        :name        :select-transport-operator
-        :type        :selection
-        :show-option ::t-operator/name
-        :update!   #(e! (to/->SelectOperator %))
-        :options     (map :transport-operator (:transport-operators-with-services state))
-        :auto-width? true}
-       (get state :transport-operator)
-       ]]]
-    nil)
+(defn- operator-form-groups []
+  [(form/group
+    {:label (tr [:common-texts :title-operator-basic-details])
+     :columns 1}
+    {:name ::t-operator/name
+     :type :string
+     :required? true}
 
-   [:div.row
+    {:name ::t-operator/business-id
+     :type :string
+     :validate [[:business-id]]}
 
-   [form/form
-    {:name->label (tr-key [:field-labels])
-     :update! #(e! (to/->EditTransportOperatorState %))
-     :name #(tr [:olennaiset-tiedot :otsikot %])
-     :footer-fn (fn [data]
-                  [buttons/save {:on-click #(e! (to/->SaveTransportOperator))
-                                   :disabled (form/disable-save? data)}
-                   (tr [:buttons :save])])}
+    {:name ::common/street
+     :type :string
+     :read (comp ::common/street ::t-operator/visiting-address)
+     :write (fn [data street]
+              (assoc-in data [::t-operator/visiting-address ::common/street] street))}
 
-    [(form/group
-      {:label (tr [:common-texts :title-operator-basic-details])
-       :columns 1}
-      {:name ::t-operator/name
-       :type :string
-       :validate [[:non-empty "Anna nimi"]]}  ;;FIXME: translate
+    {:name ::common/postal_code
+     :type :string
+     :read (comp ::common/postal_code ::t-operator/visiting-address)
+     :write (fn [data postal-code]
+              (assoc-in data [::t-operator/visiting-address ::common/postal_code] postal-code))}
 
-      {:name ::t-operator/business-id
-       :type :string
-       :validate [[:business-id]]}
+    {:name :ote.db.common/post_office
+     :type :string
+     :read (comp :ote.db.common/post_office :ote.db.transport-operator/visiting-address)
+     :write (fn [data post-office]
+              (assoc-in data [:ote.db.transport-operator/visiting-address :ote.db.common/post_office] post-office))}
 
-      {:name ::common/street
-       :type :string
-       :read (comp ::common/street ::t-operator/visiting-address)
-       :write (fn [data street]
-                (assoc-in data [::t-operator/visiting-address ::common/street] street))}
-
-      {:name ::common/postal_code
-       :type :string
-       :read (comp ::common/postal_code ::t-operator/visiting-address)
-       :write (fn [data postal-code]
-                (assoc-in data [::t-operator/visiting-address ::common/postal_code] postal-code))}
-
-      {:name :ote.db.common/post_office
-       :type :string
-       :read (comp :ote.db.common/post_office :ote.db.transport-operator/visiting-address)
-       :write (fn [data post-office]
-                (assoc-in data [:ote.db.transport-operator/visiting-address :ote.db.common/post_office] post-office))}
-
-      {:name ::t-operator/homepage
+    {:name ::t-operator/homepage
        :type :string})
 
-     (form/group
-      {:label (tr [:organization-page :contact-types])
-       :columns 1}
+   (form/group
+    {:label (tr [:organization-page :contact-types])
+     :columns 1}
 
-      {:name ::t-operator/phone :type :string}
-      {:name ::t-operator/gsm :type :string}
-      {:name ::t-operator/email :type :string}
-     )]
+    {:name ::t-operator/phone :type :string :regex ui-validation/phone-number-regex}
+    {:name ::t-operator/gsm :type :string}
+    {:name ::t-operator/email :type :string})])
 
-    (:transport-operator state)]]
-   ])
+(defn- operator-form-options [e!]
+  {:name->label (tr-key [:field-labels])
+   :update! #(e! (to/->EditTransportOperatorState %))
+   :name #(tr [:olennaiset-tiedot :otsikot %])
+   :footer-fn (fn [data]
+                [buttons/save {:on-click #(e! (to/->SaveTransportOperator))
+                               :disabled (form/disable-save? data)}
+                 (tr [:buttons :save])])})
+
+(defn operator [e! state]
+  (r/with-let [form-options (operator-form-options e!)
+               form-groups (operator-form-groups)]
+    [:div
+     [:div.row
+      [:div  {:class "col-xs-12 col-sm-4 col-md-4"}
+       [:h1 (tr [:organization-page :organization-form-title])]]]
+     (when (second (:transport-operators-with-services state))
+       [:div.row
+        [:div  {:class "col-xs-12 col-sm-4 col-md-4"}
+         [form-fields/field
+          {:label (tr [:field-labels :select-transport-operator])
+           :name        :select-transport-operator
+           :type        :selection
+           :show-option ::t-operator/name
+           :update!   #(e! (to/->SelectOperator %))
+           :options     (map :transport-operator (:transport-operators-with-services state))
+           :auto-width? true}
+          (get state :transport-operator)]]])
+
+     [:div.row
+
+      [form/form
+       form-options
+       form-groups
+
+       (:transport-operator state)]]]))


### PR DESCRIPTION
The `theme` component is the main app container all entrypoints use. That now contains the debug state and flash-message support so that we can define it only once.

**Add phone number regex**

**Refactor form**

**Have theme container provide common parts: flash-message and debug state**