### PR TITLE
157033324 Remove is-empty? from localized texts that arent required

### DIFF
--- a/ote/src/cljs/ote/views/parking.cljs
+++ b/ote/src/cljs/ote/views/parking.cljs
@@ -57,8 +57,7 @@
      :type            :localized-text
      :full-width?     true
      :write           #(assoc-in %1 [::t-service/pricing ::t-service/description] %2)
-     :read            (comp ::t-service/description ::t-service/pricing)
-     :is-empty?       validation/empty-localized-text?}
+     :read            (comp ::t-service/description ::t-service/pricing)}
 
     {:container-class "col-md-5"
      :name  ::t-service/pricing-url
@@ -77,11 +76,7 @@
      :name ::t-service/payment-method-description
      :type :localized-text
      :rows 1
-     :full-width? true
-     :is-empty? validation/empty-localized-text?
-     }
-
-    ))
+     :full-width? true}))
 
 (defn service-hours-group [e!]
   (let [tr* (tr-key [:field-labels :service-exception])
@@ -141,8 +136,7 @@
        :prepare-for-save values/without-empty-rows
        :table-fields [{:name  ::t-service/description
                        :label (tr* :description)
-                       :type  :localized-text
-                       :is-empty? validation/empty-localized-text?}
+                       :type  :localized-text}
                       {:name  ::t-service/from-date
                        :type  :date-picker
                        :label (tr* :from-date)}
@@ -187,7 +181,6 @@
     {:name            ::t-service/charging-points
      :rows            2
      :type            :localized-text
-     :is-empty? validation/empty-localized-text?
      :full-width?     true
      :container-class "col-md-6"}))
 
@@ -213,7 +206,6 @@
 
     {:name            ::t-service/accessibility-description
      :type            :localized-text
-     :is-empty? validation/empty-localized-text?
      :rows            2
      :container-class "col-md-6"
      :full-width?     true}

--- a/ote/src/cljs/ote/views/passenger_transportation.cljs
+++ b/ote/src/cljs/ote/views/passenger_transportation.cljs
@@ -38,7 +38,6 @@
 
     {:name      ::t-service/luggage-restrictions
      :type      :localized-text
-     :is-empty? validation/empty-localized-text?
      :rows      1
      :full-width? true
      :container-class "col-xs-12"}))
@@ -97,14 +96,12 @@
 
    {:name ::t-service/guaranteed-accessibility-description
     :type :localized-text
-    :is-empty? validation/empty-localized-text?
     :rows 1
     :full-width? true
     :container-class "col-xs-12 col-sm-6 col-md-6"}
 
    {:name ::t-service/limited-accessibility-description
     :type :localized-text
-    :is-empty? validation/empty-localized-text?
     :rows 1
     :container-class "col-xs-12 col-sm-6 col-md-6"
     :full-width? true}
@@ -160,7 +157,6 @@
    {:container-class "col-xs-12 col-sm-6 col-md-6"
     :name ::t-service/payment-method-description
     :type :localized-text
-    :is-empty? validation/empty-localized-text?
     :rows 6
     :full-width? true
     }
@@ -169,7 +165,6 @@
     :name ::t-service/pricing-description
     :label price-description-label
     :type :localized-text
-    :is-empty? validation/empty-localized-text?
     :full-width? true
     :write #(assoc-in %1 [::t-service/pricing ::t-service/description] %2)
     :read (comp ::t-service/description ::t-service/pricing)

--- a/ote/src/cljs/ote/views/rental.cljs
+++ b/ote/src/cljs/ote/views/rental.cljs
@@ -136,14 +136,12 @@
 
     {:name            ::t-service/guaranteed-accessibility-description
      :type            :localized-text
-     :is-empty?       validation/empty-localized-text?
      :rows            1
      :full-width?     true
      :container-class "col-md-6"}
 
     {:name ::t-service/limited-accessibility-description
      :type :localized-text
-     :is-empty? validation/empty-localized-text?
      :rows 1
      :container-class "col-md-6"
      :full-width? true}
@@ -191,7 +189,6 @@
 
    {:name ::t-service/luggage-restrictions
     :type :localized-text
-    :is-empty? validation/empty-localized-text?
     :rows 1
     :container-class "col-md-6"
     :full-width?  true}

--- a/ote/src/cljs/ote/views/terminal.cljs
+++ b/ote/src/cljs/ote/views/terminal.cljs
@@ -39,7 +39,6 @@
 
     {:name ::t-service/assistance-description
      :type :localized-text
-     :is-empty?       validation/empty-localized-text?
      :full-width      true
      :container-class "col-xs-12 col-sm-6 col-md-6"
      :rows            2
@@ -48,7 +47,6 @@
      :read            (comp ::t-service/description ::t-service/assistance)}
 
     {:name ::t-service/assistance-place-description
-     :type :localized-text
      :full-width true
      :container-class "col-xs-12 col-sm-6 col-md-6"
      :rows 2
@@ -99,7 +97,6 @@
    {:container-class "col-xs-12 col-sm-6 col-md-6"
     :name ::t-service/accessibility-description
     :type :localized-text
-    :is-empty? validation/empty-localized-text?
     :full-width? true
     :rows 2}
 

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -59,7 +59,6 @@
 
     {:name ::t-service/description
      :type  :localized-text
-     :is-empty? validation/empty-localized-text?
      :rows  1
      :read  (comp ::t-service/description service-url-field)
      :write (fn [data desc]
@@ -80,8 +79,7 @@
      :table-fields [{:name ::t-service/url
                      :type :string}
                     {:name ::t-service/description
-                     :type :localized-text
-                     :is-empty? validation/empty-localized-text?}]
+                     :type :localized-text}]
      :delete?      true
      :add-label    (tr [:buttons :add-new-service-link])}))
 
@@ -196,8 +194,7 @@
                        :full-width? true
                        :read (comp ::t-service/description ::t-service/external-interface)
                        :write #(assoc-in %1 [::t-service/external-interface ::t-service/description] %2)
-                       :required? false
-                       :is-empty? validation/empty-localized-text?}]
+                       :required? false}]
        :delete? true
        :add-label (tr [:buttons :add-external-interface])}
 
@@ -387,8 +384,7 @@
       :prepare-for-save values/without-empty-rows
       :table-fields [{:name ::t-service/description
                       :label (tr* :description)
-                      :type :localized-text
-                      :is-empty? validation/empty-localized-text?}
+                      :type :localized-text}
                      {:name ::t-service/from-date
                       :type :date-picker
                       :label (tr* :from-date)}
@@ -401,7 +397,6 @@
      {:name ::t-service/service-hours-info
       :label (tr [:field-labels :transport-service-common ::t-service/service-hours-info])
       :type :localized-text
-      :is-empty? validation/empty-localized-text?
       :full-width? true
       :container-class "col-xs-12"})))
 
@@ -421,7 +416,6 @@
 
    {:name ::t-service/description
     :type :localized-text
-    :is-empty? validation/empty-localized-text?
     :rows 2
     :full-width? true
     :container-class "col-xs-12 col-sm-12 col-md-8"}


### PR DESCRIPTION
# Fixed
* Removed is-empty? function from localized-texts that can be empty
   