### PR TITLE
154021861 front page info box

### DIFF
--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/fanstatic/napote_theme.css
@@ -805,6 +805,31 @@ nav.section.navigation.section-right > form {
     height: 100%;
 }
 
+.notification-box {
+    margin-top: 5px;
+    padding: 5px 5px 5px 20px;
+    color: white;
+    background: #ff9900;
+    background: linear-gradient(to bottom, #ff9900 10%, #e68a00 100%);
+}
+
+.notification-box a {
+    color: #fff;
+}
+
+.notification-box a:hover {
+    text-decoration: underline;
+}
+
+.notification-box p {
+    overflow: hidden;
+}
+
+.notification-box .icon {
+    font-size: 32px;
+    padding: 10px 0px 10px 0px;
+}
+
 /** HEADER **/
 
 .masthead .section-right {

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/header.html
@@ -95,7 +95,7 @@
                                                     {% set new_activities = h.new_activities() %}
                                                     <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
                                                         {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities) %}
-                                                        <a href="{{ h.url_for(controller='user', action='dashboard_datasets') }}"
+                                                        <a href="{{ h.url_for(controller='user', action='dashboard') }}"
                                                            title="{{ notifications_tooltip }}">
                                                             <span class="text">{{ _('Dashboard') }}</span>
                                                             <span class="badge">{{ new_activities }}</span>

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
@@ -1,3 +1,4 @@
+{% set intro_list = g.site_intro_text %}
 <div role="main" class="hero">
     <div class="container">
         <script type="text/javascript">
@@ -18,8 +19,23 @@
                     <p style="margin: 10px;">Lisätietoa NAP-palvelukatalogin taustoista saat osoitteesta <a href="http://www.liikennevirasto.fi/nap">www.liikennevirasto.fi/nap </a></p>
                 </div>
             </div>
-
         {% if c.userobj %}
+
+            {% if intro_list %}
+                {% set splitted_list = intro_list.split('--') %}
+                {% for intro in splitted_list: %}
+                <div style="background-color: orange; padding: 10px; margin-top: 5px; color: white;">
+                    <div class="row">
+                        <div class="span1" style="">
+                            <i class="fa fa-info-circle" style="font-size: 32px; padding: 10px 0px 10px 0px;"></i>
+                        </div>
+                        <div class="span10">
+                            {{ h.render_markdown(intro) }}
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            {% endif %}
             <div class="row row1 module">
                 <div class="span12">
                     <p><b>{% trans user=c.userobj.display_name %}User greeting {{ user }}{% endtrans %}!</b></p>

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/layout1.html
@@ -24,10 +24,10 @@
             {% if intro_list %}
                 {% set splitted_list = intro_list.split('--') %}
                 {% for intro in splitted_list: %}
-                <div style="background-color: orange; padding: 10px; margin-top: 5px; color: white;">
+                <div class="notification-box">
                     <div class="row">
                         <div class="span1" style="">
-                            <i class="fa fa-info-circle" style="font-size: 32px; padding: 10px 0px 10px 0px;"></i>
+                            <i class="icon fa fa-info-circle"></i>
                         </div>
                         <div class="span10">
                             {{ h.render_markdown(intro) }}

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/snippets/promoted.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/home/snippets/promoted.html
@@ -1,9 +1,5 @@
-{% set intro = g.site_intro_text %}
-
 <div>
-    {% if intro %}
-        {{ h.render_markdown(intro) }}
-    {% else %}
+
         {% if c.userobj %}
             {# Note: Use trans-tag to allow rendering of HTML tags in the translation string. #}
             <p>{% trans %}NAP home page publishing services info text{% endtrans %}</p>
@@ -13,5 +9,5 @@
 
         {# Note: Use trans-tag to allow rendering of HTML tags in the translation string. #}
         <p>{% trans %}NAP home page info text{% endtrans %}</p>
-    {% endif %}
+
 </div>

--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/user/dashboard.html
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/user/dashboard.html
@@ -6,7 +6,6 @@
         {% link_for _('Edit settings'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}
     </div>
     <ul class="nav nav-tabs">
-        {{ h.build_nav_icon('user_dashboard_datasets', _('My Datasets')) }}
         {{ h.build_nav_icon('user_dashboard_organizations', _('My Organizations')) }}
         {{ h.build_nav_icon('user_dashboard', _('News feed')) }}
     </ul>


### PR DESCRIPTION
From page: /ckan-admin/config
Split messages using "--"

Add 

```
###Palveluiden poisto on korjattu. 
Voit poistaa palvelusi Omat palvelutiedot -sivulta normaalisti.
Täältä -> http://localhost:8080/ote/#/
--
### CSV tuki
Välityspalveluille on lisätty mahdollisuus antaa ulkoinen rajapinta .csv tiedostoon, jossa välityspalvelu voi listata kaikki yritykset, joiden palveluita välittää.
--
Kolmas info
```

To info text textarea to see how this works
  