### PR TITLE
156989927 allow viewing sent pre notice

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -767,7 +767,6 @@
   :save-failure "Luonnoksen tallentaminen epäonnistui."
   :save-failure-send "Ilmoituksen lähettäminen epäonnistui."
   :route-description-hint "eg. Tampere - Pori or Oulu - Seinäjoki"
-  :sent-pre-notice-cannot-be-edited "Lähetettyä ilmoitusta ei voi enää muokata!"
   :add-attachment "Uusi liite"
   :select-attachment "Valitse tiedosto"
   :effective-date-descriptions {:year-start "Year start"

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -768,7 +768,7 @@
   :save-failure-send "Ilmoituksen lähettäminen epäonnistui."
   :route-description-hint "eg. Tampere - Pori or Oulu - Seinäjoki"
   :add-attachment "Uusi liite"
-  :select-attachment "Valitse tiedosto"
+  :select-attachment "Lisää liite"
   :effective-date-descriptions {:year-start "Year start"
                                 :school-start "The beginning of the school year"
                                 :school-end "The end of the school year"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -772,7 +772,6 @@
   :save-failure "Luonnoksen tallentaminen epäonnistui."
   :save-failure-send "Ilmoituksen lähettäminen epäonnistui."
   :route-description-hint "esim. Tampere - Pori tai Oulu - Seinäjoki"
-  :sent-pre-notice-cannot-be-edited "Lähetettyä ilmoitusta ei voi enää muokata!"
   :add-attachment "Uusi liite"
   :select-attachment "Valitse tiedosto"
   :effective-date-descriptions {:year-start "Vuoden alku"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -773,7 +773,7 @@
   :save-failure-send "Ilmoituksen lähettäminen epäonnistui."
   :route-description-hint "esim. Tampere - Pori tai Oulu - Seinäjoki"
   :add-attachment "Uusi liite"
-  :select-attachment "Valitse tiedosto"
+  :select-attachment "Lisää liite"
   :effective-date-descriptions {:year-start "Vuoden alku"
                                 :school-start "Kouluvuoden alku"
                                 :school-end "Kouluvuoden päätös"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -776,7 +776,7 @@ Man måste vara inloggad för att digitalisera eller publicera mobilitetstjänst
  :save-failure-send "Ilmoituksen lähettäminen epäonnistui."
  :route-description-hint "esim. Tampere - Pori tai Oulu - Seinäjoki"
  :add-attachment "Uusi liite"
- :select-attachment "Valitse tiedosto"
+ :select-attachment "Lisää liite"
  :effective-date-descriptions {:year-start "Vuoden alku"
                                :school-start "Kouluvuoden alku"
                                :school-end "Kouluvuoden päätös"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -775,7 +775,6 @@ Man måste vara inloggad för att digitalisera eller publicera mobilitetstjänst
  :save-failure "Luonnoksen tallentaminen epäonnistui."
  :save-failure-send "Ilmoituksen lähettäminen epäonnistui."
  :route-description-hint "esim. Tampere - Pori tai Oulu - Seinäjoki"
- :sent-pre-notice-cannot-be-edited "Lähetettyä ilmoitusta ei voi enää muokata!"
  :add-attachment "Uusi liite"
  :select-attachment "Valitse tiedosto"
  :effective-date-descriptions {:year-start "Vuoden alku"

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -161,7 +161,6 @@
 
 (defmethod field :file [{:keys [label name disabled? on-change]
                          :as field} data]
-  (println disabled?)
   [:div (stylefy/use-style style-form-fields/file-button-wrapper)
    [:button (merge
               (stylefy/use-sub-style style-form-fields/file-button-wrapper :button)

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -150,18 +150,23 @@
       {:on-key-press #(when (= "Enter" (.-key %))
                         (on-enter))}))])
 
-(defmethod field :file-and-delete [{:keys [on-delete table-data row-number] :as f} data]
+(defmethod field :file-and-delete [{:keys [on-delete table-data row-number disabled?] :as f} data]
   (if (empty? (get table-data row-number))
-    (field (assoc f :type :file) )
-    [ui/icon-button {:on-click #(on-delete row-number)}
+    (field (assoc f :type :file))
+    [ui/icon-button (merge
+                      {:on-click #(on-delete row-number)}
+                      (when disabled?
+                        {:disabled true}))
      [ic/action-delete]]))
 
-(defmethod field :file [{:keys [update! label name max-length min-length regex
-                                focus on-focus form? error warning table? full-width?
-                                style input-style hint-style on-change]
+(defmethod field :file [{:keys [label name disabled? on-change]
                          :as field} data]
+  (println disabled?)
   [:div (stylefy/use-style style-form-fields/file-button-wrapper)
-   [:button (stylefy/use-sub-style style-form-fields/file-button-wrapper :button)
+   [:button (merge
+              (stylefy/use-sub-style style-form-fields/file-button-wrapper :button)
+              (when disabled?
+                {:disabled true}))
     label]
    [:input
     (merge (stylefy/use-sub-style
@@ -172,7 +177,9 @@
             :on-change on-change
             ;; Hack to hide file input tooltip on different browsers.
             ;; String with space -> hide title on Chrome, FireFox and some other browsers. Not 100% reliable.
-            :title " "})]])
+            :title " "}
+           (when disabled?
+             {:disabled true}))]])
 
 (defmethod field :text-area [{:keys [update! table? label name rows error tooltip tooltip-length
                                      max-length on-blur warning full-width?

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -159,14 +159,14 @@
                         {:disabled true}))
      [ic/action-delete]]))
 
-(defmethod field :file [{:keys [label name disabled? on-change]
+(defmethod field :file [{:keys [label button-label name disabled? on-change]
                          :as field} data]
   [:div (stylefy/use-style style-form-fields/file-button-wrapper)
    [:button (merge
               (stylefy/use-sub-style style-form-fields/file-button-wrapper :button)
               (when disabled?
                 {:disabled true}))
-    label]
+    (if-not (empty? label) label button-label)]
    [:input
     (merge (stylefy/use-sub-style
              style-form-fields/file-button-wrapper :file-input)

--- a/ote/src/cljs/ote/ui/table.cljs
+++ b/ote/src/cljs/ote/ui/table.cljs
@@ -5,6 +5,7 @@
             [reagent.core :as r]))
 
 (defn table [{:keys [height name->label key-fn
+                     row-style show-row-hover?
                      on-select row-selected? no-rows-message] :as opts} headers rows]
   [ui/table (merge
              (when on-select
@@ -22,7 +23,8 @@
         [ui/table-header-column (when width
                                   {:style {:width width}})
          (name->label name)]))]]
-   [ui/table-body {:display-row-checkbox false}
+   [ui/table-body {:display-row-checkbox false
+                   :show-row-hover show-row-hover?}
     (if (empty? rows)
       [:tr [:td {:colSpan (count headers)}
             [common/help no-rows-message]]]
@@ -30,9 +32,12 @@
        (map-indexed
         (fn [i row]
           ^{:key (if key-fn (key-fn row) i)}
-          [ui/table-row {:selectable (boolean on-select)
-                         :selected (if row-selected? (row-selected? row) false)
-                         :display-border false}
+          [ui/table-row (merge
+                          {:selectable (boolean on-select)
+                           :selected (if row-selected? (row-selected? row) false)
+                           :display-border false}
+                          (when row-style
+                            {:style row-style}))
            (doall
             (for [{:keys [name width format read]} headers
                   :let [value ((or format identity) (if read (read row) (get row name)))]]

--- a/ote/src/cljs/ote/ui/table.cljs
+++ b/ote/src/cljs/ote/ui/table.cljs
@@ -24,7 +24,7 @@
                                   {:style {:width width}})
          (name->label name)]))]]
    [ui/table-body {:display-row-checkbox false
-                   :show-row-hover show-row-hover?}
+                   :show-row-hover (boolean show-row-hover?)}
     (if (empty? rows)
       [:tr [:td {:colSpan (count headers)}
             [common/help no-rows-message]]]

--- a/ote/src/cljs/ote/views/pre_notices/authority_listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/authority_listing.cljs
@@ -115,6 +115,8 @@
       [table/table {:name->label     (tr-key [:pre-notice-list-page :headers])
                     :key-fn          ::transit/id
                     :no-rows-message (tr [:pre-notice-list-page :no-pre-notices-for-operator])
+                    :row-style {:cursor "pointer"}
+                    :show-row-hover? true
                     :on-select #(e! (pre-notice/->ShowPreNotice (::transit/id (first %))))}
        [{:name ::modification/created :format (comp str time/format-timestamp-for-ui)}
         {:name ::transit/pre-notice-type

--- a/ote/src/cljs/ote/views/pre_notices/listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/listing.cljs
@@ -24,16 +24,11 @@
 (defn pre-notices-table [e! pre-notices state]
   (let [notices (filter #(= state (::transit/pre-notice-state %)) pre-notices)]
     [:div.row
-     [table/table (merge
-                    {:name->label (tr-key [:pre-notice-list-page :headers])
-                     :key-fn ::transit/id
-                     :no-rows-message (case state
-                                        :draft (tr [:pre-notice-list-page :no-pre-notices-for-operator])
-                                        :sent (tr [:pre-notice-list-page :no-pre-notices-sent]))}
-                    (when (= :sent state)
-                      {:on-select #(e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id (first %))}))
-                       :show-row-hover? true
-                       :row-style {:cursor "pointer"}}))
+     [table/table {:name->label (tr-key [:pre-notice-list-page :headers])
+                   :key-fn ::transit/id
+                   :no-rows-message (case state
+                                      :draft (tr [:pre-notice-list-page :no-pre-notices-for-operator])
+                                      :sent (tr [:pre-notice-list-page :no-pre-notices-sent]))}
       [{:name ::transit/pre-notice-type
         :format pre-notice-type->str}
        {:name ::transit/route-description}
@@ -43,14 +38,15 @@
         :read (comp time/format-timestamp-for-ui ::modification/modified)}
        {:name ::transit/pre-notice-state
         :format (tr-key [:enums ::transit/pre-notice-state])}
-       (when (= :draft state)
-         {:name :actions
-          :read (fn [row]
-                  [ui/icon-button {:href "#"
-                                   :on-click #(do
-                                                (.preventDefault %)
-                                                (e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id row)})))}
-                   [ic/content-create]])})]
+       {:name :actions
+        :read (fn [row]
+                [ui/icon-button {:href "#"
+                                 :on-click #(do
+                                              (.preventDefault %)
+                                              (e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id row)})))}
+                 (case state
+                   :draft [ic/content-create]
+                   :sent [ic/action-visibility])])}]
       notices]]))
 
 (defn pre-notices [e! {:keys [transport-operator pre-notices] :as app}]

--- a/ote/src/cljs/ote/views/pre_notices/listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/listing.cljs
@@ -28,7 +28,8 @@
                    :key-fn ::transit/id
                    :no-rows-message (case state
                                       :draft (tr [:pre-notice-list-page :no-pre-notices-for-operator])
-                                      :sent (tr [:pre-notice-list-page :no-pre-notices-sent]))}
+                                      :sent (tr [:pre-notice-list-page :no-pre-notices-sent]))
+                   :on-select #(e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id (first %))}))}
       [{:name ::transit/pre-notice-type
         :format pre-notice-type->str}
        {:name ::transit/route-description}

--- a/ote/src/cljs/ote/views/pre_notices/listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/listing.cljs
@@ -24,12 +24,16 @@
 (defn pre-notices-table [e! pre-notices state]
   (let [notices (filter #(= state (::transit/pre-notice-state %)) pre-notices)]
     [:div.row
-     [table/table {:name->label (tr-key [:pre-notice-list-page :headers])
-                   :key-fn ::transit/id
-                   :no-rows-message (case state
-                                      :draft (tr [:pre-notice-list-page :no-pre-notices-for-operator])
-                                      :sent (tr [:pre-notice-list-page :no-pre-notices-sent]))
-                   :on-select #(e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id (first %))}))}
+     [table/table (merge
+                    {:name->label (tr-key [:pre-notice-list-page :headers])
+                     :key-fn ::transit/id
+                     :no-rows-message (case state
+                                        :draft (tr [:pre-notice-list-page :no-pre-notices-for-operator])
+                                        :sent (tr [:pre-notice-list-page :no-pre-notices-sent]))}
+                    (when (= :sent state)
+                      {:on-select #(e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id (first %))}))
+                       :show-row-hover? true
+                       :row-style {:cursor "pointer"}}))
       [{:name ::transit/pre-notice-type
         :format pre-notice-type->str}
        {:name ::transit/route-description}

--- a/ote/src/cljs/ote/views/pre_notices/listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/listing.cljs
@@ -40,19 +40,20 @@
         :format (tr-key [:enums ::transit/pre-notice-state])}
        {:name :actions
         :read (fn [row]
-                [ui/icon-button {:href "#"
-                                 :on-click #(do
-                                              (.preventDefault %)
-                                              (e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id row)})))}
-                 (case state
-                   :draft [ic/content-create]
-                   :sent [ic/action-visibility])]
-                (when (= :draft state)
-                  [ui/icon-button {:href "#"
-                                   :on-click #(do
-                                                (.preventDefault %)
-                                                (e! (pre-notice/->DeletePreNotice row)))}
-                   [ic/action-delete]]))}]
+                [:div
+                 [ui/icon-button {:href "#"
+                                  :on-click #(do
+                                               (.preventDefault %)
+                                               (e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id row)})))}
+                  (case state
+                    :draft [ic/content-create]
+                    :sent [ic/action-visibility])]
+                 (when (= :draft state)
+                   [ui/icon-button {:href "#"
+                                    :on-click #(do
+                                                 (.preventDefault %)
+                                                 (e! (pre-notice/->DeletePreNotice row)))}
+                    [ic/action-delete]])])}]
       notices]]))
 
 (defn pre-notices [e! {:keys [transport-operator pre-notices delete-pre-notice-dialog] :as app}]

--- a/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
@@ -272,7 +272,7 @@
                      :disabled? true}
 
                     {:name :attachment-file
-                     :label (tr [:pre-notice-page :select-attachment])
+                     :button-label (tr [:pre-notice-page :select-attachment])
                      :type :file-and-delete
                      :disabled? sent?
                      :on-change #(e! (pre-notice/->UploadAttachment (.-target %)))

--- a/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
@@ -22,21 +22,23 @@
 (def notice-types [:termination :new :schedule-change :route-change :other])
 (def effective-date-descriptions [:year-start :school-start :school-end :season-schedule-change])
 
-(defn footer [e! pre-notice]
+(defn footer [e! sent? pre-notice]
   (let [valid-notice? (form/valid? pre-notice)]
     (when (not valid-notice?)
       [ui/card {:style {:margin "1em 0em 1em 0em"}}
        [ui/card-text {:style {:color "#be0000" :padding-bottom "0.6em"}} (tr [:pre-notice-page :publish-missing-required])]])
     [:div.col-xs-12.col-sm-6.col-md-6 {:style {:padding-top "20px"}}
-     [buttons/save {:disabled (not (form/valid? pre-notice))
-                    :on-click #(do
-                                 (.preventDefault %)
-                                 (e! (pre-notice/->OpenSendModal)))}
-      (tr [:buttons :save-and-send])]
-     [buttons/save {:on-click #(do
-                                 (.preventDefault %)
-                                 (e! (pre-notice/->SaveToDb false)))}
-      (tr [:buttons :save-as-draft])]
+     (when-not sent?
+       [:span
+        [buttons/save {:disabled (not (form/valid? pre-notice))
+                       :on-click #(do
+                                    (.preventDefault %)
+                                    (e! (pre-notice/->OpenSendModal)))}
+         (tr [:buttons :save-and-send])]
+        [buttons/save {:on-click #(do
+                                    (.preventDefault %)
+                                    (e! (pre-notice/->SaveToDb false)))}
+         (tr [:buttons :save-as-draft])]])
      [buttons/cancel {:on-click #(do
                                    (.preventDefault %)
                                    (e! (pre-notice/->CancelNotice)))}
@@ -250,11 +252,11 @@
                              [:div.col-md-8
                               [notice-area-map pre-notice]]])}))
 
-(defn notice-attachments [e!]
+(defn notice-attachments [e! sent?]
   (form/group
-    {:label   (tr [:pre-notice-page :attachment-section-title])
+    {:label (tr [:pre-notice-page :attachment-section-title])
      :columns 3
-     :layout  :row}
+     :layout :row}
     (form/info (tr [:form-help :pre-notice-attatchment-info]) {:type :generic})
 
     {:name ::transit/url
@@ -264,6 +266,7 @@
     {:name :attachments
      :type :table
      :add-label (tr [:pre-notice-page :add-attachment])
+     :add-label-disabled? (constantly sent?)
      :table-fields [{:name ::transit/attachment-file-name
                      :type :string
                      :disabled? true}
@@ -271,33 +274,32 @@
                     {:name :attachment-file
                      :label (tr [:pre-notice-page :select-attachment])
                      :type :file-and-delete
+                     :disabled? sent?
                      :on-change #(e! (pre-notice/->UploadAttachment (.-target %)))
                      :on-delete #(e! (pre-notice/->DeleteAttachment %))}]}))
 
 (defn- pre-notice-form [e! {:keys [pre-notice transport-operator] :as app}]
   (let [operators (mapv :transport-operator (:transport-operators-with-services app))
+        sent? (= :sent (::transit/pre-notice-state pre-notice))
         form-options {:name->label (tr-key [:field-labels :pre-notice])
-                      :footer-fn (r/partial footer e!)
-                      :update!   #(e! (pre-notice/->EditForm %))}]
+                      :footer-fn (r/partial footer e! sent?)
+                      :update! #(e! (pre-notice/->EditForm %))}]
     [:span
-    [:h1 (tr [:pre-notice-page :pre-notice-form-title])]
-    [select-operator e! transport-operator operators]
-    [form/form
-     form-options
-     [(transport-type e! app)
-      (effective-dates)
-      (notice-area e!)
-      (notice-attachments e!)]
-     pre-notice]
-     [pre-notice-send-modal e! app]]
-    ))
+     [:h1 (tr [:pre-notice-page :pre-notice-form-title])]
+     [select-operator e! transport-operator operators]
+     [form/form
+      form-options
+      [(transport-type e! app)
+       (effective-dates)
+       (notice-area e!)
+       (notice-attachments e! sent?)]
+      pre-notice]
+     [pre-notice-send-modal e! app]]))
 
-(defn new-pre-notice [e! {:keys [transport-operator] :as app}]
-    [pre-notice-form e! app])
+(defn new-pre-notice [e! app]
+  [pre-notice-form e! app])
 
-(defn edit-pre-notice-by-id [e! {:keys [pre-notice transport-operator] :as app}]
-  (if (or (nil? pre-notice) (= :loading pre-notice))
+(defn edit-pre-notice-by-id [e! {:keys [pre-notice] :as app}]
+  (if (or (nil? pre-notice) (:loading pre-notice))
     [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
-    (if (= (::transit/pre-notice-state pre-notice) :draft)
-      [pre-notice-form e! app]
-      [:span (tr [:pre-notice-page :sent-pre-notice-cannot-be-edited])])))
+    [pre-notice-form e! app]))


### PR DESCRIPTION
# Changed
* Type :file and :file-and-delete form fields can be now disabled.
* Added row-style and show-row-hover options for Table component.
* User can now view sent pre-notices by clicking sent pre notices list rows. (Opened in view-only-mode in edit path).
* Added mouse pointer and hover effects for pre-notices authority listing. [#157273507](https://www.pivotaltracker.com/story/show/157273507)
* Removed "Valitse tiedosto" table header from "Muutoksen tarkemmat tiedot" section and changed button translation to "Lisää liite". [#157251005](https://www.pivotaltracker.com/story/show/157251005)