### PR TITLE
155978703 Fix place search required? warning.

### DIFF
--- a/ote/src/cljs/ote/views/place_search.cljs
+++ b/ote/src/cljs/ote/views/place_search.cljs
@@ -220,7 +220,7 @@
                            :on-click #(e! (ps/->SetDrawControl true false))}]])]]]))
 
 (defn place-search-form-group [e! label name]
-  (let [empty-places? (comp empty? :results :place-search)]
+  (let [empty-places? #(not-any? (comp ::places/primary? :place) (get-in % [:place-search :results]))]
     (form/group
      {:label label
       :columns 3}


### PR DESCRIPTION
# Fixed
* Place search now properly warns if primary place field is not filled,
ignoring secondary optional place field.