### PR TITLE
153208668 Table usability improvements

### DIFF
--- a/ote/src/cljc/ote/util/values.cljc
+++ b/ote/src/cljc/ote/util/values.cljc
@@ -1,5 +1,6 @@
 (ns ote.util.values
-  "Common utilities for checking values.")
+  "Common utilities for checking values."
+  (:require [clojure.string :as str]))
 
 (defn effectively-empty?
   "Check if the given value is effectively empty.

--- a/ote/src/cljc/ote/util/values.cljc
+++ b/ote/src/cljc/ote/util/values.cljc
@@ -1,0 +1,22 @@
+(ns ote.util.values
+  "Common utilities for checking values.")
+
+(defn effectively-empty?
+  "Check if the given value is effectively empty.
+  Effectively empty values are nil and blank (or just whitespace) strings
+  and collections that contain only effectively empty values."
+  [value]
+  (or (nil? value)
+
+      ;; This is a map that is empty or only has effectively empty values
+      (and (map? value)
+           (or (empty? value)
+               (every? effectively-empty? (vals value))))
+
+      ;; This is an empty collection or only has effectively empty values
+      (and (coll? value)
+           (or (empty? value)
+               (every? effectively-empty? value)))
+
+      ;; This is a blank (empty or just whitespace) string
+      (and (string? value) (str/blank? value))))

--- a/ote/src/cljs/ote/app/controller/transport_service.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_service.cljs
@@ -71,7 +71,7 @@
 (defrecord PublishTransportServiceResponse [success? transport-service-id])
 
 (defrecord EditTransportService [form-data])
-(defrecord SaveTransportService [publish?])
+(defrecord SaveTransportService [schemas publish?])
 (defrecord SaveTransportServiceResponse [response])
 (defrecord CancelTransportServiceForm [])
 
@@ -288,12 +288,13 @@
     )
 
   SaveTransportService
-  (process-event [{publish? :publish?} {service :transport-service
-                                        operator :transport-operator :as app}]
+  (process-event [{:keys [schemas publish?]} {service :transport-service
+                                              operator :transport-operator :as app}]
     (let [key (t-service/service-key-by-type (::t-service/type service))
           service-data
           (-> service
-              (update key form/without-form-metadata)
+              (update key (comp (partial form/prepare-for-save schemas)
+                                form/without-form-metadata))
               (dissoc :transport-service-type-subtype
                       :select-transport-operator)
               (move-service-level-keys-from-form key)

--- a/ote/src/cljs/ote/ui/form.cljs
+++ b/ote/src/cljs/ote/ui/form.cljs
@@ -178,7 +178,6 @@
   (reduce
    (fn [prepared-data {:keys [name read write prepare-for-save] :as s}]
      (let [value (prepare-for-save ((or read name) data))]
-       (.log js/console "PREPARE " (pr-str name) " = " (pr-str value))
        (if write
          (write prepared-data value)
          (assoc prepared-data name value))))

--- a/ote/src/cljs/ote/ui/form.cljs
+++ b/ote/src/cljs/ote/ui/form.cljs
@@ -174,6 +174,16 @@
     ::first-modification (or first (t/now))
     ::latest-modification (t/now)))
 
+(defn prepare-for-save [schemas data]
+  (reduce
+   (fn [prepared-data {:keys [name read write prepare-for-save] :as s}]
+     (let [value (prepare-for-save ((or read name) data))]
+       (.log js/console "PREPARE " (pr-str name) " = " (pr-str value))
+       (if write
+         (write prepared-data value)
+         (assoc prepared-data name value))))
+   data
+   (filter :prepare-for-save (unpack-groups schemas))))
 
 (defn field-ui
   "UI for a single form field"

--- a/ote/src/cljs/ote/ui/form.cljs
+++ b/ote/src/cljs/ote/ui/form.cljs
@@ -19,7 +19,7 @@
 (defn info
   "Create a new info form element that doesn't have any interaction, just shows a help text."
   [text]
-  {:name (keyword (str info (swap! keyword-counter inc)))
+  {:name (keyword (str "info" (swap! keyword-counter inc)))
    :type :component
    :container-style style-form/full-width
    :component (fn [_]

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -12,7 +12,8 @@
             [ote.time :as time]
             [ote.ui.buttons :as buttons]
             [ote.ui.common :as common]
-            [ote.style.form :as style-form]))
+            [ote.style.form :as style-form]
+            [ote.util.values :as values]))
 
 
 
@@ -356,54 +357,58 @@
 
 
 (defmethod field :table [{:keys [table-fields update! delete? add-label] :as opts} data]
-  [:div
-   [ui/table
-    [ui/table-header {:adjust-for-checkbox false
-                      :display-select-all false}
-     [ui/table-row {:selectable false}
-      (doall
-       (for [{:keys [name label width] :as tf} table-fields]
-         ^{:key name}
-         [ui/table-header-column {:style
-                                  {:width width
-                                   :white-space "pre-wrap"}}
-          label]))
-      (when delete?
-        [ui/table-header-column {:style {:width "70px"}}
-         (tr [:buttons :delete])])]]
+  (let [data (if (empty? data)
+               ;; have table always contain at least one row
+               [{}]
+               data)]
+    [:div
+     [ui/table
+      [ui/table-header {:adjust-for-checkbox false
+                        :display-select-all false}
+       [ui/table-row {:selectable false}
+        (doall
+         (for [{:keys [name label width] :as tf} table-fields]
+           ^{:key name}
+           [ui/table-header-column {:style
+                                    {:width width
+                                     :white-space "pre-wrap"}}
+            label]))
+        (when delete?
+          [ui/table-header-column {:style {:width "70px"}}
+           (tr [:buttons :delete])])]]
 
-    [ui/table-body {:display-row-checkbox false}
-     (map-indexed
-      (fn [i row]
-        ^{:key i}
-        [ui/table-row {:selectable false :display-border false}
-         (doall
-          (for [{:keys [name read write width type component] :as tf} table-fields
-                :let [update-fn (if write
-                                  #(update data i write %)
-                                  #(assoc-in data [i name] %))
-                      value ((or read name) row)]]
-            ^{:key name}
-            [ui/table-row-column {:style {:width width}}
-             (if (= :component type)
-               (component {:update-form! #(update! (update-fn %))
-                           :data value})
-               [field (assoc tf
-                             :table? true
-                             :update! #(update! (update-fn %)))
-                value])]))
-         (when delete?
-           [ui/table-row-column {:style {:width "70px"}}
-            [ui/icon-button {:on-click #(update! (vec (concat (when (pos? i)
-                                                                (take i data))
-                                                              (drop (inc i) data))))}
-             [ic/action-delete]]])])
-      data)]]
-   (when add-label
-     [buttons/save {:on-click #(update! (conj (or data []) {}))
-                    :label add-label
-                    :label-style style-base/button-label-style
-                    :disabled false}])])
+      [ui/table-body {:display-row-checkbox false}
+       (map-indexed
+        (fn [i row]
+          ^{:key i}
+          [ui/table-row {:selectable false :display-border false}
+           (doall
+            (for [{:keys [name read write width type component] :as tf} table-fields
+                  :let [update-fn (if write
+                                    #(update data i write %)
+                                    #(assoc-in data [i name] %))
+                        value ((or read name) row)]]
+              ^{:key name}
+              [ui/table-row-column {:style {:width width}}
+               (if (= :component type)
+                 (component {:update-form! #(update! (update-fn %))
+                             :data value})
+                 [field (assoc tf
+                               :table? true
+                               :update! #(update! (update-fn %)))
+                  value])]))
+           (when delete?
+             [ui/table-row-column {:style {:width "70px"}}
+              [ui/icon-button {:on-click #(update! (vec (concat (when (pos? i)
+                                                                  (take i data))
+                                                                (drop (inc i) data))))}
+               [ic/action-delete]]])])
+        data)]]
+     (when add-label
+       [buttons/save {:on-click #(update! (conj (or data []) {}))
+                      :label add-label
+                      :label-style style-base/button-label-style
+                      :disabled (values/effectively-empty? (last data))}])]))
 
 (defmethod field :checkbox [{:keys [update! label]} checked?]
   [ui/checkbox {:label label

--- a/ote/src/cljs/ote/views/ckan_service_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_service_viewer.cljs
@@ -17,6 +17,7 @@
             [ote.views.theme :refer [theme]]
             [ote.views.place-search :as place-search]
             [reagent.core :as r]
+            [ote.util.values :as values]
             cljsjs.leaflet))
 
 
@@ -39,21 +40,7 @@
   (tr-or (tr [:viewer :values value]) (str value)))
 
 
-(defn effectively-empty? [value]
-  (or (nil? value)
 
-      ;; This is a map that is empty or only has effectively empty values
-      (and (map? value)
-           (or (empty? value)
-               (every? effectively-empty? (vals value))))
-
-      ;; This is an empty collection or only has effectively empty values
-      (and (coll? value)
-           (or (empty? value)
-               (every? effectively-empty? value)))
-
-      ;; This is a blank (empty or just whitespace) string
-      (and (string? value) (str/blank? value))))
 
 (declare properties-table records-table)
 
@@ -87,7 +74,7 @@
    [:table.table.table-striped.table-bordered.table-condensed
      [:tbody
       (for [[key value] (sort-by first properties)
-            :when (not (effectively-empty? value))]
+            :when (not (values/effectively-empty? value))]
         ^{:key key}
         [:tr
          [:th {:scope "row" :width "25%"}

--- a/ote/src/cljs/ote/views/parking.cljs
+++ b/ote/src/cljs/ote/views/parking.cljs
@@ -16,7 +16,8 @@
             [ote.style.form :as style-form]
             [ote.app.controller.transport-service :as ts]
             [ote.views.transport-service-common :as ts-common]
-            [ote.time :as time]))
+            [ote.time :as time]
+            [ote.util.values :as values]))
 
 (defn form-options [e! schemas]
   {:name->label (tr-key [:field-labels :parking]
@@ -47,6 +48,7 @@
 
     {:name         ::t-service/price-classes
      :type         :table
+     :prepare-for-save values/without-empty-rows
      :table-fields [{:name  ::t-service/name :type :string
                      :label (tr [:field-labels :parking ::t-service/price-class-name])}
                     {:name ::t-service/price-per-unit :type :number :currency? true :style {:width "100px"}
@@ -100,6 +102,7 @@
 
       {:name      ::t-service/service-hours
        :type      :table
+       :prepare-for-save values/without-empty-rows
        :table-fields
                   [{:name              ::t-service/week-days
                     :width             "40%"
@@ -136,6 +139,7 @@
 
       {:name         ::t-service/service-exceptions
        :type         :table
+       :prepare-for-save values/without-empty-rows
        :table-fields [{:name  ::t-service/description
                        :label (tr* :description)
                        :type  :localized-text}
@@ -161,6 +165,7 @@
 
     {:name         ::t-service/parking-capacities
      :type         :table
+     :prepare-for-save values/without-empty-rows
      :table-fields [{:name        ::t-service/parking-facility
                      :type        :selection
                      :show-option (tr-key [:enums ::t-service/parking-facility])

--- a/ote/src/cljs/ote/views/parking.cljs
+++ b/ote/src/cljs/ote/views/parking.cljs
@@ -18,7 +18,7 @@
             [ote.views.transport-service-common :as ts-common]
             [ote.time :as time]))
 
-(defn form-options [e!]
+(defn form-options [e! schemas]
   {:name->label (tr-key [:field-labels :parking]
                         [:field-labels :transport-service-common]
                         [:field-labels :transport-service]
@@ -26,7 +26,7 @@
    :update!     #(e! (ts/->EditTransportService %))
    :name        #(tr [:olennaiset-tiedot :otsikot %])
    :footer-fn   (fn [data]
-                  [ts-common/footer e! data])})
+                  [ts-common/footer e! data schemas])})
 
 (defn name-and-type-group [e!]
   (form/group
@@ -221,8 +221,7 @@
      :full-width?     true}))
 
 (defn parking [e! {form-data ::t-service/parking}]
-  (r/with-let [options (form-options e!)
-               groups [(name-and-type-group e!)
+  (r/with-let [groups [(name-and-type-group e!)
                        (ts-common/contact-info-group)
                        (ts-common/place-search-group e! ::t-service/parking)
                        (ts-common/external-interfaces)
@@ -239,7 +238,8 @@
                        (charging-points e!)
                        (pricing-group e!)
                        (accessibility-group)
-                       (service-hours-group e!)]]
+                       (service-hours-group e!)]
+               options (form-options e! groups)]
               [:div.row
                [:div {:class "col-lg-12"}
                 [:div

--- a/ote/src/cljs/ote/views/passenger_transportation.cljs
+++ b/ote/src/cljs/ote/views/passenger_transportation.cljs
@@ -21,12 +21,12 @@
 
 
 
-(defn transportation-form-options [e!]
+(defn transportation-form-options [e! schemas]
   {:name->label (tr-key [:field-labels :passenger-transportation] [:field-labels :transport-service-common] [:field-labels :transport-service])
    :update!     #(e! (ts/->EditTransportService %))
    :name        #(tr [:olennaiset-tiedot :otsikot %])
    :footer-fn   (fn [data]
-                  [ts-common/footer e! data])})
+                  [ts-common/footer e! data schemas])})
 
 (defn name-and-type-group [e!]
   (form/group
@@ -194,8 +194,7 @@
 
 
 (defn passenger-transportation-info [e! {form-data ::t-service/passenger-transportation}]
-  (with-let [form-options (transportation-form-options e!)
-             form-groups
+  (with-let [form-groups
              [(name-and-type-group e!)
               (ts-common/contact-info-group)
               (ts-common/companies-group)
@@ -210,7 +209,8 @@
                ::t-service/booking-service)
               (accessibility-group)
               (pricing-group e! form-data)
-              (ts-common/service-hours-group)]]
+              (ts-common/service-hours-group)]
+             form-options (transportation-form-options e! form-groups)]
     [:div.row
      [:div {:class "col-lg-12"}
       [:div

--- a/ote/src/cljs/ote/views/passenger_transportation.cljs
+++ b/ote/src/cljs/ote/views/passenger_transportation.cljs
@@ -154,6 +154,7 @@
    {:container-class "col-md-12"
     :name         ::t-service/price-classes
     :type         :table
+    :prepare-for-save values/without-empty-rows
     :table-fields [{:name ::t-service/name :type :string :label price-class-name-label}
                    {:name ::t-service/price-per-unit :type :number :currency? true :style {:width "100px"}
                     :input-style {:text-align "right" :padding-right "5px"}}

--- a/ote/src/cljs/ote/views/rental.cljs
+++ b/ote/src/cljs/ote/views/rental.cljs
@@ -14,7 +14,8 @@
             [ote.views.place-search :as place-search]
             [tuck.core :as tuck]
             [ote.views.transport-service-common :as ts-common]
-            [ote.time :as time]))
+            [ote.time :as time]
+            [ote.util.values :as values]))
 
 (defn rental-form-options [e! schemas]
   {:name->label (tr-key [:field-labels :rentals]
@@ -100,6 +101,7 @@
 
      {:name ::t-service/pick-up-locations
       :type :table
+      :prepare-for-save values/without-empty-rows
       :table-fields [{:name ::t-service/name
                       :type :string}
                      {:name ::t-service/pick-up-type

--- a/ote/src/cljs/ote/views/rental.cljs
+++ b/ote/src/cljs/ote/views/rental.cljs
@@ -16,7 +16,7 @@
             [ote.views.transport-service-common :as ts-common]
             [ote.time :as time]))
 
-(defn rental-form-options [e!]
+(defn rental-form-options [e! schemas]
   {:name->label (tr-key [:field-labels :rentals]
                         [:field-labels :transport-service]
                         [:field-labels :transport-service-common]
@@ -24,7 +24,7 @@
    :update!     #(e! (ts/->EditTransportService %))
    :name        #(tr [:olennaiset-tiedot :otsikot %])
    :footer-fn   (fn [data]
-                  [ts-common/footer e! data])})
+                  [ts-common/footer e! data schemas])})
 
 (defn name-group [e!]
   (form/group
@@ -128,8 +128,7 @@
       :add-label (tr [:buttons :add-new-pick-up-location])})))
 
 (defn rental [e! service]
-  (reagent/with-let [options (rental-form-options e!)
-                     groups [(name-group e!)
+  (reagent/with-let [groups [(name-group e!)
                              (ts-common/contact-info-group)
                              (ts-common/place-search-group e! ::t-service/rentals)
                              (ts-common/external-interfaces)
@@ -139,7 +138,8 @@
                               (tr [:field-labels :transport-service-common ::t-service/rental-service])
                               ::t-service/rental-service)
                              (pick-up-locations e!)
-                             ]]
+                             ]
+                     options (rental-form-options e! groups)]
     [:div.row
      [:div {:class "col-lg-12"}
       [:div

--- a/ote/src/cljs/ote/views/terminal.cljs
+++ b/ote/src/cljs/ote/views/terminal.cljs
@@ -16,12 +16,12 @@
             [ote.views.transport-service-common :as ts-common]
             [ote.style.form :as style-form]))
 
-(defn terminal-form-options [e!]
+(defn terminal-form-options [e! schemas]
   {:name->label (tr-key [:field-labels :terminal] [:field-labels :transport-service-common])
    :update!     #(e! (ts/->EditTransportService %))
    :name        #(tr [:olennaiset-tiedot :otsikot %])
    :footer-fn   (fn [data]
-                  [ts-common/footer e! data])})
+                  [ts-common/footer e! data schemas])})
 
 (defn name-and-type-group [e!]
   (form/group
@@ -114,14 +114,14 @@
    ))
 
 (defn terminal [e! {form-data ::t-service/terminal}]
-  (r/with-let [options (terminal-form-options e!)
-               groups [(name-and-type-group e!)
+  (r/with-let [groups [(name-and-type-group e!)
                        (ts-common/contact-info-group)
                        (ts-common/place-search-group e! ::t-service/terminal)
                        (ts-common/external-interfaces)
                        (indoor-map-group)
                        (assistance-service-group)
-                       (accessibility-and-other-services-group)]]
+                       (accessibility-and-other-services-group)]
+               options (terminal-form-options e! groups)]
     [:div.row
      [:div {:class "col-lg-12"}
       [:div

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -9,7 +9,8 @@
             [ote.app.controller.transport-service :as ts]
             [ote.views.place-search :as place-search]
             [clojure.string :as str]
-            [ote.time :as time]))
+            [ote.time :as time]
+            [ote.util.values :as values]))
 
 (defn service-url
   "Creates a form group for service url that creates two form elements url and localized text area"
@@ -40,6 +41,7 @@
 
     {:name         service-url-field
      :type         :table
+     :prepare-for-save values/without-empty-rows
      :table-fields [{:name ::t-service/url
                      :type :string}
                     {:name ::t-service/description
@@ -63,6 +65,7 @@
 
    {:name ::t-service/external-interfaces
     :type :table
+    :prepare-for-save values/without-empty-rows
     :table-fields [{:name ::t-service/external-service-description :type :localized-text :width "21%"
                     :read (comp ::t-service/description ::t-service/external-interface)
                     :write #(assoc-in %1 [::t-service/external-interface ::t-service/description] %2)}
@@ -86,6 +89,7 @@
 
    {:name ::t-service/companies
     :type :table
+    :prepare-for-save values/without-empty-rows
     :table-fields [{:name ::t-service/name :type :string
                     :label (tr [:field-labels :transport-service-common ::t-service/company-name])}
                    {:name ::t-service/business-id :type :string
@@ -139,20 +143,20 @@
 
 (defn footer
   "Transport service form -footer element. All transport service form should be using this function."
-  [e! {published? ::t-service/published? :as data}]
+  [e! {published? ::t-service/published? :as data} schemas]
   (let [name-missing? (str/blank? (::t-service/name data))]
     [:div.row
      (if published?
        ;; True
-       [buttons/save {:on-click #(e! (ts/->SaveTransportService true))
+       [buttons/save {:on-click #(e! (ts/->SaveTransportService schemas true))
                       :disabled (not (form/can-save? data))}
         (tr [:buttons :save-updated])]
        ;; False
        [:span
-        [buttons/save {:on-click #(e! (ts/->SaveTransportService true))
+        [buttons/save {:on-click #(e! (ts/->SaveTransportService schemas true))
                        :disabled (not (form/can-save? data))}
          (tr [:buttons :save-and-publish])]
-        [buttons/save  {:on-click #(e! (ts/->SaveTransportService false))
+        [buttons/save  {:on-click #(e! (ts/->SaveTransportService schemas false))
                         :disabled name-missing?}
          (tr [:buttons :save-as-draft])]])
      [buttons/cancel {:on-click #(e! (ts/->CancelTransportServiceForm))}
@@ -178,6 +182,7 @@
 
      {:name         ::t-service/service-hours
       :type         :table
+      :prepare-for-save values/without-empty-rows
       :table-fields
       [{:name ::t-service/week-days
         :width "40%"
@@ -214,6 +219,7 @@
 
      {:name ::t-service/service-exceptions
       :type :table
+      :prepare-for-save values/without-empty-rows
       :table-fields [{:name ::t-service/description
                       :label (tr* :description)
                       :type :localized-text}


### PR DESCRIPTION
Support new `:prepare-for-save` key for a form schemas that allows for processing before sending values to the server. This is useful because most tables want to add post processing that removes empty values.

**Move effectively-empty? to new util ns**

**Fix values ns require**

**Force table to have one row, don't allow adding if last row is empty**

**Ignore some keys, add without-empty-rows helper**

**Fix naming of info fields**

**Add schemas to footer for use when preparing form data for save**

**Add schemas to footer params**