### PR TITLE
Save and load service hours info for rentals.

### DIFF
--- a/database/src/main/resources/db/migration/V1_49__rental_service_hours_info.sql
+++ b/database/src/main/resources/db/migration/V1_49__rental_service_hours_info.sql
@@ -1,0 +1,5 @@
+ALTER TYPE rental_provider_information
+ DROP ATTRIBUTE "service-hours-info";
+
+ALTER TYPE pick_up_location
+  ADD ATTRIBUTE "service-hours-info" localized_text[];

--- a/ote/src/cljs/ote/app/controller/transport_service.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_service.cljs
@@ -105,6 +105,9 @@
                             (if-let [exceptions (::t-service/service-exceptions hours-and-exceptions)]
                               (assoc loc ::t-service/service-exceptions exceptions)
                               loc)
+                            (if-let [info (::t-service/service-hours-info hours-and-exceptions)]
+                              (assoc loc ::t-service/service-hours-info info)
+                              loc)
                             (dissoc loc ::t-service/service-hours-and-exceptions)))
                         pick-up-locations)))
       (update-in [::t-service/rentals ::t-service/vehicle-classes]
@@ -130,11 +133,13 @@
                  (fn [pick-up-locations]
                    (mapv (fn [{hours ::t-service/service-hours
                                exceptions ::t-service/service-exceptions
+                               info ::t-service/service-hours-info
                                :as pick-up-location}]
                            (-> pick-up-location
                                (assoc ::t-service/service-hours-and-exceptions
                                       {::t-service/service-hours hours
-                                       ::t-service/service-exceptions exceptions})
+                                       ::t-service/service-exceptions exceptions
+                                       ::t-service/service-hours-info info})
                                (dissoc ::t-service/service-hours
                                        ::t-service/service-exceptions)))
                          pick-up-locations)))


### PR DESCRIPTION
# Fixed
- Rental pick-up location service hours info

# Datamodel
- Service hours info moved from rentals type to pick-up location type.