### PR TITLE
[WIP] 153864234 - Add HH:MM validation rule for :time-fields.

### DIFF
--- a/ote/src/cljs/ote/ui/validation.cljs
+++ b/ote/src/cljs/ote/ui/validation.cljs
@@ -95,6 +95,12 @@
                    (year-month-and-day comparison-date)))
     (or message (str "Date must " (fmt/pvm comparison-date)))))
 
+;; Valid time HH:MM
+(defmethod validate-rule :time [_ _ data _ _ & [message]]
+  (when
+    (and (not (empty-value? data)) (not (re-matches #"^(0[0-9]|1[0-9]|2[0-3])(:[0-5][0-9])?$" data)))
+    (or message "Invalid time format")))
+
 (defmethod validate-rule :number-range [_ _ data _ _ & [min-value max-value message]]
   (when-not (<= min-value data max-value)
     (or message (str "Number must be between " min-value " and " max-value))))


### PR DESCRIPTION
Work in progress:
All that is left to be done, is to use this validation rule for :time-type form fields and translate the validation error message to sv and en.

----

The validation regex supports time strings in format HH(:MM), that is 00-23(:00-59). The :MM part is optional.
Our 24h-mode is a special case, and should bypass the regex validation if the "24h"-checkbox is pressed.