### PR TITLE
153130249 edge remove service bug

### DIFF
--- a/ote/src/cljs/ote/app/controller/front_page.cljs
+++ b/ote/src/cljs/ote/app/controller/front_page.cljs
@@ -38,9 +38,9 @@
        (comm/post! "transport-operator/data" {}
                   {:on-success (tuck/send-async! ->TransportOperatorDataResponse)
                    :on-failure (tuck/send-async! ->TransportOperatorDataFailed)})
-      (assoc app :transport-operator-data-loaded? false
-                 :services-changed? false)
-       ) app))
+       (assoc app :transport-operator-data-loaded? false
+                  :services-changed? false))
+     app))
 
 (extend-protocol tuck/Event
 
@@ -77,7 +77,7 @@
 
   EnsureTransportOperator
   (process-event [_ app]
-     (if (get app :services-changed?)
+     (if (:services-changed? app)
       (get-transport-operator-data app)
       app))
 

--- a/ote/src/cljs/ote/app/controller/transport_service.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_service.cljs
@@ -284,8 +284,9 @@
   DeleteTransportServiceResponse
   (process-event [{response :response} app]
     (let [filtered-map (filter #(not= (:ote.db.transport-service/id %) (int response)) (get app :transport-service-vector))]
-      (assoc app :transport-service-vector filtered-map))
-    )
+      (assoc app :transport-service-vector filtered-map
+                 :page :own-services
+                 :services-changed? true)))
 
   SaveTransportService
   (process-event [{publish? :publish?} {service :transport-service
@@ -311,7 +312,9 @@
                 (assoc app :flash-message (tr [:common-texts :transport-service-saved]))
                 response)]
     (routes/navigate! :own-services)
-    (dissoc app :transport-service)))
+    (-> app
+        (assoc :services-changed? true)
+        (dissoc :transport-service))))
 
   EditTransportService
   (process-event [{form-data :form-data} {ts :transport-service :as app}]

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -200,29 +200,28 @@
   (e! (fp-controller/->GetTransportOperatorData))
 
   (fn [e! {loaded? :transport-operator-data-loaded? :as app}]
-    (if (not loaded?)
-      [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
-
     [:div {:style (stylefy/use-style style-base/body)}
      [theme e! app
       [:div.ote-sovellus
        [top-nav e! app]
 
+       (if (or (= false loaded?) (= true (nil? loaded?)))
+         [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
 
-       [:div.container-fluid.wrapper (stylefy/use-style style-base/wrapper)
-        (case (:page app)
-          :no-operator [fp/no-operator e! app]
-          :front-page [fp/own-services e! app]
-          :own-services [fp/own-services e! app]
-          :transport-service [t-service/select-service-type e! app]
-          :transport-operator [to/operator e! app]
+         [:div.container-fluid.wrapper (stylefy/use-style style-base/wrapper)
+          (case (:page app)
+            :no-operator [fp/no-operator e! app]
+            :front-page [fp/own-services e! app]
+            :own-services [fp/own-services e! app]
+            :transport-service [t-service/select-service-type e! app]
+            :transport-operator [to/operator e! app]
 
-          ;; Routes for the service form, one for editing an existing one by id
-          ;; and another when creating a new service
-          :edit-service [t-service/edit-service-by-id e! app]
-          :new-service [t-service/edit-new-service e! app]
+            ;; Routes for the service form, one for editing an existing one by id
+            ;; and another when creating a new service
+            :edit-service [t-service/edit-service-by-id e! app]
+            :new-service [t-service/edit-new-service e! app]
 
-          :services [service-search/service-search e! (:service-search app)]
-          [:div (tr [:common-texts :no-such-page]) (pr-str (:page app))])]
+            :services [service-search/service-search e! (:service-search app)]
+            [:div (tr [:common-texts :no-such-page]) (pr-str (:page app))])])
 
-       [footer]]]])))
+       [footer]]]]))

--- a/ote/src/cljs/ote/views/theme.cljs
+++ b/ote/src/cljs/ote/views/theme.cljs
@@ -80,15 +80,7 @@
 
                        ;; Hint color in text fields
                        :disabledColor  (color :grey900)
-
-                       ;; Border color
-                       :borderColor (color :grey600)
-
-                       :shadowColor (color :grey900)
-
-                       ;; canvas color
-                       ;;:canvas-color  (color :lightBlue50)
-
+                       
                        ;; Main text color
                        :text-color     (color :grey900)
                        }

--- a/ote/src/cljs/ote/views/theme.cljs
+++ b/ote/src/cljs/ote/views/theme.cljs
@@ -80,7 +80,7 @@
 
                        ;; Hint color in text fields
                        :disabledColor  (color :grey900)
-                       
+
                        ;; Main text color
                        :text-color     (color :grey900)
                        }


### PR DESCRIPTION
There is three fixes in this pr.

1. When spinner is shown whole page is rendered (footer and header) not empty page with spinner
2. :front-page page is now removed and we cannot redirect users to :front-page anymore
3. When user deletes a service, we now set :service-changed? flag to true, so we can refresh app-state completely when needed.