### PR TITLE
156529732 Add gtfs visualization links and fix gtfs viewer route rendering

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -269,7 +269,8 @@
                                  :external-service-url "Direct URL to machine-readable interface. If a direct link is not available you can alternatively use a web-address with information about the interface and its use."
                                  :format "Select the data format. If the list does not have a format, you can add it by writing it in."
                                  :license "Specify which license or terms of use apply to your interface. If the list does not have the license you use, you can add it by writing it in."
-                                 :external-service-description "Specify additional information about the interface that may be useful for developers (e.g. about license). You may add a web-address that contains further information."}
+                                 :external-service-description "Specify additional information about the interface that may be useful for developers (e.g. about license). You may add a web-address that contains further information."
+                                 :view-routes "View routes"}
 
   :RAE-link-text "RAE-software"
   :SEA-ROUTE-link-text "Sea traffic route and timetable editor"

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1115,7 +1115,8 @@
   :total-services ["Catalog has total of " :total-service-count " services."]
   :fetching-more "Fetching more services..."
   :operator-services ["Transport operator " :name " has " :count " services"]
-  :operator-no-services "Transport operator has no services."}
+  :operator-no-services "Transport operator has no services."
+  :view-routes "View routes"}
 
  :login
  {:label "Login credentials"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -269,7 +269,8 @@
                                  :external-service-url "Ilmoita ensisijaisesti suora osoite koneluettavaan rajapintaan. Voit vaihtoehtoisesti ilmoittaa web-osoitteen, jossa kerrotaan tietoja rajapinnasta tai sen käytöstä."
                                  :format "Valitse listalta tietosisällön formaatti. Jos listalla ei ole käyttämääsi formaattia, voit lisätä sen kirjoittamalla."
                                  :license "Kerro, minkä lisenssin tai käyttöehtojen mukaisesti rajapintasi on julkaistu. Jos listalla ei ole käyttämääsi lisenssiä, voit lisätä sen kirjoittamalla."
-                                 :external-service-description "Kerro lisätietoja rajapintaasi liittyen, joista voisi olla hyötyä kehittäjille (esim. lisenssistä). Voit lisätä tähän kenttään myös web-osoitteen, josta lisätiedot löytyvät."}
+                                 :external-service-description "Kerro lisätietoja rajapintaasi liittyen, joista voisi olla hyötyä kehittäjille (esim. lisenssistä). Voit lisätä tähän kenttään myös web-osoitteen, josta lisätiedot löytyvät."
+                                 :view-routes "Katsele reittejä"}
   :RAE-link-text "Rae-työkalulla"
   :SEA-ROUTE-link-text "Merenkulun reitti - ja aikataulueditorilla"
   :companies-main-info "Mikäli palvelun tuottamiseen osallistuu muita yrityksiä tai palvelussa välitetään useiden yritysten palveluita, ilmoita kyseisten yritysten nimet ja y-tunnukset tässä osiossa. Tähän kohtaan tietoja tallentavat vain ne tahot, jotka koordinoivat palvelun tuottamista (esim. taksivälityskeskukset tai tilaava viranomainen). Tätä kohtaa eivät täytä ne yksittäiset yritykset, jotka ajavat välityskeskuksen kyytejä."

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1130,7 +1130,8 @@
   :total-services ["Palvelukatalogissa on yhteensä " :total-service-count " palvelua."]
   :fetching-more "Haetaan lisää palveluita..."
   :operator-services ["Palveluntuottajalla " :name " on " :count " palvelua."]
-  :operator-no-services "Palveluntuottajalla ei ole palveluita."}
+  :operator-no-services "Palveluntuottajalla ei ole palveluita."
+  :view-routes "Katsele reittejä"}
 
  :login
  {:label "Kirjautumistiedot"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1122,7 +1122,8 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :total-services [" Katalogen innehåller totalt " :total-service-count " tjänster."]
   :fetching-more "Sökning av tjänster pågår..."
   :operator-services ["Tjänsteproducenten" :name " har " :count " tjänster."]
-  :operator-no-services "Tjänsteproducenten har inga tjänster."}
+  :operator-no-services "Tjänsteproducenten har inga tjänster."
+  :view-routes "Visa rutter"}
 
  :login
  {:label "Inloggning"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -277,7 +277,8 @@
                                  :external-service-url "Ange i första hand ett direkt maskinläsbart gränssnitt. Om detta inte är ändamålsenligt ange då en webbadress för mera information om gränssnittet och dess användning."
                                  :format "Välj ett format i listan. Ifall lämpligt format saknas, fyll då i det själv."
                                  :license "Uppge licens eller användarvillkor för gränssnittet. Ifall lämpligt alternativ saknas, fyll då i det själv."
-                                 :external-service-description "Uppge sådan information som kan vara viktig för tjänsteutvecklare (t.ex. om licens). Du kan även uppge en webbadress med tilläggsuppgifter."}
+                                 :external-service-description "Uppge sådan information som kan vara viktig för tjänsteutvecklare (t.ex. om licens). Du kan även uppge en webbadress med tilläggsuppgifter."
+                                 :view-routes "Visa rutter"}
   :RAE-link-text "RAE-verktyg (läs mer på www.liikennevirasto.fi/rae)"
   :SEA-ROUTE-link-text " (Öppna rutteditorn för sjötrafik här)"
   :companies-main-info "Om tjänsten tillhandahålls av flera tjänsteproducenter eller om man via tjänsten förmedlar flera företags tjänster, fyll i företagens namn och FO-nummer här."

--- a/ote/src/cljs/ote/app/controller/gtfs_viewer.cljs
+++ b/ote/src/cljs/ote/app/controller/gtfs_viewer.cljs
@@ -34,7 +34,7 @@
    :app gtfs}
   (let [route-id (:gtfs/route-id route)
         trips (gq/route-trips gtfs route-id)
-        shape-ids (into #{} (map :gtfs/shape-id) trips)
+        shape-ids (into #{} (keep :gtfs/shape-id) trips)
         stop-sequences (gq/stop-sequences-for-trips gtfs trips)
         color (if (str/blank? (:gtfs/route-color route))
                 "#000000"

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -20,7 +20,7 @@
 (def action-button-container (merge inline-block
                                     {:margin-right "1em"}))
 
-(def icon-small {:width 16 :height 16
+(def icon-small {:width 20 :height 20
                  :vertical-align "middle"})
 
 (def icon-medium {:width 24 :height 24

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -60,14 +60,28 @@
   (let [comma (if (not (empty? street)) ", " " ")]
     (str street comma postal_code " " post_office)))
 
+(defn- gtfs-viewer-link [{interface ::t-service/external-interface [format] ::t-service/format}]
+  (let [format (str/lower-case format)]
+    (when (or (= "gtfs" format) (= "kalkati.net" format))
+      (common-ui/linkify
+        (str "#/routes/view-gtfs?url=" (::t-service/url interface)
+             (when (= "kalkati.net" format)
+               "&type=kalkati"))
+        [ui/flat-button {:label (tr [:service-search :view-routes])
+                         :primary true
+                         :label-position "before"
+                         :icon (ic/action-open-in-new)}]
+        {:target "_blank"}))))
+
 (def external-interface-table-columns
   ;; [label width value-fn]
-  [[:table-header-external-interface "20%"
+  [[:table-header-external-interface "25%"
     (comp #(common-ui/linkify % % {:target "_blank"}) ::t-service/url ::t-service/external-interface)]
    [::t-service/format-short "10%" (comp #(str/join ", " %) ::t-service/format)]
-   [::t-service/license "10%" ::t-service/license]
-   [::t-service/external-service-description "10%"
-    (comp #(t-service/localized-text-for "FI" %) ::t-service/description ::t-service/external-interface)]])
+   [::t-service/license "15%" ::t-service/license]
+   [::t-service/external-service-description "25%"
+    (comp #(t-service/localized-text-for "FI" %) ::t-service/description ::t-service/external-interface)]
+   [:gtfs-viewer "25%" (comp #(gtfs-viewer-link %))]])
 
 (defn parse-content-value [value-array]
   (let [data-content-value #(tr [:enums ::t-service/interface-data-content %])
@@ -80,7 +94,7 @@
   (when-not (empty? external-interface-links)
     [:div
      [:span.search-card-title {:style {:padding "0.5em 0em 1em 0em"}} (tr [:service-search :external-interfaces])]
-     [:table {:style {:margin-top "10px"}}
+     [:table {:style {:margin-top "10px" :width "100%"}}
       [:thead (stylefy/use-style style/external-interface-header)
        [:tr
         (doall
@@ -95,7 +109,7 @@
              ^{:key (str "external-table-row-" i)}
              [:tr {:style style/external-table-row}
               ^{:key (str "external-interface-" i)}
-              [:td {:style {:width "20%" :font-size "14px"}}
+              [:td {:style {:width "25%" :font-size "14px"}}
                (common-ui/linkify
                  (::t-service/url external-interface)
                  (if (nil? data-content)
@@ -103,9 +117,11 @@
                    (parse-content-value data-content))
                  {:target "_blank"})]
               [:td {:style {:width "10%" :font-size "14px"}} (str/join ", " format)]
-              [:td {:style {:width "10%" :font-size "14px"}} license]
-              [:td {:style {:width "10%" :font-size "14px"}}
-               (t-service/localized-text-for "FI" (::t-service/description external-interface))]])
+              [:td {:style {:width "15%" :font-size "14px"}} license]
+              [:td {:style {:width "25%" :font-size "14px"}}
+               (t-service/localized-text-for "FI" (::t-service/description external-interface))]
+              [:td {:style {:width "25%" :font-size "14px"}}
+               (gtfs-viewer-link row)]])
            external-interface-links))]]]))
 
 (defn- result-card [e! admin?


### PR DESCRIPTION
# Added
* Add a gtfs viewer links for GTFS and Kalkati.net file format in service catalog and service form next to external interfaces fields.
   
# Fixed
* Fixed a bug in GTFS viewer that prevented it rendering lines for routes that have no shape-data.
   
