### PR TITLE
Use . instead of + in base64 alphabet

### DIFF
--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -16,7 +16,9 @@
 (defn base64->hex
   "Convert base64 encoded string to hex"
   [base64]
-  (let [bytes (.decode (Base64/getDecoder) base64)]
+  (let [bytes (.decode (Base64/getDecoder)
+                       ;; Passlib uses unconventional \. character instead of \+ in base64
+                       (str/replace base64 #"\." "+"))]
     (str/join (map #(format "%02x" %) bytes))))
 
 (defn passlib->buddy

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -160,11 +160,11 @@
                   (if desktop? style-topnav/desktop-link style-topnav/link))
                 {:style {:float "right"}})]]
        [:li
-        [linkify "/user/login" (tr [:common-texts :navigation-login])
+        [linkify "#" (tr [:common-texts :navigation-login])
          (merge (stylefy/use-style
                   (if desktop? style-topnav/desktop-link style-topnav/link))
                 {:style {:float "right"}}
-                #_{:on-click #(do
+                {:on-click #(do
                               (.preventDefault %)
                               (e! (login/->ShowLoginDialog)))})]]])
 


### PR DESCRIPTION
**Use . instead of + in base64 alphabet**