### PR TITLE
156493140 calendar validation

### DIFF
--- a/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
@@ -615,3 +615,20 @@
 
 (defn valid-name [route]
   (if (empty? (get route ::transit/name)) false true))
+
+(defn valid-calendar-rule-dates? [data]
+  (every?
+    (fn [rule]
+      (if (and
+            (not (str/blank? (get rule ::transit/from-date)))
+            (not (str/blank? (get rule ::transit/to-date)))
+            )
+        true false))
+    (::transit/service-rules data)))
+
+(defn valid-calendar-from-tro-dates? [data]
+  (if (and
+        (not (str/blank? (get data ::transit/from-date)))
+        (not (str/blank? (get data ::transit/to-date)))
+        )
+    true false))

--- a/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
@@ -585,6 +585,7 @@
   (if (or (empty? route-calendar)
           (and
             (empty? (get route-calendar :rule-dates))
+            (empty? (get route-calendar ::transit/service-added-dates))
             (empty? (get route-calendar ::transit/service-removed-dates))
             (empty? (get route-calendar ::transit/service-rules)))) false true))
 

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -659,7 +659,7 @@
   [:div.error "Missing field type: " (:type opts)])
 
 
-(defmethod field :table [{:keys [table-fields table-wrapper-style update! delete? add-label error-data] :as opts} data]
+(defmethod field :table [{:keys [table-fields table-wrapper-style update! delete? add-label add-label-validate error-data] :as opts} data]
   (let [data (if (empty? data)
                ;; table always contains at least one row
                [{}]
@@ -732,26 +732,29 @@
         [buttons/save {:on-click #(update! (conj (or data []) {}))
                        :label add-label
                        :label-style style-base/button-label-style
-                       :disabled (values/effectively-empty? (last data))}]])]))
+                       :disabled (if add-label-validate
+                                   (not (add-label-validate (last data)))
+                                   (values/effectively-empty? (last data)))}]])]))
 
-(defn- checkbox-container [update! table? label warning error style checked?]
+(defn- checkbox-container [update! table? label warning error style checked? disabled?]
   [:div (when error (stylefy/use-style style-base/required-element))
    [ui/checkbox {:label    (when-not table? label)
                  :checked  (boolean checked?)
                  :on-check #(update! (not checked?))
+                 :disabled disabled?
                  :style    style}]
    (when error
      (tr [:common-texts :required-field]))])
 
-(defmethod field :checkbox [{:keys [update! table? label warning error style extended-help]} checked?]
+(defmethod field :checkbox [{:keys [update! table? label warning error style extended-help disabled?]} checked?]
   (if extended-help
     [:div {:style {:margin-right (str "-" (:margin-right style-form/form-field))}}
      [common/extended-help
       (:help-text extended-help)
       (:help-link-text extended-help)
       (:help-link extended-help)]
-     (checkbox-container update! table? label warning error style checked?)]
-    (checkbox-container update! table? label warning error style checked?)))
+     (checkbox-container update! table? label warning error style checked? disabled?)]
+    (checkbox-container update! table? label warning error style checked? disabled?)))
 
 (defmethod field :checkbox-group [{:keys [update! table? label show-option options help error warning header? option-enabled?]} data]
   ;; Options:

--- a/ote/src/cljs/ote/views/route/service_calendar.cljs
+++ b/ote/src/cljs/ote/views/route/service_calendar.cljs
@@ -11,8 +11,9 @@
             [stylefy.core :as stylefy]
             [ote.ui.form-fields :as form-fields]))
 
-(def rule-fields
-  (delay (into [{:type :date-picker
+(defn rule-fields [calendar]
+  ;(delay
+    (into [{:type :date-picker
                  :name ::transit/from-date
                  :label (tr [:route-wizard-page :route-calendar-from-date])
                  :width "29%"}
@@ -29,16 +30,18 @@
                                    [::transit/sunday (tr [:enums :ote.db.transport-service/day :short :SUN])]]]
                  {:type :checkbox
                   :name name
+                  :disabled? (not (rw/valid-calendar-rule-dates? calendar))
                   :label label
-                  :width "6%"}))))
+                  :width "6%"})));)
 
 (defn- rules-table [e! trip-idx calendar]
   [:div.row {:style {:padding "20px"}}
    [form-fields/field {:type :table
                        :update! #(e! (rw/->EditServiceCalendarRules {::transit/service-rules %} trip-idx))
-                       :table-fields @rule-fields
+                       :table-fields (rule-fields calendar)
                        :delete? true
-                       :add-label (tr [:route-wizard-page :route-calendar-add-new-period])}
+                       :add-label (tr [:route-wizard-page :route-calendar-add-new-period])
+                       :add-label-validate rw/valid-calendar-from-tro-dates?}
     (::transit/service-rules calendar)]])
 
 (defn day-style-fn [calendar]

--- a/ote/src/cljs/ote/views/route/service_calendar.cljs
+++ b/ote/src/cljs/ote/views/route/service_calendar.cljs
@@ -14,7 +14,6 @@
             [ote.localization :refer [tr selected-language]]))
 
 (defn rule-fields [calendar]
-  ;(delay
     (into [{:type :date-picker
                  :name ::transit/from-date
                  :label (tr [:route-wizard-page :route-calendar-from-date])
@@ -34,7 +33,7 @@
                   :name name
                   :disabled? (not (rw/valid-calendar-rule-dates? calendar))
                   :label label
-                  :width "6%"})));)
+                  :width "6%"})))
 
 (defn- rules-table [e! trip-idx calendar]
   [:div.row {:style {:padding "20px"}}

--- a/ote/src/cljs/ote/views/route/trips.cljs
+++ b/ote/src/cljs/ote/views/route/trips.cljs
@@ -22,6 +22,7 @@
           (and
             (empty? (get-in service-calendars [row-idx :rule-dates]))
             (empty? (get-in service-calendars [row-idx ::transit/service-removed-dates]))
+            (empty? (get-in service-calendars [row-idx ::transit/service-added-dates]))
             (empty? (get-in service-calendars [row-idx ::transit/service-rules]))))
     {:badge-content "!"
      :secondary true


### PR DESCRIPTION
# Added
 * Added validation to calendar rules. Now user cannot select which week days route is transiting if from/to dates are not set.
 * Added  validation to calendar notification so that missing rule dates are not indicated if they are not missing. Previously user could add few transit days by hand and validator didn't notice that. 