### PR TITLE
156612783

### DIFF
--- a/ote/src/clj/ote/integration/export/gtfs.clj
+++ b/ote/src/clj/ote/integration/export/gtfs.clj
@@ -62,7 +62,7 @@
                                          transport-operator-columns
                                          {::t-operator/id transport-operator-id}))
         routes (map #(-> %
-                       (update ::transit/name (flip t-service/localized-text-for) *language*)
+                       (update ::transit/name (flip t-service/localized-text-with-fallback) *language*)
                        (update ::transit/trips (flip mapv) transit/trip-stop-times-from-24h))
                     (current-routes db transport-operator-id))]
     {:status 200

--- a/ote/src/cljc/ote/db/transport_service.cljc
+++ b/ote/src/cljc/ote/db/transport_service.cljc
@@ -131,6 +131,13 @@
 (defn localized-text-for [language localized-text]
   (some #(when (= (::lang %) (str/upper-case (name language))) (::text %)) localized-text))
 
+(defn localized-text-with-fallback [language localized-text]
+  (let [text (localized-text-for language localized-text)]
+    (if (str/blank? text)
+      (some #(when-not (str/blank? %) %)
+            (map #(localized-text-for % localized-text) ["EN" "FI" "SV"]))
+      text)))
+
 (def transportable-aid
   [:wheelchair :walking-stick :crutches :walker])
 

--- a/ote/src/cljc/ote/gtfs/transform.cljc
+++ b/ote/src/cljc/ote/gtfs/transform.cljc
@@ -21,7 +21,7 @@
 (defn- stops-txt [stops]
   (for [[id {::transit/keys [name location stop-type]}] stops]
     {:gtfs/stop-id id
-     :gtfs/stop-name (t-service/localized-text-for #?(:cljs @localization/selected-language
+     :gtfs/stop-name (t-service/localized-text-with-fallback #?(:cljs @localization/selected-language
                                                       :clj localization/*language*) name)
      :gtfs/stop-lat (.-x (.getGeometry location))
      :gtfs/stop-lon (.-y (.getGeometry location))}))

--- a/ote/src/cljs/ote/views/route/route_list.cljs
+++ b/ote/src/cljs/ote/views/route/route_list.cljs
@@ -48,7 +48,7 @@
                                    (.preventDefault %)
                                    (e! (route-list/->ConfirmDeleteRoute id)))}])]}
 
-      (str (tr [:route-list-page :delete-dialog-remove-route]) (t-service/localized-text-for @selected-language name))])])
+      (str (tr [:route-list-page :delete-dialog-remove-route]) (t-service/localized-text-with-fallback @selected-language name))])])
 
 
 (defn list-routes [e! routes]
@@ -79,10 +79,10 @@
              [:a {:href     "#"
                   :on-click #(do
                                (.preventDefault %)
-                               (e! (fp/->ChangePage :edit-route {:id id})))} (t-service/localized-text-for @selected-language name)]]
+                               (e! (fp/->ChangePage :edit-route {:id id})))} (t-service/localized-text-with-fallback @selected-language name)]]
             [ui/table-row-column {:class "hidden-xs hidden-sm " :style {:width "10%"}} (tr [:route-list-page :route-list-published?-values published?])]
-            [ui/table-row-column {:style {:width "10%"}} (t-service/localized-text-for @selected-language departure-point-name)]
-            [ui/table-row-column {:style {:width "10%"}} (t-service/localized-text-for @selected-language destination-point-name)]
+            [ui/table-row-column {:style {:width "10%"}} (t-service/localized-text-with-fallback @selected-language departure-point-name)]
+            [ui/table-row-column {:style {:width "10%"}} (t-service/localized-text-with-fallback @selected-language destination-point-name)]
             [ui/table-row-column {:style {:width "10%"}} (when available-from (time/format-date available-from))]
             [ui/table-row-column {:style {:width "10%"}} (when available-to (time/format-date available-to))]
             [ui/table-row-column {:class "hidden-xs hidden-sm " :style {:width "15%"}} (time/format-timestamp-for-ui (or modified created))]

--- a/ote/src/cljs/ote/views/route/service_calendar.cljs
+++ b/ote/src/cljs/ote/views/route/service_calendar.cljs
@@ -74,7 +74,7 @@
       :title (r/as-element
                [:div (tr [:route-wizard-page :route-calendar-group-name]
                          {:departure-time (and departure-time (time/format-time departure-time))
-                          :departure-stop (t-service/localized-text-for @selected-language departure-stop)})
+                          :departure-stop (t-service/localized-text-with-fallback @selected-language departure-stop)})
                 [ui/raised-button {:secondary true
                                    :icon (ic/action-delete)
                                    :style {:float "right"}

--- a/ote/src/cljs/ote/views/route/stop_sequence.cljs
+++ b/ote/src/cljs/ote/views/route/stop_sequence.cljs
@@ -25,7 +25,7 @@
 (defn- stop-marker [e! point lat-lng]
   (-> lat-lng
       (js/L.marker #js {:opacity 0.7
-                        :title (t-service/localized-text-for
+                        :title (t-service/localized-text-with-fallback
                                  @selected-language
                                  (js->clj (aget point "properties" "name")
                                           :keywordize-keys true))})
@@ -38,7 +38,7 @@
 
 (defn- custom-stop-dialog [e! route]
   (let [name (-> route :custom-stops last :name)
-        name-str (t-service/localized-text-for @selected-language name)]
+        name-str (t-service/localized-text-with-fallback @selected-language name)]
     (when (:custom-stop-dialog route)
       [ui/dialog
        {:open true
@@ -126,7 +126,7 @@
        (fn [i {::transit/keys [code name arrival-time departure-time]}]
          ^{:key (str code "_" i)}
          [:tr {:style {:border-bottom "solid 1px black"}}
-          [:td (t-service/localized-text-for @selected-language name)]
+          [:td (t-service/localized-text-with-fallback @selected-language name)]
           [:td [common/tooltip {:text (tr [:route-wizard-page :stop-sequence-delete])}
                 [ui/icon-button {:on-click #(e! (rw/->DeleteStop i))}
                  [ic/action-delete]]]]])

--- a/ote/src/cljs/ote/views/route/trips.cljs
+++ b/ote/src/cljs/ote/views/route/trips.cljs
@@ -96,7 +96,7 @@
                         :width "155px"
                         :overflow-x "hidden"
                         :white-space "pre"
-                        :text-overflow "ellipsis"}} (t-service/localized-text-for @selected-language name)]
+                        :text-overflow "ellipsis"}} (t-service/localized-text-with-fallback @selected-language name)]
          [:div {:style {:width "8px"
                         :margin-right "7px"
                         :display "inline-block"


### PR DESCRIPTION
# Added
* Localized-text-for (with fallback) helper function
   
# Changed
* Try to pick one of defined languages for localized text types if the user language provides no match. This is only used for sea route views and gtfs generation (stop and route names).
