### PR TITLE
154560658 Service catalog operation area search field changes

### DIFF
--- a/database/src/main/resources/db/migration/V1_66__operation_area_search_postal_codes_etc.sql
+++ b/database/src/main/resources/db/migration/V1_66__operation_area_search_postal_codes_etc.sql
@@ -1,0 +1,41 @@
+-- update existing triggers and operation-area-facet.
+
+-- delete all from operation-area-facet table
+DELETE FROM "operation-area-facet";
+
+-- insert initial data to facet. Use all areas matching rows in places-view.
+INSERT
+INTO "operation-area-facet"
+("transport-service-id", "operation-area")
+  SELECT t.id, LOWER(oad.text)
+  FROM operation_area oa
+    JOIN "transport-service" t ON oa."transport-service-id" = t.id
+    JOIN LATERAL unnest(oa.description) AS oad ON TRUE
+  WHERE t."published?" = true
+        AND oad.text IN (SELECT p.namefin FROM "places" p);
+
+
+-- Create trigger function to update facet when service changes
+CREATE OR REPLACE FUNCTION transport_service_operation_area_array () RETURNS TRIGGER AS $$
+BEGIN
+
+  -- Delete all previous entries for this service
+  DELETE
+  FROM "operation-area-facet"
+  WHERE "transport-service-id" = NEW.id;
+
+  IF NEW."published?" = TRUE THEN
+    -- Insert new values (for published only)
+    INSERT
+    INTO "operation-area-facet"
+    ("transport-service-id", "operation-area")
+      SELECT NEW.id, LOWER(oad.text)
+      FROM operation_area oa
+        JOIN LATERAL unnest(oa.description) AS oad ON TRUE
+      WHERE oa."transport-service-id" = NEW.id
+            AND oad.text IN (SELECT p.namefin FROM "places" p);
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -274,7 +274,7 @@
 (defmethod field :chip-input [{:keys [update! label name error warning regex on-blur
                                       max-length style hint-style
                                       filter suggestions suggestions-config default-values max-results
-                                      open-on-focus? clear-on-blur?
+                                      auto-select? open-on-focus? clear-on-blur?
                                       allow-duplicates? add-on-blur? new-chip-key-codes
                                       form? table? full-width? full-width-input? disabled?] :as field}
                               data]
@@ -303,6 +303,7 @@
         :max-search-results (or max-results 10)
         :open-on-focus open-on-focus?
         :clear-on-blur clear-on-blur?
+        :auto-select? auto-select?
 
         ;; == Chip options ==
         :allow-duplicates allow-duplicates?

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -276,8 +276,7 @@
                                       filter suggestions suggestions-config default-values max-results
                                       open-on-focus? clear-on-blur?
                                       allow-duplicates? add-on-blur? new-chip-key-codes
-                                      form? table? full-width? full-width-input? disabled?]
-                               :or {open-on-focus? true, clear-on-blur? true, full-width-input? true} :as field}
+                                      form? table? full-width? full-width-input? disabled?] :as field}
                               data]
 
   (let [chips (set (or data #{}))

--- a/ote/src/cljs/ote/ui/mui_chip_input.cljs
+++ b/ote/src/cljs/ote/ui/mui_chip_input.cljs
@@ -3,6 +3,8 @@
             [cljs-react-material-ui.reagent :as ui]
             [reagent.core :as r]))
 
+;; FIXME: Chips are always placed above input field in form group. Suspecting that flexbox set in the form-group is affecting this somehow.
+;;        Correct behaviour is: place chips inside the input field until there is no horizontal space left, after that create a new line.
 (def chip-input
   (let [component (r/adapt-react-class (aget js/window "MaterialUIChipInput"))
         default-props {:floating-label-fixed true
@@ -20,7 +22,7 @@
 
                        ;; == Styling ==
                        :full-width false
-                       :full-width-input true
+                       :full-width-input false
                        ; Modify original style
                        ; FIXME: For some reason, the text input underline is misplaced compared to other original mui-textfields.
                        ;        This change fixes those problems, in combination with conditional chipContainerStyle change.

--- a/ote/src/cljs/ote/ui/mui_chip_input.cljs
+++ b/ote/src/cljs/ote/ui/mui_chip_input.cljs
@@ -1,5 +1,35 @@
 (ns ote.ui.mui-chip-input
   (:require material-ui-chip-input
+            [cljs-react-material-ui.reagent :as ui]
             [reagent.core :as r]))
 
-(def chip-input (r/adapt-react-class (aget js/window "MaterialUIChipInput")))
+(def chip-input
+  (let [component (r/adapt-react-class (aget js/window "MaterialUIChipInput"))
+        default-props {:floating-label-fixed true
+
+                       ;; == Autocomplete options ==
+                       :filter (or filter (aget js/MaterialUI "AutoComplete" "caseInsensitiveFilter"))
+                       :max-search-results 10
+                       :open-on-focus true
+                       :clear-on-blur true
+
+                       ;; == Chip options ==
+                       :allow-duplicates false
+                       ; Vector of key-codes for triggering new chip creation, 13 => enter, 32 => space
+                       :new-chip-key-codes [13]
+
+                       ;; == Styling ==
+                       :full-width false
+                       :full-width-input true
+                       ; Modify original style
+                       ; FIXME: For some reason, the text input underline is misplaced compared to other original mui-textfields.
+                       ;        This change fixes those problems, in combination with conditional chipContainerStyle change.
+                       :inputStyle {:margin-top 12
+                                    :margin-bottom 14}}]
+    (fn [props] [component (r/merge-props
+                             (merge
+                               default-props
+                               ; Remove margin if there are no chips (works only in "controlled" case i.e. :value prop is used).
+                               (when (empty? (:value props))
+                                 {:chipContainerStyle {:margin-top 0}}))
+                             props)])))

--- a/ote/src/cljs/ote/ui/mui_chip_input.cljs
+++ b/ote/src/cljs/ote/ui/mui_chip_input.cljs
@@ -3,35 +3,65 @@
             [cljs-react-material-ui.reagent :as ui]
             [reagent.core :as r]))
 
+;; TODO: Todo implement custom cljs version of mui chip-input component mirroring the amazing features of the component.
+
 ;; FIXME: Chips are always placed above input field in form group. Suspecting that flexbox set in the form-group is affecting this somehow.
 ;;        Correct behaviour is: place chips inside the input field until there is no horizontal space left, after that create a new line.
-(def chip-input
-  (let [component (r/adapt-react-class (aget js/window "MaterialUIChipInput"))
-        default-props {:floating-label-fixed true
+(def default-props {:ref "chip-input"
+                    :floating-label-fixed true
 
-                       ;; == Autocomplete options ==
-                       :filter (or filter (aget js/MaterialUI "AutoComplete" "caseInsensitiveFilter"))
-                       :max-search-results 10
-                       :open-on-focus true
-                       :clear-on-blur true
+                    ;; == Autocomplete options ==
+                    :filter (or filter (aget js/MaterialUI "AutoComplete" "caseInsensitiveFilter"))
+                    :max-search-results 10
+                    :open-on-focus true
+                    :clear-on-blur true
 
-                       ;; == Chip options ==
-                       :allow-duplicates false
-                       ; Vector of key-codes for triggering new chip creation, 13 => enter, 32 => space
-                       :new-chip-key-codes [13]
+                    ;; == Chip options ==
+                    :allow-duplicates false
+                    ; Vector of key-codes for triggering new chip creation, 13 => enter, 32 => space
+                    :new-chip-key-codes [13]
 
-                       ;; == Styling ==
-                       :full-width false
-                       :full-width-input false
-                       ; Modify original style
-                       ; FIXME: For some reason, the text input underline is misplaced compared to other original mui-textfields.
-                       ;        This change fixes those problems, in combination with conditional chipContainerStyle change.
-                       :inputStyle {:margin-top 12
-                                    :margin-bottom 14}}]
-    (fn [props] [component (r/merge-props
-                             (merge
-                               default-props
-                               ; Remove margin if there are no chips (works only in "controlled" case i.e. :value prop is used).
-                               (when (empty? (:value props))
-                                 {:chipContainerStyle {:margin-top 0}}))
-                             props)])))
+                    ;; == Styling ==
+                    :full-width false
+                    :full-width-input false
+                    ; Modify original style
+                    ; For some reason, the text input underline is misplaced compared to other original mui-textfields.
+                    ;        This change fixes those problems, in combination with conditional chipContainerStyle change.
+                    :inputStyle {:margin-top 12
+                                 :margin-bottom 14}})
+
+(def chip-input* (r/adapt-react-class (aget js/window "MaterialUIChipInput")))
+
+(defn chip-input [props]
+  (let [ref (atom nil)
+        auto-select? (atom false)]
+    (r/create-class
+      {:component-did-mount
+       (fn [this]
+         (let [c (reset! ref (aget this "refs" "chip-input"))
+               handleAddChip* (aget c "handleAddChip")]
+           ;; Autoselect first matching suggestion if :auto-select prop is true after pressing :new-chip-key-code key.
+           ;; This will override the normal handleAddChip member function of chip-input with our custom function.
+           (aset @ref "handleAddChip"
+                 (fn [val]
+                   (if @auto-select?
+                     (let [autocomplete (aget @ref "autoComplete")
+                           ;; RequestLists contains filtered suggestions from AutoComplete
+                           requests (aget autocomplete "requestsList")
+                           chip (first requests)]
+                       ;; Call the original ChipInput.handleAddChip function
+                       (when chip (.call handleAddChip* c chip)))
+                     (.call handleAddChip* c val))))))
+
+       :reagent-render
+       (fn [props]
+         (reset! auto-select? (:auto-select? props))
+
+         [chip-input* (merge
+                        default-props
+                        ; Remove margin if there are no chips (works only in "controlled" case i.e. :value prop is used).
+                        (when (empty? (:value props))
+                          {:chipContainerStyle {:margin-top 0}})
+
+                        ;; Remove custom prop to prevent Reactunknown prop warning
+                        (dissoc props :auto-select?))])})))

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -244,7 +244,8 @@
           :max-results 10
           :suggestions-config {:text :text :value :text}
           :suggestions (::t-service/operation-area facets)
-          :new-chip-key-codes []                            ;; Prevent adding a custom value by disabling 'enter'
+          ;; Select first match from autocomplete filter result list after pressing enter
+          :auto-select? true
           :full-width? true}
 
          {:name ::t-service/sub-type

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -228,33 +228,36 @@
                  :name->label (tr-key [:service-search]
                                       [:field-labels :transport-service-common]
                                       [:field-labels :transport-service])}
-       [(form/group
-          {:label (tr [:service-search :filters-label])
-           :columns 3
-           :layout :row
-           :card-style style-base/filters-form}
+      [(form/group
+         {:label (tr [:service-search :filters-label])
+          :columns 3
+          :layout :row
+          :card-style style-base/filters-form}
 
          {:name :text-search
-         :type :string
-         :hint-text (tr [:service-search :text-search-placeholder])}
+          :type :string
+          :hint-text (tr [:service-search :text-search-placeholder])}
 
          {:name ::t-service/operation-area
-         :type :multiselect-selection
-         :show-option #(:text %)
-         :options (::t-service/operation-area facets)
-         :auto-width? true}
+          :type :chip-input
+          :open-on-focus? true
+          :max-results 10
+          :suggestions-config {:text :text :value :text}
+          :suggestions (::t-service/operation-area facets)
+          :new-chip-key-codes []                            ;; Prevent adding a custom value by disabling 'enter'
+          :full-width true}
 
          {:name ::t-service/sub-type
-         :type :multiselect-selection
-         :show-option #(str (sub-type (:sub-type %)))
-         :options (::t-service/sub-type facets)
-         :auto-width? true}
+          :type :multiselect-selection
+          :show-option #(str (sub-type (:sub-type %)))
+          :options (::t-service/sub-type facets)
+          :auto-width? true}
 
-         {:type      :component
-          :name      :operators
+         {:type :component
+          :name :operators
           :component (fn [{data :data}]
                        [:span [operator-search e! data]])})]
-         filters]]))
+      filters]]))
 
 (defn service-search [e! app]
   (e! (ss/->InitServiceSearch))

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -245,7 +245,7 @@
           :suggestions-config {:text :text :value :text}
           :suggestions (::t-service/operation-area facets)
           :new-chip-key-codes []                            ;; Prevent adding a custom value by disabling 'enter'
-          :full-width true}
+          :full-width? true}
 
          {:name ::t-service/sub-type
           :type :multiselect-selection


### PR DESCRIPTION
# Added
* Autocompleting chip-input field for opeartion area search in service catalog.
* A new feature for chip-input that makes typing autocomplete search terms  easier. If the feature is enabled, the first autocomplete suggestion is selected if pressing a key defined in :new-chip-key-codes vector. Enable the feature: [chip-input {:auto-select? true} ...]

# Datamodel
* Re-enabled all the area polygons for the operation area search facet, excluding the self-drawn polygons.