### PR TITLE
156683885 Force route-type to :ferry

### DIFF
--- a/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
@@ -508,6 +508,7 @@
           route (-> app :route form/without-form-metadata
                     (assoc ::transit/service-calendars deduped-cals)
                     (assoc ::transit/published? (or published? false))
+                    (assoc ::transit/route-type :ferry)
                     (update ::transit/stops (fn [stop]
                                               (map
                                                 #(dissoc % ::transit/departure-time ::transit/arrival-time)


### PR DESCRIPTION
# Fixed
* New sea route when page was refreshed using browser refresh. :ferry type was missing and it is mandatory field.
   

