### PR TITLE
155214317 Use generic help box for external interfaces help bo

### DIFF
--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -90,6 +90,13 @@
            :align-items "center"
            :white-space "pre-wrap"})
 
+;; Full width generic help box
+(def generic-help (merge help
+                         {:background-color "#F5F5F5" :padding "15px"
+                          :margin-left "-15px"
+                          :margin-right "-15px"
+                          :margin-top "-15px"}))
+
 (def filters-form
   {:border "solid 1px #0046ad"})
 

--- a/ote/src/cljs/ote/style/form.cljs
+++ b/ote/src/cljs/ote/style/form.cljs
@@ -20,13 +20,13 @@
 (def form-group-container {:padding-bottom "1em"})
 
 (def form-card {:background-color "#fff"
-                      :box-shadow "rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px"})
+                :box-shadow "rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px"})
 
 (def form-card-label {:padding "15px 15px"
-                       :font-size "1.125em"
-                       :font-weight "bold"
-                       :color "#fff"
-                       :background-color "#00A9DF"})
+                      :font-size "1.125em"
+                      :font-weight "bold"
+                      :color "#fff"
+                      :background-color "#00A9DF"})
 
 (def form-card-body {:padding "15px 15px"
                      :font-size "1em"

--- a/ote/src/cljs/ote/ui/common.cljs
+++ b/ote/src/cljs/ote/ui/common.cljs
@@ -59,6 +59,11 @@
        :on-request-close #(reset! open? false)}
       body]]))
 
+;; Full width gray generic help box
+(defn generic-help [help]
+  [:div.help (stylefy/use-style style-base/generic-help)
+   [:div (stylefy/use-style style-form/help-text-element) help]])
+
 (defn help [help]
   [:div.help (stylefy/use-style style-base/help)
    [:div (stylefy/use-style style-form/help-text-element) help]])

--- a/ote/src/cljs/ote/ui/form.cljs
+++ b/ote/src/cljs/ote/ui/form.cljs
@@ -18,12 +18,16 @@
 
 (defn info
   "Create a new info form element that doesn't have any interaction, just shows a help text."
-  [text]
-  {:name (keyword (str "info" (swap! keyword-counter inc)))
-   :type :component
-   :container-style style-form/full-width
-   :component (fn [_]
-                [common/help text])})
+  [text & [options]]
+  (let [type (:type options)]
+    {:name (keyword (str "info" (swap! keyword-counter inc)))
+     :type :component
+     :container-style style-form/full-width
+     :component (fn [_]
+                  [(if (= :generic type)
+                     common/generic-help
+                     common/help)
+                   text])}))
 
 (defn info-with-link
   "Create a new info form element that doesn't have any interaction, just shows a help text."

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -556,11 +556,12 @@
 
 (defmethod field :checkbox [{:keys [update! table? label warning error style extended-help]} checked?]
   (if extended-help
-    [common/extended-help
-     (:help-text extended-help)
-     (:help-link-text extended-help)
-     (:help-link extended-help)
-     (checkbox-container update! table? label warning error style checked?)]
+    [:div {:style {:margin-right (str "-" (:margin-right style-form/form-field))}}
+     [common/extended-help
+      (:help-text extended-help)
+      (:help-link-text extended-help)
+      (:help-link extended-help)
+      (checkbox-container update! table? label warning error style checked?)]]
     (checkbox-container update! table? label warning error style checked?)))
 
 (defmethod field :checkbox-group [{:keys [update! table? label show-option options help]} data]

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -91,7 +91,8 @@
            (tr [:form-help :external-interfaces-read-more :dialog-text])]]
          (when (= :passenger-transportation type)
            [:div {:style {:margin-top "20px"}}
-            [:b (tr [:form-help :external-interfaces-payment-systems])]])])
+            [:b (tr [:form-help :external-interfaces-payment-systems])]])]
+        {:type :generic})
 
       {:name ::t-service/external-interfaces
        :type :table


### PR DESCRIPTION
# Added
* Add a new gray "generic help box" for external interfaces. This will replace gradually the blue help boxes.

# Fixed
* Fixed a margin-right problem with brokerage form group check box help text.