### PR TITLE
Change the test to use stops with larger distance to prevent the stops covering each other.

### DIFF
--- a/cypress/integration/route_spec.js
+++ b/cypress/integration/route_spec.js
@@ -30,10 +30,15 @@ describe('Sea route tests', function () {
     });
 
     it('Add stops', function () {
-        cy.get('img[title="OULUN SATAMA: Vihreäsaari"]').click();
-        cy.get('img[title="RAAHE: Rautaruukki"]').click();
-        cy.get('img[title="KALAJOKI: Itäkenttä"]').click();
-        cy.get('img[title="VAASA: Lassenlaituri"]').click();
+        cy.get('.leaflet-control-zoom-out').click().wait(200);
+        cy.get('.leaflet-control-zoom-out').click().wait(200);
+        cy.get('.leaflet-control-zoom-out').click().wait(200);
+        cy.get('.leaflet-control-zoom-out').click().wait(200);
+        cy.get('.leaflet-control-zoom-out').click();
+        cy.get('img[title="Puerto Mont"]').click();
+        cy.get('img[title="Panama"]').click();
+        cy.get('img[title="Los Angeles"]').click();
+        cy.get('img[title="Middleton Island"]').click();
     });
 
     it('Add calendar', function () {

--- a/database/testdata-ote.sql
+++ b/database/testdata-ote.sql
@@ -10,3 +10,10 @@ VALUES
 INSERT INTO "transport-operator" (name, "business-id", homepage, "visiting-address", "ckan-group-id")
 VALUES ('Terminaali Oy', '1234567-8', 'http://www.example.com',
 ROW('Terminaalitie 1','90100','Terminaalikaupunki')::address, 'ff5ca54d-2ff5-476d-9ad4-e903b6d1eeb4');
+
+INSERT INTO "public"."finnish_ports"("code","name","location","created")
+VALUES
+(E'OTE141',E'{"(FI,\\"Puerto Mont\\")"}',E'POINT(-72.917481 -41.474117)',E'2018-04-27 10:01:51.364+00'),
+(E'OTE140',E'{"(FI,Panama)"}',E'POINT(-79.498291 8.995635)',E'2018-04-27 10:01:51.342+00'),
+(E'OTE139',E'{"(FI,\\"Los Angeles\\")"}',E'POINT(-118.349611 33.474982)',E'2018-04-27 10:01:51.304+00'),
+(E'OTE138',E'{"(FI,\\"Middleton Island\\")"}',E'POINT(-146.318054 59.430127)',E'2018-04-27 07:06:00.846+00');


### PR DESCRIPTION
# Fixed
* Sea route stop are overlapped easily which may cause the test fail. Changed the test to use stops outside Finland with larger distances.