### PR TITLE
Improve radiator dashboard

### DIFF
--- a/tools/dashboard/project.clj
+++ b/tools/dashboard/project.clj
@@ -4,6 +4,7 @@
                  [http-kit "2.2.0"]
                  [compojure "1.6.0"]
                  [cheshire "5.8.0"]
+                 [amazonica "0.3.118"]
 
                  [reagent "0.8.0-alpha2"]
                  [figwheel "0.5.13"]
@@ -12,6 +13,10 @@
                   :exclusions [org.apache.httpcomponents/httpasyncclient]]
                  [com.cognitect/transit-clj "0.8.300"]
                  [com.cognitect/transit-cljs "0.8.243"]]
+
+  :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.13"]
+                                  [com.cemerick/piggieback "0.2.2"]
+                                  [org.clojure/tools.nrepl "0.2.12"]]}}
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-figwheel "0.5.13"]]

--- a/tools/dashboard/src/clj/dashboard/data/cloudwatch.clj
+++ b/tools/dashboard/src/clj/dashboard/data/cloudwatch.clj
@@ -1,0 +1,23 @@
+(ns dashboard.data.cloudwatch
+  (:require [amazonica.aws.cloudwatch :as cloudwatch]))
+
+(defn last-five-minutes []
+  {:start-time (java.util.Date. (- (System/currentTimeMillis)
+                                   (* 1000 60 5)))
+   :end-time (java.util.Date.)
+   :period 300})
+
+(defn fetch-metric
+  "Fetch last five minutes' min/max/avg of given metric"
+  [namespace metric-name dimensions]
+  (cloudwatch/get-metric-statistics (merge (last-five-minutes)
+                                           {:statistics ["Average" "Minimum" "Maximum"]
+                                            :namespace namespace
+                                            :metric-name metric-name
+                                            :dimensions dimensions})))
+
+(defn finap-db-load []
+  (-> (fetch-metric "AWS/RDS"
+                    "CPUUtilization"
+                    [{:name "DBInstanceIdentifier" :value "napote-db-prod"}])
+      :datapoints first (select-keys #{:minimum :maximum :average})))

--- a/tools/dashboard/src/clj/dashboard/main.clj
+++ b/tools/dashboard/src/clj/dashboard/main.clj
@@ -5,7 +5,8 @@
             [cognitect.transit :as t]
 
             [dashboard.data.finap-services :as data-finap-services]
-            [dashboard.data.jenkins :as data-jenkins])
+            [dashboard.data.jenkins :as data-jenkins]
+            [dashboard.data.cloudwatch :as data-cloudwatch])
   (:import (java.util.concurrent Executors TimeUnit))
   (:gen-class))
 
@@ -31,7 +32,9 @@
 (def tasks [{:interval 900 :key :published-services
              :task #'data-finap-services/fetch-published-service-count}
             {:interval 10 :key :jenkins
-             :task #'data-jenkins/jobs}])
+             :task #'data-jenkins/jobs}
+            {:interval 60 :key :db-load
+             :task #'data-cloudwatch/finap-db-load}])
 
 (defn start-tasks []
   (doseq [{:keys [interval key task]} tasks]

--- a/tools/dashboard/src/cljs/dashboard/ui.cljs
+++ b/tools/dashboard/src/cljs/dashboard/ui.cljs
@@ -1,0 +1,32 @@
+(ns dashboard.ui)
+
+(defn polar->cartesian [cx cy radius angle-deg]
+  (let [rad (/ (* js/Math.PI (- angle-deg 90)) 180.0)]
+    [(+ cx (* radius (js/Math.cos rad)))
+     (+ cy (* radius (js/Math.sin rad)))]))
+
+
+(defn arc [cx cy r db de color width]
+  (let [[ax ay] (polar->cartesian cx cy r db)
+        [lx ly] (polar->cartesian cx cy r de)
+        large? (if (< (- de db) 180) 0 1)
+        dir? 1]
+    [:path {:d (str "M " ax " " ay " "
+                    "A" r " " r " 0 " large? " " dir? " " lx " " ly)
+            :fill "none"
+            :stroke color
+            :stroke-width width}]))
+
+
+(defn gauge [percentage]
+  (let [angle (- (* 180.0 (/ percentage 100.0)) 90)
+        cx 50
+        cy 50
+        r 40]
+    [:svg {:width 100 :height 80}
+     [arc cx cy r -90 90 "lightGray" 10]
+     [arc cx cy r -90 angle "red" 5]
+     (let [[x y] (polar->cartesian cx cy (- r 5) angle)]
+       [:line {:x1 cx :y1 cy :x2 x :y2 y :style {:stroke "black" :stroke-width 2}}])
+     [:text {:text-anchor "middle" :x cx :y (+ cy 20) :style {:font-size 20}}
+      (str (.toFixed percentage 1) "%")]]))

--- a/tools/dashboard/src/cljs/dashboard/ui.cljs
+++ b/tools/dashboard/src/cljs/dashboard/ui.cljs
@@ -22,11 +22,11 @@
   (let [angle (- (* 180.0 (/ percentage 100.0)) 90)
         cx 50
         cy 50
-        r 40]
+        r 40
+        [needle-x needle-y] (polar->cartesian cx cy (- r 5) angle)]
     [:svg {:width 100 :height 80}
      [arc cx cy r -90 90 "lightGray" 10]
      [arc cx cy r -90 angle "red" 5]
-     (let [[x y] (polar->cartesian cx cy (- r 5) angle)]
-       [:line {:x1 cx :y1 cy :x2 x :y2 y :style {:stroke "black" :stroke-width 2}}])
+     [:line {:x1 cx :y1 cy :x2 needle-x :y2 needle-y :style {:stroke "black" :stroke-width 2}}]
      [:text {:text-anchor "middle" :x cx :y (+ cy 20) :style {:font-size 20}}
       (str (.toFixed percentage 1) "%")]]))

--- a/tools/dashboard/src/cljs/dashboard/view.cljs
+++ b/tools/dashboard/src/cljs/dashboard/view.cljs
@@ -31,7 +31,20 @@
    [:div.highlight {:style {:font-size "250%"}}
     service-count]])
 
+(defn load-percentage [label {:keys [minimum maximum average]}]
+  [:div.load-percentage {:style (merge radiator-item-style
+                                       {:height 75 :width 150 :text-align "center"})}
+   [:div [:b label] " (5 min)"]
+   (when average
+     [:div {:style {:font-size "200%"}}  (str (.toFixed average 1) "%")])
+   [:div {:style {:font-size "85%"}}
+    (when minimum
+      [:span "MIN: " (str (.toFixed minimum 1) "%")])
+    " / "
+    (when maximum
+      [:span "MAX: " (str (.toFixed maximum 1) "%")])]])
 (defn dashboard-view [e! app]
   [:div.dashboard {:style {:display "flex" :flex-direction "row"}}
    [jenkins-jobs (:jenkins app)]
-   [published-services (:published-services app)]])
+   [published-services (:published-services app)]
+   [load-percentage "DB Load" (:db-load app)]])

--- a/tools/dashboard/src/cljs/dashboard/view.cljs
+++ b/tools/dashboard/src/cljs/dashboard/view.cljs
@@ -1,4 +1,5 @@
-(ns dashboard.view)
+(ns dashboard.view
+  (:require [dashboard.ui :as ui]))
 
 (def radiator-item-style
   {:border "solid 1px black"
@@ -33,16 +34,19 @@
 
 (defn load-percentage [label {:keys [minimum maximum average]}]
   [:div.load-percentage {:style (merge radiator-item-style
-                                       {:height 75 :width 150 :text-align "center"})}
+                                       {:height 115 :width 150 :text-align "center"})}
    [:div [:b label] " (5 min)"]
+
    (when average
-     [:div {:style {:font-size "200%"}}  (str (.toFixed average 1) "%")])
+     [:div
+      [ui/gauge average]])
    [:div {:style {:font-size "85%"}}
     (when minimum
       [:span "MIN: " (str (.toFixed minimum 1) "%")])
     " / "
     (when maximum
       [:span "MAX: " (str (.toFixed maximum 1) "%")])]])
+
 (defn dashboard-view [e! app]
   [:div.dashboard {:style {:display "flex" :flex-direction "row"}}
    [jenkins-jobs (:jenkins app)]


### PR DESCRIPTION
Add cloudwatch metrics for DB load (CPU utilization). Shows 5min avg/max/min in dashboard widget.