### PR TITLE
157276910 Search only with full business id

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1117,7 +1117,7 @@
   :operators "Transport operator"
   :text-search-placeholder "Search by name"
   :operator-search "Transport operator"
-  :operator-search-placeholder "Search by name"
+  :operator-search-placeholder "Search by name or business id"
   :no-filters "Search for services by adding search criteria above"
   :result-count (:plural :count
                          "No services found"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1129,7 +1129,7 @@
   :operators "Palveluntuottajat"
   :text-search-placeholder "Hae nimellä tai sen osalla"
   :operator-search "Palveluntuottaja"
-  :operator-search-placeholder "Hae nimellä tai sen osalla"
+  :operator-search-placeholder "Hae nimellä tai y-tunnuksella"
   :no-filters "Hae palveluita syöttämällä hakuehdot yllä"
 
   :result-count ["Hakuehdoille "

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1123,7 +1123,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :operators "Tjänsteproducent"
   :text-search-placeholder "Sök med namn"
   :operator-search "Tjänsteproducent"
-  :operator-search-placeholder "Sök med namn"
+  :operator-search-placeholder "Sök med namn eller FO-nummer"
   :no-filters "Sök tjänster genom att fylla i uppgifter ovan"
   :result-count (:plural :count
                          "Inga resultat"

--- a/ote/src/clj/ote/services/service_search.clj
+++ b/ote/src/clj/ote/services/service_search.clj
@@ -82,7 +82,7 @@
   "Return a list of completions that match the given search term."
   [db term]
   (into [] (service-search-by-operator db {:name (str "%" term "%")
-                                           :businessid (str "%" term "%")})))
+                                           :businessid (str term )})))
 
 (defn- search [db {:keys [operation-area sub-type text operators offset limit]
                    :as filters}]

--- a/ote/src/clj/ote/services/service_search.sql
+++ b/ote/src/clj/ote/services/service_search.sql
@@ -34,14 +34,14 @@ SELECT COUNT(id) FROM "transport-service" WHERE "published?" = TRUE;
 -- Finds operators by name and by business-id and services that have companies added as "operators.
 SELECT op.name as "operator", op."business-id" as "business-id"
   FROM "transport-operator" op
- WHERE ( op.name ILIKE :name OR op."business-id" ILIKE :businessid)
+ WHERE ( op.name ILIKE :name OR op."business-id" = :businessid)
    AND op."deleted?" = FALSE
 UNION
 SELECT c.name as "operator", c."business-id" as "business-id"
   FROM "transport-service" s
   LEFT JOIN service_company sc ON sc."transport-service-id" = s.id
   JOIN LATERAL unnest(COALESCE(sc.companies, s.companies)) AS c ON TRUE
- WHERE (c.name ILIKE :name OR c."business-id" ILIKE :businessid)
+ WHERE (c.name ILIKE :name OR c."business-id" = :businessid)
    AND s."published?" = TRUE;
 
 -- name: service-ids-by-business-id


### PR DESCRIPTION
# Changed
* Update operator hint text to match operator search functionality.
* Remove like from business-id search. Only full business-id are a match in search from now on.
   