### PR TITLE
156836192 Add missing fields to authority pre notice view

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -715,7 +715,10 @@
             :ote.db.modification/created "Luotu"
             :ote.db.modification/modified "Muokattu"
             :ote.db.transit/route-description "Reitin kuvaus"
-            :actions "Toiminnot"}
+            :actions "Toiminnot"
+            :region-names "Regions"
+            :ote.db.transit/attachments "Attached files"
+            :ote.db.transport-operator/transport-operator "Transport operator"}
 
   :pre-notice-dialog {:label "Muutosilmoituksen tiedot"
                       :comments-label "Viranomaisen kommentit (näkyvät vain viranomaiselle)"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -717,7 +717,10 @@
             :ote.db.modification/created "Luotu"
             :ote.db.modification/modified "Muokattu"
             :ote.db.transit/route-description "Reitin kuvaus"
-            :actions "Toiminnot"}
+            :actions "Toiminnot"
+            :region-names "Maakunta"
+            :ote.db.transit/attachments "Liitetiedostot"
+            :ote.db.transport-operator/transport-operator "Palveluntuottaja"}
 
   :pre-notice-dialog {:label "Muutosilmoituksen tiedot"
                       :comments-label "Viranomaisen kommentit (näkyvät vain viranomaisille)"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -718,7 +718,10 @@
             :ote.db.modification/created "Luotu"
             :ote.db.modification/modified "Muokattu"
             :ote.db.transit/route-description "Reitin kuvaus"
-            :actions "Toiminnot"}
+            :actions "Toiminnot"
+            :region-names "Maakunnat"
+            :ote.db.transit/attachments "Liitetiedostot"
+            :ote.db.transport-operator/transport-operator "Tjänsteproducent"}
 
   :pre-notice-dialog {:label "Muutosilmoituksen tiedot"
                       :comments-label "Viranomaisen kommentit (näkyvät vain viranomaisille)"

--- a/ote/src/cljc/ote/db/places.cljc
+++ b/ote/src/cljc/ote/db/places.cljc
@@ -6,4 +6,5 @@
   #?(:cljs (:require-macros [ote.db.specql-db :refer [define-tables]])))
 
 (define-tables
-  ["places" ::places])
+  ["places" ::places]
+  ["finnish_regions" ::finnish-regions])

--- a/ote/src/cljs/ote/ui/common.cljs
+++ b/ote/src/cljs/ote/ui/common.cljs
@@ -29,9 +29,18 @@
      (if-not url
        [:span]
        ;; Lazy check if url has a protocol, or if it is a relative path
-       (let [url (if (re-matches #"^(\w+:|.?.?/).*" url)
+       (let [url (cond
+                   ;; URL with protocol, use as is
+                   (re-matches #"^(\w+:|.?.?/).*" url)
                    url
-                   (str "http://" url))]
+
+                   ;; User specified link without protocol (like "www.serviceprovider.fi/foo")
+                   (re-matches #"^[^/]+\..*" url)
+                   (str "http://" url)
+
+                   ;; Internal relative link, like "pre-notice/attachment/1"
+                   :default
+                   url)]
          [:a (merge {:href url} a-props) label])))))
 
 

--- a/ote/src/cljs/ote/views/pre_notices/authority_listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/authority_listing.cljs
@@ -41,6 +41,14 @@
       [:div (when effective-date (time/format-date effective-date)) " " effective-date-description])
     effective-dates)])
 
+(defn- attachment-list [attachments]
+  [:div
+   (for [{::transit/keys [id attachment-file-name]} attachments]
+     ^{:key id}
+     [:div [common/linkify
+            (str "pre-notice/attachment/" id) attachment-file-name
+            {:target "_blank"}]])])
+
 (defn pre-notice-view [e! pre-notice]
   (let [tr* (tr-key [:field-labels :pre-notice]
                     [:pre-notice-list-page :headers])]
@@ -62,10 +70,13 @@
              (fn [[key fmt]]
                [[:b (str (tr* key) ": ")] (fmt (get pre-notice key))])
              [[::modification/created time/format-timestamp-for-ui]
+              [::t-operator/transport-operator ::t-operator/name]
               [::transit/pre-notice-type format-notice-types]
               [::transit/route-description str]
+              [:region-names str]
               [::transit/effective-dates format-effective-dates]
-              [::transit/url str]]))
+              [::transit/url str]
+              [::transit/attachments attachment-list]]))
       [:div.pre-notice-comments (stylefy/use-style styles/comment-container)
        [:h3 (tr [:pre-notice-list-page :pre-notice-dialog :comments-label])]
        [comment-list (::transit/comments pre-notice)]
@@ -93,7 +104,7 @@
         {:name ::transit/pre-notice-type
          :format format-notice-types}
         {:name ::transit/route-description}
-        {:name :operator :read (comp ::t-operator/name ::t-operator/transport-operator)}]
+        {:name ::t-operator/transport-operator :read (comp ::t-operator/name ::t-operator/transport-operator)}]
 
        pre-notices]]]))
 


### PR DESCRIPTION
# Added
- Operator, regions and attachments are now visible in authority pre notice view