### PR TITLE
Tyylimuutoksia lomakkeen info-teksteihin

### DIFF
--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -71,10 +71,8 @@
           :margin-left "0.2em"}))
 
 (def help (merge (flex-container "row")
-                 {:border-radius "0.5em"
-                  :border "solid 1px #c4c4c4"
-                  :color "#434343"
-                  :background-color "#DAEDF7"
+                 {:border-bottom "1px solid #dddddd"
+                  :color "#666666"
                   :padding "0.2em"
                   :margin "0.2em"
                   :align-items "center"

--- a/ote/src/cljs/ote/style/form.cljs
+++ b/ote/src/cljs/ote/style/form.cljs
@@ -34,7 +34,9 @@
 
 (def border-color "#C4C4C4")
 (def border-right {:border-right (str "solid 2px " border-color)
-                   :box-sizing "border-box"})
+                   :box-sizing "border-box"
+                   :padding-right "20px"
+                   :margin-right "20px"})
 
 (def help-icon-element {:padding "0px 0px 0px 10px"})
 (def help-text-element {:padding "5px 5px 5px 10px"})

--- a/ote/src/cljs/ote/ui/common.cljs
+++ b/ote/src/cljs/ote/ui/common.cljs
@@ -25,7 +25,6 @@
 
 (defn help [help]
   [:div.help (stylefy/use-style style-base/help)
-   [:div (stylefy/use-style style-form/help-icon-element) [ic/action-info-outline]]
    [:div (stylefy/use-style style-form/help-text-element) help]])
 
 (defn table2 [& items]

--- a/ote/src/cljs/ote/views/passenger_transportation.cljs
+++ b/ote/src/cljs/ote/views/passenger_transportation.cljs
@@ -103,24 +103,24 @@
     :type :localized-text
     :rows 1
     :full-width? true
-    :container-class "col-md-5"}
+    :container-class "col-md-6"}
 
    {:name ::t-service/limited-accessibility-description
     :type :localized-text
     :rows 1
-    :container-class "col-md-6"
+    :container-class "col-md-5"
     :full-width? true}
 
    {:name ::t-service/accessibility-info-url
     :type :string
-    :container-class "col-md-5"
+    :container-class "col-md-6"
     :full-width? true}
 
    {:name        ::t-service/additional-services
     :type        :multiselect-selection
     :show-option (tr-key [:enums ::t-service/additional-services])
     :options     t-service/additional-services
-    :container-class "col-md-6"
+    :container-class "col-md-5"
     :full-width? true}
    ))
 


### PR DESCRIPTION
Remove borders and background colors and icons from into texts.
Set padding and margin to right-border on accessibility section