### PR TITLE
158486660 Show a notice in search results if GTFS viewer cannot be used.

### DIFF
--- a/database/src/main/resources/db/migration/V1_102__external_interfaces_search_import_errors.sql
+++ b/database/src/main/resources/db/migration/V1_102__external_interfaces_search_import_errors.sql
@@ -1,0 +1,27 @@
+-- Add data about GTFS import errors in service search results
+
+ALTER TYPE external_interface_search_result
+  ADD ATTRIBUTE "gtfs-import-error" TEXT,
+  ADD ATTRIBUTE "gtfs-db-error" TEXT;
+
+-- Drop old
+DROP VIEW transport_service_search_result;
+
+-- Create new with external interface GTFS import errors
+CREATE VIEW transport_service_search_result AS
+  SELECT t.*, op.name as "operator-name", op."business-id" as "business-id",
+              (SELECT sc."companies"
+               FROM "service_company" sc
+               WHERE sc."transport-service-id" = t.id) AS "service-companies",
+              (SELECT array_agg(oaf."operation-area")
+               FROM "operation-area-facet" oaf
+               WHERE oaf."transport-service-id" = t.id) AS "operation-area-description",
+              (SELECT array_agg(ROW(ei."external-interface", ei.format,
+                                ei."ckan-resource-id",
+                                ei.license, ei."data-content",
+                                ei."gtfs-import-error",
+                                ei."gtfs-db-error")::external_interface_search_result)
+               FROM "external-interface-description" ei
+               WHERE ei."transport-service-id" = t.id)::external_interface_search_result[] AS "external-interface-links"
+  FROM "transport-service" t
+    JOIN  "transport-operator" op ON op.id = t."transport-operator-id";

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1178,6 +1178,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :operator-services ["Transport operator " :name " has " :count " services"]
   :operator-no-services "Transport operator has no services."
   :view-routes "View routes"
+  :view-routes-failure "Route viewing not possible"
   :load-csv-file "Load csv file"
   :data-content-search-label "Interface content"
   :other-involved-companies "Other companies providing the service"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1192,6 +1192,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :operator-services ["Palveluntuottajalla " :name " on " :count " palvelua."]
   :operator-no-services "Palveluntuottajalla ei ole palveluita."
   :view-routes "Katsele reittejä"
+  :view-routes-failure "Reittejä ei voi katsella"
   :load-csv-file "Lataa csv tiedosto"
   :data-content-search-label "Rajapinnan sisältö"
   :other-involved-companies "Muut palvelun tuottamiseen osallistuvat yritykset"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1178,6 +1178,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :operator-services ["Tjänsteproducenten" :name " har " :count " tjänster."]
   :operator-no-services "Tjänsteproducenten har inga tjänster."
   :view-routes "Visa rutter"
+  :view-routes-failure "Reittejä ei voi katsella"
   :load-csv-file "Ladda csv"
   :data-content-search-label "Gränssnittsinnehåll"
   :other-involved-companies "De företag som producerar tjänsten"

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -78,7 +78,9 @@
               [ic/action-open-in-new {:style {:position "relative" :top "6px" :color "#06c" :padding-right "3px"}}]
               (tr [:service-search :view-routes])]
              {:target "_blank"})
-           (tr [:service-search :view-routes-failure]))]))))
+           [:span
+            [ic/alert-warning {:style {:position "relative" :top "6px" :color "#f80" :padding-right "3px"}}]
+            (tr [:service-search :view-routes-failure])])]))))
 
 (defn parse-content-value [value-array]
   (let [data-content-value #(tr [:enums ::t-service/interface-data-content %])

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -62,20 +62,23 @@
   (let [comma (if (not (empty? street)) ", " " ")]
     (str street comma postal_code " " post_office)))
 
-(defn- gtfs-viewer-link [{interface ::t-service/external-interface [format] ::t-service/format}]
+(defn- gtfs-viewer-link [{interface ::t-service/external-interface [format] ::t-service/format
+                          has-errors? :has-errors?}]
   (when format
     (let [format (str/lower-case format)]
       (when (or (= "gtfs" format) (= "kalkati.net" format))
         [:span " | "
-         (common-ui/linkify
-           (str "#/routes/view-gtfs?url=" (.encodeURIComponent js/window
-                                                               (::t-service/url interface))
-                (when (= "kalkati.net" format)
-                  "&type=kalkati"))
-           [:span
-            [ic/action-open-in-new {:style {:position "relative" :top "6px" :color "#06c" :padding-right "3px"}}]
-            (tr [:service-search :view-routes])]
-           {:target "_blank"})]))))
+         (if-not has-errors?
+           (common-ui/linkify
+             (str "#/routes/view-gtfs?url=" (.encodeURIComponent js/window
+                                                                 (::t-service/url interface))
+                  (when (= "kalkati.net" format)
+                    "&type=kalkati"))
+             [:span
+              [ic/action-open-in-new {:style {:position "relative" :top "6px" :color "#06c" :padding-right "3px"}}]
+              (tr [:service-search :view-routes])]
+             {:target "_blank"})
+           (tr [:service-search :view-routes-failure]))]))))
 
 (defn parse-content-value [value-array]
   (let [data-content-value #(tr [:enums ::t-service/interface-data-content %])


### PR DESCRIPTION
# Added
* Show an error msg in service search results in external interfaces section if GTFS viewer cannot be used (i.e. GTFS import failed).
