### PR TITLE
156194960  Use route-long-name instead of route-short-name in GTFS

### DIFF
--- a/ote/src/cljc/ote/gtfs/transform.cljc
+++ b/ote/src/cljc/ote/gtfs/transform.cljc
@@ -26,7 +26,8 @@
 (defn- routes-txt [transport-operator-id routes]
   (for [{::transit/keys [id name route-type]} routes]
     {:gtfs/route-id id
-     :gtfs/route-short-name name
+     :gtfs/route-short-name ""
+     :gtfs/route-long-name name
      :gtfs/route-type (case route-type
                         :light-rail "0"
                         :subway "1"


### PR DESCRIPTION
# Fixed
 * Use route-long-name instead of route-short-name in GTFS
 * Set short-name as empty string as specifications asks us to do. (https://developers.google.com/transit/gtfs/reference/)