### PR TITLE
Use sent timestamp in authority pre-notices listing

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -768,6 +768,7 @@ You can also draw the operating area or point to the map with drawing tools. You
 
   :headers {:ote.db.transit/id "ID"
             :ote.db.transit/regions "Regions"
+            :ote.db.transit/sent "Published"
             :ote.db.transit/pre-notice-type "Notice type"
             :ote.db.transit/pre-notice-state "State"
             :ote.db.modification/created "Created"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -774,6 +774,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
 
   :headers {:ote.db.transit/id "ID"
             :ote.db.transit/regions "Maakunta"
+            :ote.db.transit/sent "Julkaistu"
             :ote.db.transit/pre-notice-type "Ilmoitustyyppi"
             :ote.db.transit/pre-notice-state "Tila"
             :ote.db.modification/created "Luotu"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -770,6 +770,7 @@ Man måste vara inloggad för att digitalisera eller publicera mobilitetstjänst
 
   :headers {:ote.db.transit/id "ID"
             :ote.db.transit/regions "Landskap"
+            :ote.db.transit/sent "Publicerad"
             :ote.db.transit/pre-notice-type "Typ av meddelande"
             :ote.db.transit/pre-notice-state "Status"
             :ote.db.modification/created "Skapad"

--- a/ote/src/clj/ote/services/pre_notices/authority.clj
+++ b/ote/src/clj/ote/services/pre_notices/authority.clj
@@ -17,13 +17,14 @@
 (defn list-published-notices [db user]
   (specql/fetch db ::transit/pre-notice
                 #{::transit/id
+                  ::transit/sent
                   ::modification/created
                   ::transit/regions
                   ::transit/route-description
                   ::transit/pre-notice-type
                   [::t-operator/transport-operator #{::t-operator/name}]}
                 {::transit/pre-notice-state :sent}
-                {:specql.core/order-by ::modification/created
+                {:specql.core/order-by ::transit/sent
                  :specql.core/order-direction :desc}))
 
 (def comment-columns  (conj (specql/columns ::transit/pre-notice-comment)

--- a/ote/src/cljs/ote/views/pre_notices/authority_listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/authority_listing.cljs
@@ -111,7 +111,7 @@
             (mapcat
              (fn [[key fmt]]
                [[:b (str (tr* key) ": ")] (fmt (get pre-notice key))])
-             [[::modification/created time/format-timestamp-for-ui]
+             [[::transit/sent time/format-timestamp-for-ui]
               [::t-operator/transport-operator format-transport-operator]
               [::transit/pre-notice-type format-notice-types]
               [::transit/route-description str]
@@ -149,7 +149,7 @@
                     :row-style {:cursor "pointer"}
                     :show-row-hover? true
                     :on-select #(e! (pre-notice/->ShowPreNotice (::transit/id (first %))))}
-       [{:name ::modification/created :format (comp str time/format-timestamp-for-ui)}
+       [{:name ::transit/sent :format (comp str time/format-timestamp-for-ui)}
         {:name ::transit/regions :format region-name}
         {:name ::transit/pre-notice-type
          :format format-notice-types}


### PR DESCRIPTION
# Fixed
* Use sent timestamp in authority pre-notices listing.

