### PR TITLE
156606540 Unsaved changes prompt for all major forms, state and routing management improvements.

### DIFF
--- a/ote/src/cljs/ote/app/controller/pre_notices.cljs
+++ b/ote/src/cljs/ote/app/controller/pre_notices.cljs
@@ -145,12 +145,15 @@
 
   EditSingleFormElement
   (process-event [{element :element data :data} app]
-    (assoc-in app [:pre-notice element] data))
+    (-> app
+        (assoc-in [:pre-notice element] data)
+        (assoc :before-unload-message (tr [:dialog :navigation-prompt :unsaved-data]))))
 
   EditForm
   (process-event [{form-data :form-data} app]
     (-> app
-        (update :pre-notice merge form-data)))
+        (update :pre-notice merge form-data)
+        (assoc :before-unload-message (tr [:dialog :navigation-prompt :unsaved-data]))))
 
   OpenSendModal
   (process-event [_ app]
@@ -172,16 +175,17 @@
       (comm/post! "pre-notice" notice
                   {:on-success (tuck/send-async! ->SaveNoticeResponse)
                    :on-failure (tuck/send-async! ->SaveNoticeFailure)})
-      (dissoc app :before-unload-message)))
+      app))
 
   SaveNoticeResponse
   (process-event [{response :response} app]
     (routes/navigate! :pre-notices)
     ;; TODO: when published? true, use save-success-send
     (-> app
-        (assoc :flash-message (tr [:pre-notice-page :save-success]))
-        (dissoc :pre-notice)
-        (assoc :page :pre-notices)))
+        (dissoc :pre-notice
+                :before-unload-message)
+        (assoc :flash-message (tr [:pre-notice-page :save-success])
+               :page :pre-notices)))
 
   SaveNoticeFailure
   (process-event [{response :response} app]
@@ -193,8 +197,7 @@
   CancelNotice
   (process-event [_ app]
     (routes/navigate! :pre-notices)
-    (-> app
-        (dissoc :pre-notice)))
+    app)
 
   DeleteEffectiveDate
   (process-event [{id :id} app]
@@ -213,11 +216,13 @@
                 :on-failure (tuck/send-async! ->ServerError)})))
 
 (define-event SelectedRegions [regions]
-  {:path [:pre-notice]}
+  {}
   (let [region-ids (mapv :id regions)]
     ;; Get locations for all regions
-    (load-region-geojson app region-ids)
-    (assoc app ::transit/regions region-ids)))
+    (load-region-geojson (:pre-notice app) region-ids)
+    (-> app
+        (assoc-in [:pre-notice ::transit/regions] region-ids)
+        (assoc :before-unload-message (tr [:dialog :navigation-prompt :unsaved-data])))))
 
 (define-event ShowPreNoticeResponse [response]
   {:path [:pre-notice-dialog]}
@@ -252,8 +257,11 @@
   (update app :pre-notice-dialog dissoc :new-comment))
 
 (define-event UploadResponse [response]
-  {:path [:pre-notice :attachments]}
-  (conj (or (vec (butlast app)) []) response))
+  {}
+  (-> app
+      (update-in [:pre-notice :attachments]
+                 #(conj (or (vec (butlast %)) []) response))
+      (assoc :before-unload-message (tr [:dialog :navigation-prompt :unsaved-data]))))
 
 (define-event UploadAttachment [input]
   {}
@@ -272,8 +280,11 @@
 
 (define-event DeleteAttachment [row-index]
   {:path [:pre-notice :attachments]}
-  (vec (concat (take row-index app)
-           (drop (inc row-index) app))))
+  (-> app
+      (update-in [:pre-notice :attachments]
+                 #(vec (concat (take row-index %)
+                               (drop (inc row-index) %))))
+      (assoc :before-unload-message (tr [:dialog :navigation-prompt :unsaved-data]))))
 
 (defn load-regions-from-server []
   (comm/get! "pre-notices/regions"

--- a/ote/src/cljs/ote/app/controller/route/route_list.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_list.cljs
@@ -52,11 +52,7 @@
   CreateNewRoute
   (process-event [_ app]
     (routes/navigate! :new-route)
-    (-> app
-        (dissoc :route)
-        (assoc-in [:route :step] :basic-info)
-        (assoc-in [:route ::transit/route-type] :ferry)
-        (assoc-in [:route ::transit/transport-operator-id] (get-in app [:transport-operator ::t-operator/id]))))
+    app)
 
   OpenDeleteRouteModal
   (process-event [{id :id} app]

--- a/ote/src/cljs/ote/app/controller/transport_service.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_service.cljs
@@ -384,13 +384,14 @@
               transform-save-by-type)]
 
       ;; Disable post if concurrent save event is in progress
-      (when-not (:service-save-in-progress app)
+      (if (not (:service-save-in-progress app))
         (do
           (comm/post! "transport-service" service-data
                       {:on-success (tuck/send-async! ->SaveTransportServiceResponse)
                        :on-failure (tuck/send-async! ->FailedTransportServiceResponse)})
           (-> app
-              (assoc :service-save-in-progress true))))))
+              (assoc :service-save-in-progress true)))
+        app)))
 
   SaveTransportServiceResponse
   (process-event [{response :response} app]

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -85,27 +85,29 @@
                ;; Open confirmation dialog and only go to new page
                ;; if the user confirms navigation.
                (assoc app
-                      :navigation-prompt-open? true
-                      :navigation-confirm (go-to-url-event new-url)))
+                 :navigation-prompt-open? true
+                 :navigation-confirm (go-to-url-event new-url)))
 
-             (let [navigation-data {:page   name
-                                    :params params
-                                    :query  query
-                                    :url    js/window.location.href}
-                   event (on-navigate-event navigation-data)
-                   orig-app app
-                   app (merge app navigation-data)]
+             (if (not= (:url app) js/window.location.href)
+               (let [navigation-data {:page name
+                                      :params params
+                                      :query query
+                                      :url js/window.location.href}
+                     event (on-navigate-event navigation-data)
+                     orig-app app
+                     app (merge app navigation-data)]
 
-               (if (requires-authentication? app)
-                 (do (navigate! :front-page)
-                     (assoc orig-app
-                            :login {:show?       true
-                                    :navigate-to navigation-data}))
-                 (do
-                   ;; Send startup events (if any) immediately after returning from this swap
-                   (when event
-                     (.setTimeout js/window #(send-startup-events event) 0))
-                   app)))))))
+                 (if (requires-authentication? app)
+                   (do (navigate! :front-page)
+                       (assoc orig-app
+                         :login {:show? true
+                                 :navigate-to navigation-data}))
+                   (do
+                     ;; Send startup events (if any) immediately after returning from this swap
+                     (when event
+                       (.setTimeout js/window #(send-startup-events event) 0))
+                     app)))
+               app)))))
 
 (defn start! [go-to-url-event]
   (r/start! ote-router {:default :front-page

--- a/ote/src/cljs/ote/views/route.cljs
+++ b/ote/src/cljs/ote/views/route.cljs
@@ -35,27 +35,28 @@
       [ui/card-text {:style {:color "#be0000" :padding-bottom "0.6em"}} (tr [:route-wizard-page :publish-missing-required])]])])
 
 (defn new-route [e! app]
-  [:span
-   [form-container e! app]
-   [:div.col-xs-12.col-sm-6.col-md-6 {:style {:padding-top "20px"}}
-    [buttons/save {:disabled (not (rw/valid-route? (:route app)))
-                   :on-click #(do
-                                (.preventDefault %)
-                                (e! (rw/->SaveToDb true)))}
-     (tr [:buttons :save-and-publish])]
-    [buttons/save {:disabled (not (rw/valid-route-name? (get-in app [:route ::transit/name])))
-                   :on-click #(do
-                                (.preventDefault %)
-                                (e! (rw/->SaveToDb false)))}
-     (tr [:buttons :save-as-draft])]
-    [buttons/cancel {:on-click #(do
+  (when-not (nil? (:route app))
+    [:span
+     [form-container e! app]
+     [:div.col-xs-12.col-sm-6.col-md-6 {:style {:padding-top "20px"}}
+      [buttons/save {:disabled (not (rw/valid-route? (:route app)))
+                     :on-click #(do
                                   (.preventDefault %)
-                                  (e! (rw/->CancelRoute)))}
-     (tr [:buttons :cancel])]]])
+                                  (e! (rw/->SaveToDb true)))}
+       (tr [:buttons :save-and-publish])]
+      [buttons/save {:disabled (not (rw/valid-route-name? (get-in app [:route ::transit/name])))
+                     :on-click #(do
+                                  (.preventDefault %)
+                                  (e! (rw/->SaveToDb false)))}
+       (tr [:buttons :save-as-draft])]
+      [buttons/cancel {:on-click #(do
+                                    (.preventDefault %)
+                                    (e! (rw/->CancelRoute)))}
+       (tr [:buttons :cancel])]]]))
 
-(defn edit-route-by-id [e! app]
-  (e! (rw/->LoadRoute (get-in app [:params :id])))
-  (fn [e! app]
+(defn edit-route-by-id [e! {route :route :as app}]
+  (if (or (nil? route) (:loading? route))
+    [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]
     [:span
      [form-container e! app]
      [:div.col-xs-12.col-sm-6.col-md-6 {:style {:padding-top "20px"}}
@@ -68,8 +69,8 @@
           (tr [:buttons :save])]
          [buttons/save {:disabled (not (rw/valid-route-name? (get-in app [:route ::transit/name])))
                         :on-click #(do
-                                  (.preventDefault %)
-                                  (e! (rw/->SaveToDb false)))}
+                                     (.preventDefault %)
+                                     (e! (rw/->SaveToDb false)))}
           (tr [:buttons :back-to-draft])]]
         [:span
          [buttons/save {:disabled (not (rw/valid-route? (:route app)))
@@ -79,9 +80,9 @@
           (tr [:buttons :save-and-publish])]
          [buttons/save {:disabled (not (rw/valid-name (:route app)))
                         :on-click #(do
-                                  (.preventDefault %)
-                                  (e! (rw/->SaveToDb false)))}
-           (tr [:buttons :save-as-draft])]])
+                                     (.preventDefault %)
+                                     (e! (rw/->SaveToDb false)))}
+          (tr [:buttons :save-as-draft])]])
       [buttons/cancel {:on-click #(do
                                     (.preventDefault %)
                                     (e! (rw/->CancelRoute)))}


### PR DESCRIPTION
# Added
* Added on-leave-event in the app router, for invoking events when the user is leaving from the current route.
   
# Fixed
* Prevent  router triggering on-navigate-event twice times when pressing the browser back button.
* Improved sea-route state handling and fixed some issues related to sea-route state management.

# Changed
* Show a warning prompt if trying to cancel form creation / edit when there is unchanged data in the following forms: sea route, pre-notice or service form.
