### PR TITLE
159068982 - Send app hash route changes to GA.

### DIFF
--- a/ote/src/clj/ote/services/index.clj
+++ b/ote/src/clj/ote/services/index.clj
@@ -95,7 +95,10 @@
              {:id "main-body"
               :onload "ote.main.main();"
               :features flags
-              :data-language localization/*language*}
+              :data-language localization/*language*
+              :data-ga-tracking-code (:tracking-code ga-conf)}
+             (when dev-mode?
+               {:data-dev-mode? true})
              (when (bound? #'anti-forgery/*anti-forgery-token*)
                {:data-anti-csrf-token anti-forgery/*anti-forgery-token*}))
       [:div#oteapp]

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -5,6 +5,12 @@
             [tuck.core :as tuck]
             [ote.util.fn :refer [flip]]))
 
+(def ga-tracking-code
+  (.getAttribute js/document.body "data-ga-tracking-code"))
+
+(def dev-mode?
+  (.getAttribute js/document.body "data-dev-mode?"))
+
 (def ote-router
   (r/router
    [["/" :front-page]
@@ -83,7 +89,7 @@
 
 (declare navigate!)
 
-(defn- on-navigate [go-to-url-event name params query]
+(defn- on-navigate [go-to-url-event route-name params query]
   (swap! state/app
          (fn [{:keys [before-unload-message navigation-prompt-open? url] :as app}]
            (if (and before-unload-message (not navigation-prompt-open?))
@@ -98,7 +104,7 @@
                  :navigation-confirm (go-to-url-event new-url)))
 
              (if (not= (:url app) js/window.location.href)
-               (let [navigation-data {:page name
+               (let [navigation-data {:page route-name
                                       :params params
                                       :query query
                                       :url js/window.location.href}
@@ -117,7 +123,17 @@
                    (do
                      ;; Send startup events (if any) immediately after returning from this swap
                      (when (or event-leave event-to)
-                       (.setTimeout js/window #(send-startup-events (vec (concat event-leave event-to))) 0))
+                       (.setTimeout
+                         js/window
+                         (fn []
+                           (send-startup-events (vec (concat event-leave event-to)))
+
+                           (when-not dev-mode?
+                             (js/gtag "config"
+                                      ga-tracking-code
+                                      #js {"anonymize_ip" true
+                                           "page_path" (subs js/window.location.hash 1)})))
+                         0))
                      app)))
                app)))))
 


### PR DESCRIPTION
# Changed
* App hash route changes are now sent to Google Analytics for more granular user behaviour analyzing.