### PR TITLE
Add ote email configuration for aws, improve email config.

### DIFF
--- a/aws/ansible/templates/ote/config.edn.j2
+++ b/aws/ansible/templates/ote/config.edn.j2
@@ -8,6 +8,20 @@
                    :digest-algorithm "MD5"}
         ;;:session {:key "{{ote_cookie_key}}"}
         }
+
+ :email {:server
+         {;; Hostname of the STMP server. Optional if running locally.
+          :host "{{email_smtp_server}}"
+          ;; Port is set to 465 is ssl is true
+          :ssl false
+          ;; Port is set to 25 if tsl is true
+          :tsl true
+          :user "{{email_user}}"
+          :pass "{{email_password}}"}
+
+         ;; Common message opts
+         :msg {:from "{{email_from}}"}}
+
  :places {:finnish-municipalities
           {:type :shapefile
            :name-field "NAMEFIN"

--- a/ote/config.edn
+++ b/ote/config.edn
@@ -8,16 +8,20 @@
                    :digest-algorithm "MD5"}
         :session {:key "cookie0123456789"}}
 
- :email {;; Hostname of the STMP server. Optional if running locally.
-         :host nil
-         ;; Port of the SMTP server. Numerous contextual defaults exists. E.g. when using :ssl or :tsl settings.
-         :port nil
-         ;; Port is set to 465 is ssl is true
-         :ssl false
-         ;; Port is set to 25 if tsl is true
-         :tsl false
-         :user nil
-         :pass nil}
+ :email {:server
+         {;; Hostname of the STMP server. Optional if running locally.
+          :host nil
+          ;; Port of the SMTP server. Numerous contextual defaults exists. E.g. when using :ssl or :tsl settings.
+          :port nil
+          ;; Port is set to 465 is ssl is true
+          :ssl false
+          ;; Port is set to 25 if tsl is true
+          :tsl false
+          :user nil
+          :pass nil}
+
+         ;; Common message opts
+         :msg {:from "NAP"}}
 
  :places {:finnish-municipalities
           {:type :shapefile

--- a/ote/src/clj/ote/tasks/pre_notices.clj
+++ b/ote/src/clj/ote/tasks/pre_notices.clj
@@ -91,7 +91,7 @@
     (catch Exception e
       (log/warn "Error while generating notification html:" e))))
 
-(defn send-notification! [db email-config]
+(defn send-notification! [db {server-opts :server msg-opts :msg :as email-opts}]
   (localization/with-language
     "fi"
     (tx/with-transaction db
@@ -103,9 +103,9 @@
             (when-not (empty? emails)
               (log/info "Trying to send a pre-notice email to: " (pr-str emails))
               (send-email
-                email-config
+                server-opts
                 {:bcc emails
-                 :from "NAP"
+                 :from (or (:from msg-opts) "NAP")
                  :subject (str "Uudet 60 päivän muutosilmoitukset NAP:ssa "
                                (datetime-string (t/now) timezone))
                  :body [{:type "text/html" :content notification}]}))


### PR DESCRIPTION
# Added
* Add email configs in ote aws config template.
   
# Changed
* Separate email server configs and common email msg configs.

