### PR TITLE
156907735 Improve route name validation

### DIFF
--- a/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
@@ -15,7 +15,8 @@
             [ote.localization :refer [tr tr-key]]
             [taoensso.timbre :as log]
             [ote.util.collections :as collections]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [ote.localization :refer [selected-language]]))
 
 ;; Load available stops from server (GeoJSON)
 (defrecord LoadStops [])
@@ -591,11 +592,16 @@
   [{::transit/keys [stops] :as route}]
   (> (count stops) 1))
 
+(defn valid-route-name? [name]
+  (let [localized-name (t-service/localized-text-for @selected-language name)]
+    (not (str/blank? localized-name))))
+
 (defn valid-basic-info?
   "Check if given route has a name and an operator."
   [{::transit/keys [name transport-operator-id]}]
-  (and (not (str/blank? name))
-       transport-operator-id))
+  (and
+    (valid-route-name? name)
+    (not (nil? transport-operator-id))))
 
 (defn valid-calendar? [trip-calendar]
   (not (or
@@ -644,5 +650,4 @@
 (defn empty-calendar-from-to-dates? [{::transit/keys [from-date to-date] :as data}]
   (or
     (str/blank? from-date)
-    (str/blank? to-date)
-    ))
+    (str/blank? to-date)))

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -189,7 +189,7 @@
 
 (def languages ["FI" "SV" "EN"])
 
-(defmethod field :localized-text [{:keys [update! table? label name rows rows-max warning error full-width? style]
+(defmethod field :localized-text [{:keys [update! table? is-empty? label name rows rows-max warning error full-width? style]
                                    :as   field} data]
   (r/with-let [selected-language (r/atom (first languages))]
     (let [data (or data [])
@@ -239,7 +239,11 @@
              lang]))]
        (when (or error warning)
          [:div (stylefy/use-style style-base/required-element)
-          (if error error warning)])])))
+          (if error error warning)])
+       (when (and (not error) (not warning) is-empty? (is-empty? data))
+         [:div (stylefy/use-style style-base/required-element)
+          (tr [:common-texts :required-field])])
+       ])))
 
 (defmethod field :autocomplete [{:keys [update! label name error warning regex
                                         max-length style hint-style

--- a/ote/src/cljs/ote/views/route.cljs
+++ b/ote/src/cljs/ote/views/route.cljs
@@ -43,7 +43,7 @@
                                 (.preventDefault %)
                                 (e! (rw/->SaveToDb true)))}
      (tr [:buttons :save-and-publish])]
-    [buttons/save {:disabled (not (rw/valid-name (:route app)))
+    [buttons/save {:disabled (not (rw/valid-route-name? (get-in app [:route ::transit/name])))
                    :on-click #(do
                                 (.preventDefault %)
                                 (e! (rw/->SaveToDb false)))}
@@ -66,7 +66,7 @@
                                      (.preventDefault %)
                                      (e! (rw/->SaveToDb true)))}
           (tr [:buttons :save])]
-         [buttons/save {:disabled (not (rw/valid-name (:route app)))
+         [buttons/save {:disabled (not (rw/valid-route-name? (get-in app [:route ::transit/name])))
                         :on-click #(do
                                   (.preventDefault %)
                                   (e! (rw/->SaveToDb false)))}

--- a/ote/src/cljs/ote/views/route/basic_info.cljs
+++ b/ote/src/cljs/ote/views/route/basic_info.cljs
@@ -5,7 +5,8 @@
             [ote.db.transport-operator :as t-operator]
             [ote.db.transit :as transit]
             [cljs-react-material-ui.reagent :as ui]
-            [ote.localization :refer [tr tr-key]]))
+            [ote.localization :refer [tr tr-key]]
+            [ote.ui.validation :as validation]))
 
 (defn- ensure-operator
   "When page is refreshed it is possible that operator is not set.
@@ -27,7 +28,9 @@
          {:name      ::transit/name
           :type      :localized-text
           :label     (tr [:route-wizard-page :basic-info-route-name])
-          :required? true}
+          :is-empty? validation/empty-localized-text?
+          :required? true
+          }
          {:name         ::transit/transport-operator-id
           :option-value ::t-operator/id
           :type         :selection


### PR DESCRIPTION
# Fixed
* Route name validation
* Take empty-localized-text? function into use in route name.
* Show "Required field" text if value is empty and no other errors or warnings are noticed.
* Improve "save as draft" validation by checking that localized name is indeed given before route can be saved as draft.

