### PR TITLE
157994008 Pre-notice attachment file content type validation

### DIFF
--- a/nap/docker/nginx/proxy.conf
+++ b/nap/docker/nginx/proxy.conf
@@ -22,6 +22,7 @@ http {
     tcp_nodelay         on;
     keepalive_timeout   65;
     types_hash_max_size 2048;
+    client_max_body_size 33m;
 
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -844,6 +844,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :data-not-found                             "Data is not found"
   :required-field                             "Required field"
   :invalid-postal-code                        "Please, check the postalcode (5 numbers)"
+  :invalid-file-type                          "Invalid file type"
   :transport-service-saved                    "Transport service information has been saved!"
   :transport-operator-saved                   "Transport operator information has been saved!"
   :footer-livi-logo                           "Finnish Transport Aggency Logo"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -853,6 +853,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :data-not-found                             "Tietoja ei löytynyt"
   :required-field                             "Tieto vaaditaan"
   :invalid-postal-code                        "Tarkista postinumero (5 numeroa)"
+  :invalid-file-type                          "Virheellinen tiedostotyyppi"
   :transport-service-saved                    "Liikkumispalvelun tiedot tallennettu!"
   :transport-operator-saved                   "Palveluntarjoajan tiedot tallennettu!"
   :footer-livi-logo                           "Liikennevirasto Logo"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -849,6 +849,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :data-not-found                             "Inga uppgifter hittades"
   :required-field                             "Obligatorisk uppgift"
   :invalid-postal-code                        "Kolla postnumret (5 siffror)"
+  :invalid-file-type                          "Ogiltig filtyp"
   :transport-service-saved                    "Uppgifterna sparade!"
   :transport-operator-saved                   "Uppgifterna sparade!"
   :footer-livi-logo                           "Liikennevirasto Logo"

--- a/ote/src/clj/ote/services/pre_notices/attachments.clj
+++ b/ote/src/clj/ote/services/pre_notices/attachments.clj
@@ -46,7 +46,7 @@
         (case msg
           "Invalid file type"
           {:status 422
-           :body (str "Invalid file type.")}
+           :body "Invalid file type."}
           {:status 500
            :body msg})))))
 

--- a/ote/src/clj/ote/services/pre_notices/attachments.clj
+++ b/ote/src/clj/ote/services/pre_notices/attachments.clj
@@ -14,10 +14,10 @@
             [ote.nap.users :as users])
   (:import (java.nio.file Files)))
 
+(def allowed-mime-types ["application/pdf" "image/jpeg" "image/png"])
+
 (defn- generate-file-key [id filename]
   (str id "_" filename))
-
-(def allowed-mime-types ["application/pdf" "image/jpeg" "image/png"])
 
 (defn validate-file [{:keys [tempfile]}]
   (let [path (.toPath tempfile)

--- a/ote/src/clj/ote/services/pre_notices/attachments.clj
+++ b/ote/src/clj/ote/services/pre_notices/attachments.clj
@@ -14,7 +14,7 @@
             [ote.nap.users :as users])
   (:import (java.nio.file Files)))
 
-(def allowed-mime-types ["application/pdf" "image/jpeg" "image/png"])
+(def allowed-mime-types #{"application/pdf" "image/jpeg" "image/png"})
 
 (defn- generate-file-key [id filename]
   (str id "_" filename))
@@ -22,7 +22,7 @@
 (defn validate-file [{:keys [tempfile]}]
   (let [path (.toPath tempfile)
         content-mime (Files/probeContentType path)]
-    (when-not (some #(= % content-mime) allowed-mime-types)
+    (when-not (allowed-mime-types content-mime)
       (throw (ex-info "Invalid file type" {:file-type content-mime})))))
 
 (defn upload-attachment [db {bucket :bucket :as config} {user :user :as req}]

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -151,15 +151,18 @@
                         (on-enter))}))])
 
 (defmethod field :file-and-delete [{:keys [on-delete table-data row-number disabled?] :as f} data]
-  (if (empty? (get table-data row-number))
-    (field (assoc f :type :file))
-    [ui/icon-button (merge
-                      {:on-click #(on-delete row-number)}
-                      (when disabled?
-                        {:disabled true}))
-     [ic/action-delete]]))
+  (let [row-data (get table-data row-number)]
+    (if (or (empty? row-data) (:error row-data))
+      (field (assoc f :type :file
+                      :error (:error row-data)))
+      [ui/icon-button (merge
+                        {:on-click #(on-delete row-number)}
+                        (when disabled?
+                          {:disabled true}))
+       [ic/action-delete]])))
 
-(defmethod field :file [{:keys [label button-label name disabled? on-change]
+(defmethod field :file [{:keys [label button-label name disabled? on-change
+                                error warning]
                          :as field} data]
   [:div (stylefy/use-style style-form-fields/file-button-wrapper)
    [:button (merge
@@ -178,7 +181,10 @@
             ;; String with space -> hide title on Chrome, FireFox and some other browsers. Not 100% reliable.
             :title " "}
            (when disabled?
-             {:disabled true}))]])
+             {:disabled true}))]
+   (when (or error warning)
+     [:div (stylefy/use-style style-base/required-element)
+      (if error error warning)])])
 
 (defmethod field :text-area [{:keys [update! table? label name rows error tooltip tooltip-length
                                      max-length on-blur warning full-width?


### PR DESCRIPTION
# Added
* File content validation for pre-notice form attachments. Allowed file types are now pdf, jpeg and png.

# Environment
* Increased nginx max request body size to 33MB.
