### PR TITLE
154956543 User info not visible if no operators

### DIFF
--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -106,11 +106,14 @@
   (let [operators (keep #(get-transport-operator db {::t-operator/ckan-group-id (:id %)}) groups)
         operator-ids (into #{} (map ::t-operator/id) operators)
         operator-services (get-transport-services db {::t-service/transport-operator-id (op/in operator-ids)})]
-    (map (fn [{id ::t-operator/id :as operator}]
-           {:transport-operator       operator
-            :transport-service-vector (vec (filter #(= id (::t-service/transport-operator-id %)) operator-services))
-            :user                     (dissoc user :apikey :email :id)})
-    operators)))
+    {:user (dissoc user :apikey :email :id)
+     :transport-operators
+     (map (fn [{id ::t-operator/id :as operator}]
+            {:transport-operator operator
+             :transport-service-vector (into []
+                                             (filter #(= id (::t-service/transport-operator-id %)))
+                                             operator-services)})
+          operators)}))
 
 (defn get-transport-operator-data [db {:keys [title id] :as ckan-group} user]
   (let [transport-operator (get-transport-operator db {::t-operator/ckan-group-id (:id ckan-group)})

--- a/ote/src/cljs/ote/app/controller/login.cljs
+++ b/ote/src/cljs/ote/app/controller/login.cljs
@@ -14,12 +14,12 @@
 
 (defn update-transport-operator-data
   [{:keys [page ckan-organization-id transport-operator] :as app}
-   response]
+   {:keys [user transport-operators] :as response}]
 
   (let [app (assoc app
                    :transport-operator-data-loaded? true
-                   :user (:user (first response)))]
-    (if (and (nil? (:transport-operator (first response)))
+                   :user user)]
+    (if (and (empty? transport-operators)
              (not= :services page))
       ;; If page is :transport-operator and user has no operators, start creating a new one
       (do
@@ -38,11 +38,11 @@
                                                   (= ckan-organization-id
                                                      (get-in % [:transport-operator ::t-operator/ckan-group-id])))
                                           %)
-                                       response)
-                                 (first response))]
+                                       transport-operators)
+                                 (first transport-operators))]
 
           (assoc app
-                 :transport-operators-with-services response
+                 :transport-operators-with-services transport-operators
                  :transport-operator (:transport-operator selected-operator)
                  :transport-service-vector (:transport-service-vector selected-operator))))))
 


### PR DESCRIPTION
# Fixed
- User menu is now visible even if the user has no associated transport operators