### PR TITLE
153474070 CKAN/OTE flow changes

### DIFF
--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/index.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/index.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+{% block page_primary_action %}
+{% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/snippets/organization_item.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/organization/snippets/organization_item.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+{% block image %}
+{% endblock %}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/user/dashboard_organizations.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/user/dashboard_organizations.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+{% block page_primary_action %}
+{% endblock %}

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -428,6 +428,7 @@
  :organization-page
  {:contact-types            "Yhteystavat"
   :organization-form-title  "Palveluntuottajan tiedot"
+  :organization-new-title "Create new transport operator"
   }
 
  :passenger-transportation-page

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -239,6 +239,7 @@
   :close "Sulje"
   :publish "Julkaise"
   :edit-service "Muokkaa palvelun tietoja"
+  :edit "Edit"
 
   :save-and-publish "Tallenna ja julkaise"
   :save-as-draft "Tallenna luonnoksena"
@@ -257,7 +258,8 @@
   :add-add-new-row         "Lisää uusi rivi"
   :add-new-pick-up-location "Lisää toimipiste"
   :add-new-additional-service "Lisää palvelu"
-  :add-new-vehicle "Lisää ajoneuvo"}
+  :add-new-vehicle "Lisää ajoneuvo"
+  :add-new-transport-operator "Add new transport operator"}
 
 
 

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -240,6 +240,7 @@
   :close "Sulje"
   :publish "Julkaise"
   :edit-service "Muokkaa palvelun tietoja"
+  :edit "Muokkaa"
 
   :save-and-publish "Tallenna ja julkaise"
   :save-as-draft "Tallenna luonnoksena"
@@ -258,7 +259,9 @@
   :add-add-new-row         "Lisää uusi rivi"
   :add-new-pick-up-location "Lisää toimipiste"
   :add-new-additional-service "Lisää palvelu"
-  :add-new-vehicle "Lisää ajoneuvo"}
+  :add-new-vehicle "Lisää ajoneuvo"
+  :add-new-transport-operator "Lisää uusi palveluntuottaja"
+  }
 
 
 

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -430,6 +430,7 @@
  :organization-page
  {:contact-types            "Yhteystavat"
   :organization-form-title  "Palveluntuottajan tiedot"
+  :organization-new-title "Lisää palveluntuottaja"
   }
 
  :passenger-transportation-page

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -239,6 +239,7 @@
   :close "Sulje"
   :publish "Julkaise"
   :edit-service "Muokkaa uppassningens tietoja"
+  :edit "Muokkaa"
 
   :save-and-publish "Spara och publisera"
   :save-as-draft "Spara kladd"
@@ -257,7 +258,8 @@
   :add-add-new-row         "Lägga till ny rivi"
   :add-new-pick-up-location "Lägga till toimipiste"
   :add-new-additional-service "Lisää palvelu"
-  :add-new-vehicle "Lisää ajoneuvo"}
+  :add-new-vehicle "Lisää ajoneuvo"
+  :add-new-transport-operator "Lägga till ny transport operator"}
 
  ;; Database enumeration values
  :enums

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -426,6 +426,7 @@
  :organization-page
  {:contact-types            "Yhteystavat"
   :organization-form-title  "Uppassningenstuottajan tiedot"
+  :organization-new-title "Lägga till uppassningensproducent"
   }
 
  :passenger-transportation-page

--- a/ote/src/clj/ote/nap/ckan.clj
+++ b/ote/src/clj/ote/nap/ckan.clj
@@ -130,3 +130,6 @@
 
 (defn delete-dataset! [ckan dataset-id]
   (ckan-post ckan "action/dataset_purge" {:ckan/id dataset-id}))
+
+(defn create-organization! [ckan organization]
+  (ckan-post ckan "action/organization_create" organization))

--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -25,7 +25,9 @@
   CreateTransportOperator
   (process-event [_ app]
     (routes/navigate! :transport-operator)
-    (assoc app :transport-operator {:new? true}))
+    (assoc app
+           :transport-operator {:new? true}
+           :services-changed? true))
 
   SelectOperator
   (process-event [{data :data} app]

--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -14,12 +14,18 @@
 (defrecord FailedTransportOperatorResponse [response])
 
 (defrecord TransportOperatorResponse [response])
+(defrecord CreateTransportOperator [])
 
 
 (defn transport-operator-by-ckan-group-id[id]
   (comm/get! (str "transport-operator/" id) {:on-success (t/send-async! ->TransportOperatorResponse)}))
 
 (extend-protocol t/Event
+
+  CreateTransportOperator
+  (process-event [_ app]
+    (routes/navigate! :transport-operator)
+    (assoc app :transport-operator {:new? true}))
 
   SelectOperator
   (process-event [{data :data} app]
@@ -52,16 +58,17 @@
   (process-event [{data :data} app]
     (routes/navigate! :own-services)
     (assoc app
-      :page :own-services
-      :flash-message (tr [:common-texts :transport-operator-saved ])
-      :transport-operator data
-      :transport-operators-with-services (map (fn [{:keys [transport-operator] :as operator-with-services}]
-                                                (if (= (::t-operator/id data)
-                                                       (::t-operator/id transport-operator))
-                                                  (assoc operator-with-services
-                                                    :transport-operator data)
-                                                  operator-with-services))
-                                              (:transport-operators-with-services app))))
+           :page :own-services
+           :flash-message (tr [:common-texts :transport-operator-saved ])
+           :transport-operator data
+           :transport-operators-with-services (map (fn [{:keys [transport-operator] :as operator-with-services}]
+                                                     (if (= (::t-operator/id data)
+                                                            (::t-operator/id transport-operator))
+                                                       (assoc operator-with-services
+                                                              :transport-operator data)
+                                                       operator-with-services))
+                                                   (:transport-operators-with-services app))
+           :services-changed? true))
 
   TransportOperatorResponse
   (process-event [{response :response} app]

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -88,3 +88,5 @@
 (def language-flag
   {:padding-left "10px"
    :padding-right "10px"})
+
+(def section-margin {:margin-top "1em"})

--- a/ote/src/cljs/ote/ui/common.cljs
+++ b/ote/src/cljs/ote/ui/common.cljs
@@ -18,3 +18,14 @@
   [:div.help (stylefy/use-style style-base/help)
    [:div (stylefy/use-style style-form/help-icon-element) [ic/action-info-outline]]
    [:div (stylefy/use-style style-form/help-text-element) help]])
+
+(defn table2 [& items]
+  [:table
+   [:tbody
+    (map-indexed
+     (fn [i [left right]]
+       ^{:key i}
+       [:tr
+        [:td left]
+        [:td right]])
+     (partition 2 items))]])

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -206,8 +206,11 @@
      (doall
       (map-indexed
        (fn [i option]
-         ^{:key i}
-         [ui/menu-item {:value i :primary-text (show-option option)}])
+         (if (= :divider option)
+           ^{:key i}
+           [ui/divider]
+           ^{:key i}
+           [ui/menu-item {:value i :primary-text (show-option option)}]))
        options))]))
 
 

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -20,7 +20,8 @@
             [ote.style.base :as style-base]
             [reagent.core :as r]
             [ote.ui.form-fields :as form-fields]
-            [ote.ui.common :as ui-common]))
+            [ote.ui.common :as ui-common]
+            [ote.views.transport-operator :as t-operator-view]))
 
 (defn- delete-service-action [e! {::t-service/keys [id name]
                                   :keys [show-delete-modal?]
@@ -94,33 +95,6 @@
        (transport-services-table-rows e! services transport-operator-id)]]]))
 
 
-(defn transport-operator-selection [e! {operator :transport-operator
-                                        operators :transport-operators-with-services}]
-  [:span
-   (when-not (empty? operators)
-     [ui-common/table2
-      [form-fields/field
-       {:label (tr [:field-labels :select-transport-operator])
-        :name        :select-transport-operator
-        :type        :selection
-        :show-option #(if (nil? %)
-                        (tr [:buttons :add-new-transport-operator])
-                        (::t-operator/name %))
-        :update!   #(if (nil? %)
-                      (e! (to/->CreateTransportOperator))
-                      (e! (to/->SelectOperator %)))
-        :options     (into (mapv :transport-operator operators)
-                           [:divider nil])
-        :auto-width? true}
-       operator]
-      [ui/flat-button {:label (tr [:buttons :edit])
-                       :style {:margin-top "1.5em"
-                               :font-size "8pt"}
-                       :icon (ic/content-create {:style {:width 16 :height 16}})
-                       :on-click #(do
-                                    (.preventDefault %)
-                                    (e! (fp/->ChangePage :transport-operator nil)))}]])])
-
 (defn table-container-for-front-page [e! has-services? operator-services state]
   [:div
    [:div.row
@@ -135,7 +109,7 @@
                         :icon (ic/content-add)}]]]
 
     [:div {:class "col-md-12"}
-     [transport-operator-selection e! state]]]
+     [t-operator-view/transport-operator-selection e! state]]]
 
    [:div.row
     [:div {:class "col-xs-12 col-md-12"}

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -19,7 +19,8 @@
             [stylefy.core :as stylefy]
             [ote.style.base :as style-base]
             [reagent.core :as r]
-            [ote.ui.form-fields :as form-fields]))
+            [ote.ui.form-fields :as form-fields]
+            [ote.ui.common :as ui-common]))
 
 (defn- delete-service-action [e! {::t-service/keys [id name]
                                   :keys [show-delete-modal?]
@@ -74,7 +75,7 @@
 
 (defn transport-services-listing [e! transport-operator-id services section-label]
   (when (> (count services) 0)
-    [:div.row
+    [:div.row (stylefy/use-style style-base/section-margin)
      [:div {:class "col-xs-12 col-md-12"}
       [:h3 section-label]
 
@@ -93,39 +94,53 @@
        (transport-services-table-rows e! services transport-operator-id)]]]))
 
 
+(defn transport-operator-selection [e! {operator :transport-operator
+                                        operators :transport-operators-with-services}]
+  [:span
+   (when-not (empty? operators)
+     [ui-common/table2
+      [form-fields/field
+       {:label (tr [:field-labels :select-transport-operator])
+        :name        :select-transport-operator
+        :type        :selection
+        :show-option #(if (nil? %)
+                        (tr [:buttons :add-new-transport-operator])
+                        (::t-operator/name %))
+        :update!   #(if (nil? %)
+                      (e! (to/->CreateTransportOperator))
+                      (e! (to/->SelectOperator %)))
+        :options     (into (mapv :transport-operator operators)
+                           [:divider nil])
+        :auto-width? true}
+       operator]
+      [ui/flat-button {:label (tr [:buttons :edit])
+                       :style {:margin-top "1.5em"
+                               :font-size "8pt"}
+                       :icon (ic/content-create {:style {:width 16 :height 16}})
+                       :on-click #(do
+                                    (.preventDefault %)
+                                    (e! (fp/->ChangePage :transport-operator nil)))}]])])
 
 (defn table-container-for-front-page [e! has-services? operator-services state]
   [:div
    [:div.row
-    [:div {:class "col-xs-12 col-sm-4 col-md-4"}
-     [:h1 (tr [:common-texts :own-api-list]) ]
-     ]
-
-    [:div {:class "col-xs-12 col-sm-4 col-md-4"}
-     (if (second (:transport-operators-with-services state))
-     [form-fields/field
-      {:label (tr [:field-labels :select-transport-operator])
-       :name        :select-transport-operator
-       :type        :selection
-       :show-option ::t-operator/name
-       :update!   #(e! (to/->SelectOperator %))
-       :options     (map :transport-operator (:transport-operators-with-services state))
-       :auto-width? true}
-      (get state :transport-operator)
-      ]
-    nil)
-     ]
-    [:div {:class "col-xs-12 col-sm-4 col-md-4"}
-     [ui/raised-button {:label (tr [:buttons :add-transport-service])
+    [:div {:class "col-md-12"}
+     [:h1 (tr [:common-texts :own-api-list])
+      [ui/raised-button {:label (tr [:buttons :add-transport-service])
+                        :style {:float "right"}
                         :on-click #(do
                                      (.preventDefault %)
                                      (e! (ts/->OpenTransportServiceTypePage)))
-                        :primary  true}]]]
+                        :primary  true
+                        :icon (ic/content-add)}]]]
+
+    [:div {:class "col-md-12"}
+     [transport-operator-selection e! state]]]
+
    [:div.row
     [:div {:class "col-xs-12 col-md-12"}
-
      (if (and has-services? (not (empty? operator-services)))
-      ;; TRUE -> Table for transport services
+       ;; TRUE -> Table for transport services
        (doall
         (for [type t-service/transport-service-types
               :let [services (filter #(= (:ote.db.transport-service/type %) type) operator-services)]
@@ -143,31 +158,32 @@
 (defn own-services [e! state]
   (e! (fp/->EnsureTransportOperator))
   (fn [e! state]
-  ;; Get services by default from first organization
-  (let [has-services? (not (empty? (map #(get-in % [:transport-service-vector ::t-service/id]) state)))
-        operator-services (some #(when (= (get-in state [:transport-operator ::t-operator/id]) (get-in % [:transport-operator ::t-operator/id]))
-                             %)
-                          (:transport-operators-with-services state))
-        operator-services (if (empty? operator-services)
-                      (:transport-service-vector (first (:transport-operators-with-services state)))
-                      (:transport-service-vector state))]
-    [:div
-     (if has-services?
-       (table-container-for-front-page e! has-services? operator-services state)
-       [transport-service/select-service-type e! state] ;; Render service type selection page if no services added
-       )])))
+    ;; Get services by default from first organization
+    (let [has-services? (not (empty? (map #(get-in % [:transport-service-vector ::t-service/id]) state)))
+          operator-services (some #(when (= (get-in state [:transport-operator ::t-operator/id]) (get-in % [:transport-operator ::t-operator/id]))
+                                     %)
+                                  (:transport-operators-with-services state))
+          operator-services (if (empty? operator-services)
+                              (:transport-service-vector (first (:transport-operators-with-services state)))
+                              (:transport-service-vector state))]
+      [:div
+       (if has-services?
+         [table-container-for-front-page e! has-services? operator-services state]
+         ;; Render service type selection page if no services added
+         [transport-service/select-service-type e! state])])))
 
-(defn no-operator [e! state]
+(defn no-operator
   "If user haven't added service-operator, we will ask to do so."
+  [e! state]
   [:div
    [:div.row
     [:div {:class "col-xs-12 col-sm-12 col-md-12"}
      [:h3 (tr [:front-page :header-no-operator])]
      [:p (tr [:front-page :desc-to-add-new-operator])]
-     [:p (tr [:front-page :to-add-new-operator])
-      [:a {:href "/organization/new"} (tr [:common-texts :navigation-organizations]) ]
-      (tr [:front-page :to-add-new-operator-tab])]
-     ]
-    ]
-   ]
-  )
+     [:br]
+     [ui/raised-button {:label (tr [:buttons :add-new-transport-operator])
+                        :primary true
+                        :on-click #(do
+                                     (.preventDefault %)
+                                     (e! (to/->CreateTransportOperator)))
+                        :icon (ic/content-create)}]]]])

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -84,21 +84,16 @@
                     :on-click #(do (.preventDefault %)
                                    (e! (fp-controller/->GoToUrl "/dashboard/datasets")))}]
      [ui/menu-item {:style {:color "#FFFFFF"}
-                   :primary-text (tr [:common-texts :user-menu-profile])
-                   :on-click #(do (.preventDefault %)
-                                  (e! (fp-controller/->GoToUrl (str "/user/edit/" username))))}]
-    [ui/menu-item {:style {:color "#FFFFFF"}
-                   :primary-text (tr [:common-texts :user-menu-service-operator])
-                   :on-click #(do
-                                (.preventDefault %)
-                                (e! (fp-controller/->ChangePage :transport-operator nil)))}]
-    [ui/menu-item {:style {:color "#FFFFFF"}
-                   :primary-text (tr [:common-texts :user-menu-log-out])
-                   :on-click #(do (.preventDefault %)
-                                  (e! (fp-controller/->GoToUrl "/user/_logout")))} ]
+                    :primary-text (tr [:common-texts :user-menu-profile])
+                    :on-click #(do (.preventDefault %)
+                                   (e! (fp-controller/->GoToUrl (str "/user/edit/" username))))}]
+     [ui/menu-item {:style {:color "#FFFFFF"}
+                    :primary-text (tr [:common-texts :user-menu-log-out])
+                    :on-click #(do (.preventDefault %)
+                                   (e! (fp-controller/->GoToUrl "/user/_logout")))} ]
 
-    [ui/menu-item {:style {:color "#FFFFFF"}
-                   :primary-text (r/as-element [language-selection e!])}]]))
+     [ui/menu-item {:style {:color "#FFFFFF"}
+                    :primary-text (r/as-element [language-selection e!])}]]))
 
 (def own-services-pages #{:own-services :transport-service :new-service :edit-service})
 (def services-pages #{:services})

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -31,6 +31,7 @@
 
     {:name ::common/postal_code
      :type :string
+     :regex #"\d{0,5}"
      :read (comp ::common/postal_code ::t-operator/visiting-address)
      :write (fn [data postal-code]
               (assoc-in data [::t-operator/visiting-address ::common/postal_code] postal-code))}

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -1,15 +1,51 @@
 (ns ote.views.transport-operator
   "Form to edit transport operator information."
-  (:require [ote.ui.form :as form]
+  (:require [reagent.core :as r]
+            [cljs-react-material-ui.reagent :as ui]
+            [cljs-react-material-ui.icons :as ic]
+
+            [ote.ui.form :as form]
             [ote.ui.form-groups :as form-groups]
             [ote.ui.buttons :as buttons]
             [ote.ui.validation :as ui-validation]
+            [ote.ui.common :as ui-common]
+            [ote.ui.form-fields :as form-fields]
+
             [ote.app.controller.transport-operator :as to]
+            [ote.app.controller.front-page :as fp]
+
             [ote.db.transport-operator :as t-operator]
             [ote.db.common :as common]
-            [ote.localization :refer [tr tr-key]]
-            [ote.ui.form-fields :as form-fields]
-            [reagent.core :as r]))
+            [ote.localization :refer [tr tr-key]]))
+
+(defn transport-operator-selection [e! {operator :transport-operator
+                                        operators :transport-operators-with-services}]
+  [:span
+   ;; Show operator selection if there are operators and we are not creating a new one
+   (when (and (not (empty? operators))
+              (not (:new? operator)))
+     [ui-common/table2
+      [form-fields/field
+       {:label (tr [:field-labels :select-transport-operator])
+        :name        :select-transport-operator
+        :type        :selection
+        :show-option #(if (nil? %)
+                        (tr [:buttons :add-new-transport-operator])
+                        (::t-operator/name %))
+        :update!   #(if (nil? %)
+                      (e! (to/->CreateTransportOperator))
+                      (e! (to/->SelectOperator %)))
+        :options     (into (mapv :transport-operator operators)
+                           [:divider nil])
+        :auto-width? true}
+       operator]
+      [ui/flat-button {:label (tr [:buttons :edit])
+                       :style {:margin-top "1.5em"
+                               :font-size "8pt"}
+                       :icon (ic/content-create {:style {:width 16 :height 16}})
+                       :on-click #(do
+                                    (.preventDefault %)
+                                    (e! (fp/->ChangePage :transport-operator nil)))}]])])
 
 (defn- operator-form-groups []
   [(form/group
@@ -62,25 +98,16 @@
                                :disabled (form/disable-save? data)}
                  (tr [:buttons :save])])})
 
-(defn operator [e! state]
+(defn operator [e! {operator :transport-operator :as state}]
   (r/with-let [form-options (operator-form-options e!)
                form-groups (operator-form-groups)]
     [:div
      [:div.row
       [:div  {:class "col-xs-12"}
-       [:h1 (tr [:organization-page :organization-form-title])]]]
-     (when (second (:transport-operators-with-services state))
-       [:div.row
-        [:div  {:class "col-xs-12"}
-         [form-fields/field
-          {:label (tr [:field-labels :select-transport-operator])
-           :name        :select-transport-operator
-           :type        :selection
-           :show-option ::t-operator/name
-           :update!   #(e! (to/->SelectOperator %))
-           :options     (map :transport-operator (:transport-operators-with-services state))
-           :auto-width? true}
-          (get state :transport-operator)]]])
+       [:h1 (tr [:organization-page
+                 (if (:new? operator)
+                   :organization-new-title
+                   :organization-form-title)])]]]
 
      [:div.row.organization-info
 


### PR DESCRIPTION
Change the CKAN dashboard (remove my services as OTE has a better view for it). Create organizations in OTE (via CKAN API). This removes the need to have 2 different forms for creating an org.

**Hide pictures from org list**

**Buttons for adding new transport operator**

**Create CKAN org**

**Event for creating a transport operator**

**Add helper for two column table**

**Support special :divider option in select list**

**Force postal code to be valid with regex**

**Remove org edit from user menu**

**Refactor front page operator selection**

**Add authorization check editing transport operator**

**Remove image from transport operator**

**Set services changed flag immediately**
When returning from creating without saving, this makes sure no stale
operator data is in app state

**Remove add organization link**