### PR TITLE
155181346 Run goog.require cal only in dev mode

### DIFF
--- a/ote/src/clj/ote/services/index.clj
+++ b/ote/src/clj/ote/services/index.clj
@@ -91,7 +91,8 @@
       (when dev-mode?
         [:script {:src "js/out/goog/base.js" :type "text/javascript"}])
       [:script {:src (ote-js-location dev-mode?) :type "text/javascript"}]
-      [:script {:type "text/javascript"} "goog.require('ote.main');"]]]))
+      (when dev-mode?
+        [:script {:type "text/javascript"} "goog.require('ote.main');"])]]))
 
 (defn index [dev-mode?]
   {:status 200


### PR DESCRIPTION
# Fixed
- Fix `goog.require` JS console error on startup