### PR TITLE
153848260 Bug: unable to edit previously saved time

### DIFF
--- a/ote/src/cljc/ote/time.cljc
+++ b/ote/src/cljc/ote/time.cljc
@@ -50,7 +50,7 @@
    "%02d:%02d:%02d" hours minutes seconds))
 
 (defn format-time [{:keys [hours minutes seconds] :as time}]
-  (if seconds
+  (if (and seconds (not= 0 seconds))
     (format-time-full time)
     (#?(:clj format
         :cljs gstr/format)


### PR DESCRIPTION
**Don't format 0 seconds**
Time input field doesn't allow seconds (regex validation). Omit
seconds if they are zero.