### PR TITLE
155533490 ulkoiset rajapinnat  osio muutoksia 26.2. läpikäynnin pohjalta

### DIFF
--- a/ote/resources/public/css/styles.css
+++ b/ote/resources/public/css/styles.css
@@ -32,10 +32,12 @@ h2 {
     font-size: 120%;
 }
 
-p {
-    line-height: 21px;
-    -webkit-margin-before: 0;
-    -webkit-margin-after: 0;
+
+/* Rendered translations are wrapped with <p> by Marked JS library.
+   Remove the margins of the first P-element */
+.translation-markdown > p{
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 #oteapp, .ote-sovellus {

--- a/ote/resources/public/css/styles.css
+++ b/ote/resources/public/css/styles.css
@@ -35,7 +35,7 @@ h2 {
 
 /* Rendered translations are wrapped with <p> by Marked JS library.
    Remove the margins of the first P-element */
-.translation-markdown > p{
+.translation-markdown > p {
     margin-top: 0;
     margin-bottom: 0;
 }

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -72,7 +72,7 @@
    :ote.db.transport-service/companies "Other companies providing the service"
    :ote.db.transport-service/company-name "Company name"
    :ote.db.transport-service/business-id "Company business ID"
-   :ote.db.transport-service/companies-csv-url "WWW-address to a .csv-file of the companies producing the service"
+   :ote.db.transport-service/companies-csv-url "WWW-address to a .csv-file of the companies providing the service"
    :ote.db.transport-service/license "License"
    :ote.db.transport-service/notice-external-interfaces? "I have read all the information labels and filled in information about machine-readable interfaces that contain essential data about my service."
    :external-interfaces-warning "Connection to address failed"
@@ -256,9 +256,9 @@
   :external-interfaces-payment-systems "Road and rail operators who have an electronic ticket/sales system must fill information about their machine-readable sales and ticket interface."
   :external-interfaces-tooltips {:data-content "Select the type of information this machine-readable interface provides. You can choose multiple options. If no selection is appropriate, choose \"other\" and fill in additional information."
                                  :external-service-url "Direct URL to machine-readable interface. If a direct link is not available you can alternatively use a web-address with information about the interface and its use."
-                                 :format "Select the data format. Choose all that apply. If the list does not have a format, you can add it by writing it in."
+                                 :format "Select the data format. If the list does not have a format, you can add it by writing it in."
                                  :license "Specify which license or terms of use apply to your interface. If the list does not have the license you use, you can add it by writing it in."
-                                 :external-service-description "Specify additional information about the interface that may be useful for developers. You may add a web-address that contains further information."}
+                                 :external-service-description "Specify additional information about the interface that may be useful for developers (e.g. about license). You may add a web-address that contains further information."}
 
   :RAE-link-text "RAE-software"
 
@@ -285,7 +285,7 @@
 
  ;; License suggestions (TODO: If we will have more of options, it would be better to store these in the database)
  :licenses
- {:external-interfaces ["Creative Commons 4.0" "CC0 1.0" "AGPL"]}
+ {:external-interfaces ["Creative Commons 4.0" "CC0 1.0"]}
 
  ;; CSV parsing
  :csv

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -257,9 +257,9 @@
   :external-interfaces-payment-systems "Sellaisten tie- ja raideliikenteen toimijoiden, joilla on käytössään lippu- ja maksujärjestelmä, tulee lisäksi ilmoittaa tässä osiossa koneluettavan tilaus- ja kertalippurajapinnan tiedot."
   :external-interfaces-tooltips {:data-content "Valitse millaisia tietoja koneluettava rajapinta tarjoaa. Voit valita listalta useita vaihtoehtoja. Mikäli valintalistalta ei löydy sopivia vaihtoehtoja, valitse “muu” ja kerro tietosisällöistä “Lisätietoja”-kentässä."
                                  :external-service-url "Ilmoita ensisijaisesti suora osoite koneluettavaan rajapintaan. Voit vaihtoehtoisesti ilmoittaa web-osoitteen, jossa kerrotaan tietoja rajapinnasta tai sen käytöstä."
-                                 :format "Valitse listalta tietosisällön formaatti. Mikäli rajapintasi välittää tietoa useassa formaatissa, valitse listalta kaikki oleelliset vaihtoehdot. Jos listalla ei ole käyttämääsi formaattia, voit lisätä sen kirjoittamalla."
+                                 :format "Valitse listalta tietosisällön formaatti. Jos listalla ei ole käyttämääsi formaattia, voit lisätä sen kirjoittamalla."
                                  :license "Kerro, minkä lisenssin tai käyttöehtojen mukaisesti rajapintasi on julkaistu. Jos listalla ei ole käyttämääsi lisenssiä, voit lisätä sen kirjoittamalla."
-                                 :external-service-description "Kerro lisätietoja rajapintaasi liittyen, joista voisi olla hyötyä kehittäjille. Voit lisätä tähän kenttään myös web-osoitteen, josta lisätiedot löytyvät."}
+                                 :external-service-description "Kerro lisätietoja rajapintaasi liittyen, joista voisi olla hyötyä kehittäjille (esim. lisenssistä). Voit lisätä tähän kenttään myös web-osoitteen, josta lisätiedot löytyvät."}
   :RAE-link-text "Rae-työkalulla"
   :companies-main-info "Mikäli palvelun tuottamiseen osallistuu muita yrityksiä tai palvelussa välitetään useiden yritysten palveluita, ilmoita kyseisten yritysten nimet ja y-tunnukset tässä osiossa. Tähän kohtaan tietoja tallentavat vain ne tahot, jotka koordinoivat palvelun tuottamista (esim. taksivälityskeskukset tai tilaava viranomainen). Tätä kohtaa eivät täytä ne yksittäiset yritykset, jotka ajavat välityskeskuksen kyytejä."
   :csv-info "Mikäli ylläpidät välitettävien yritysten listaa .csv-tiedostossa, syötä alla olevaan osoitekenttään suora osoite tiedostoon. (esim. https://www.finap.fi/ote/csv/palveluyritykset.csv)."
@@ -286,7 +286,7 @@
 
  ;; License suggestions (TODO: If we will have more of options, it would be better to store these in the database)
  :licenses
- {:external-interfaces ["Creative Commons 4.0" "CC0 1.0" "AGPL"]}
+ {:external-interfaces ["Creative Commons 4.0" "CC0 1.0"]}
 
  ;; CSV parsing
  :csv

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -266,9 +266,9 @@
   ;; Needs a new translation
   :external-interfaces-tooltips {:data-content "Välj typ av innehåll. Du kan välja flera typer samtidigt för samma gränssnitt. Ifall lämpligt alternativ saknas välj ”Övrigt” och beskriv innehållet i ”Tilläggsuppgifter”."
                                  :external-service-url "Ange i första hand ett direkt maskinläsbart gränssnitt. Om detta inte är ändamålsenligt ange då en webbadress för mera information om gränssnittet och dess användning."
-                                 :format "Välj ett format i listan. Du kan vid behov välja flera format för samma gränssnitt. Ifall lämpligt format saknas, fyll då i det själv."
+                                 :format "Välj ett format i listan. Ifall lämpligt format saknas, fyll då i det själv."
                                  :license "Uppge licens eller användarvillkor för gränssnittet. Ifall lämpligt alternativ saknas, fyll då i det själv."
-                                 :external-service-description "Uppge sådan information som kan vara viktig för tjänsteutvecklare. Du kan även uppge en webbadress med tilläggsuppgifter."}
+                                 :external-service-description "Uppge sådan information som kan vara viktig för tjänsteutvecklare (t.ex. om licens). Du kan även uppge en webbadress med tilläggsuppgifter."}
   :RAE-link-text "RAE-verktyg (läs mer på www.liikennevirasto.fi/rae)"
   :companies-main-info "Om tjänsten tillhandahålls av flera tjänsteproducenter eller om man via tjänsten förmedlar flera företags tjänster, fyll i företagens namn och FO-nummer här."
   :csv-info "Om du upprätthåller en lista över de tjänsteproducenter som tillhandahåller tjänsten, uppge då här adressen där listan finns (adressexempel: https://www.finap.fi/ote/csv/palveluyritykset.csv)"
@@ -293,8 +293,7 @@
 
  ;; License suggestions (TODO: If we will have more of options, it would be better to store these in the database)
  :licenses
- {:external-interfaces ["Creative Commons 4.0" "CC0 1.0" "AGPL"]}
-
+ {:external-interfaces ["Creative Commons 4.0" "CC0 1.0"]}
 
  ;; CSV parsing
  :csv

--- a/ote/src/cljc/ote/localization.cljc
+++ b/ote/src/cljc/ote/localization.cljc
@@ -75,9 +75,11 @@
      ;; serving the edn files to prevent any possible injection vectors.
      ;; NOTE: We make sure here, that the result of the parsing is stored in a node, so it can be safely
      ;; used anywhere in a ui component.
-     [:span {:dangerouslySetInnerHTML
-             ;; We are converting args list to vector to trigger message default behaviour (=reduce)
-             {:__html (js/marked (message (vec args) parameters) #js {:sanitize true})}}]
+     [:span
+      {:class "translation-markdown"                        ;; Defined in styles.css
+       :dangerouslySetInnerHTML
+       ;; We are converting args list to vector to trigger message default behaviour (=reduce)
+       {:__html (js/marked (message (vec args) parameters) #js {:sanitize true})}}]
 
      :clj
      (throw (ex-info "Markdown formatted translations not supported." {operator args}))))

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -332,6 +332,11 @@
                    (when on-blur (on-blur event)))
         :on-request-add handle-add!
         :on-request-delete handle-del!}
+       ;; Define suggestions data element format.
+       ;; Will be used internally like:
+       ;;   dataSourceConfig: {:value :key}
+       ;;   dataSource element: {:key 2}
+       ;;   ((:value dataSourceConfig) {:key 2}) -> 2
        (when suggestions-config
          {:dataSourceConfig suggestions-config})
        (when max-length

--- a/ote/src/cljs/ote/ui/mui_chip_input.cljs
+++ b/ote/src/cljs/ote/ui/mui_chip_input.cljs
@@ -33,18 +33,18 @@
 (def chip-input* (r/adapt-react-class (aget js/window "MaterialUIChipInput")))
 
 (defn chip-input [props]
-  (let [ref (atom nil)
-        auto-select? (atom false)]
+  (let [ref (atom nil)]
     (r/create-class
       {:component-did-mount
        (fn [this]
          (let [c (reset! ref (aget this "refs" "chip-input"))
-               handleAddChip* (aget c "handleAddChip")]
+               handleAddChip* (aget c "handleAddChip")
+               auto-select? (:auto-select? props)]
            ;; Autoselect first matching suggestion if :auto-select prop is true after pressing :new-chip-key-code key.
            ;; This will override the normal handleAddChip member function of chip-input with our custom function.
            (aset @ref "handleAddChip"
                  (fn [val]
-                   (if @auto-select?
+                   (if auto-select?
                      (let [autocomplete (aget @ref "autoComplete")
                            ;; RequestLists contains filtered suggestions from AutoComplete
                            first-match (first (js->clj (aget autocomplete "requestsList") :keywordize-keys true))
@@ -62,8 +62,6 @@
 
        :reagent-render
        (fn [props]
-         (reset! auto-select? (:auto-select? props))
-
          [chip-input* (merge
                         default-props
                         ; Remove margin if there are no chips (works only in "controlled" case i.e. :value prop is used).

--- a/ote/src/cljs/ote/ui/mui_chip_input.cljs
+++ b/ote/src/cljs/ote/ui/mui_chip_input.cljs
@@ -47,8 +47,15 @@
                    (if @auto-select?
                      (let [autocomplete (aget @ref "autoComplete")
                            ;; RequestLists contains filtered suggestions from AutoComplete
-                           requests (aget autocomplete "requestsList")
-                           chip (first requests)]
+                           first-match (first (js->clj (aget autocomplete "requestsList") :keywordize-keys true))
+                           suggestions (js->clj (aget @ref "props" "dataSource") :keywordize-keys true)
+
+                           ;; Note: Suggestion can contain map or plain string.
+                           ;; RequestsList will be empty if there is only one suggestion. Pick the first suggestion in that case.
+                           chip (first (if first-match
+                                         (filter #(= (or (:text %) %) (:text first-match)) suggestions)
+                                         suggestions))]
+
                        ;; Call the original ChipInput.handleAddChip function
                        (when chip (.call handleAddChip* c chip)))
                      (.call handleAddChip* c val))))))

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -161,7 +161,7 @@
                 filter-service-count fetching-more?]} service-search
         operator (:operator (:params app))]
     [:div.col-xs-12.col-md-12.col-lg-12
-     [:p
+     [:span
       (if operator
         (tr (if (zero? filter-service-count)
               [:service-search :operator-no-services]


### PR DESCRIPTION
# Fixed
* Removed global <p> element styling completely. Fixed some styling issues related to rendered markdown.
* Added some translation fixes for #155062911.
* Fix a bug in chip-input auto-select feature. Now supporting autocomplete vector-map datasources in addition to plain strings.

# Added
* Change interfaces data-content field to chip input, format field to autocomplete and remove AGPL suggestion from licesenses field.