### PR TITLE
154919036 operation area search - replace with previous version

### DIFF
--- a/ote/src/cljs/ote/app/controller/place_search.cljs
+++ b/ote/src/cljs/ote/app/controller/place_search.cljs
@@ -42,7 +42,7 @@
 (defn- search [{{name :name :as place-search} :place-search :as app}]
   (when-let [timeout (:timeout place-search)]
     (.clearTimeout js/window timeout))
-  (if (> (count name) 2)
+  (if (>= (count name) 2)
     (let [on-success (tuck/send-async! ->PlaceCompletionsResponse name)]
       (assoc-in
        app [:place-search :timeout]

--- a/ote/src/cljs/ote/views/place_search.cljs
+++ b/ote/src/cljs/ote/views/place_search.cljs
@@ -135,14 +135,13 @@
                 (second (get-in coordinate  [:coordinates  :coordinates]))]}]])
 
 (defn- completions [completions]
-  (let [sorted-completions  (sort-by ::places/namefin completions)]
   (apply array
          (map (fn [{::places/keys [id namefin type]}]
                 #js {:text namefin
                      :id id
                      :value (r/as-element
                              [ui/menu-item {:primary-text namefin}])})
-              sorted-completions))))
+              completions)))
 
 (defn place-search [e! place-search]
   (let [results (:results place-search)]


### PR DESCRIPTION
# Fixed
 - Change 3 char limit to 2 char in operation area search
 - Remove alphabetical ordering and return previous version of ordering results