### PR TITLE
159885008 Fix critical bugs in timestamp formatting in ote.time.

### DIFF
--- a/ote/src/cljc/ote/time.cljc
+++ b/ote/src/cljc/ote/time.cljc
@@ -31,26 +31,29 @@
 (s/def ::specql-data-types/time #(instance? Time %))
 
 #?(:cljs
-(defn format-timestamp-for-ui [time]
-  (if  (nil? time)
+(defn format-timestamp-for-ui [timestring]
+  (if  (nil? timestring)
     " " ;: if nil - print empty string
-    (->> time
+    (->> timestring
+         coerce/from-string
          t/to-default-time-zone
          (format/unparse (format/formatter "dd.MM.yyyy HH:mm"))))))
 
 #?(:cljs
-   (defn format-timestamp->date-for-ui [time]
-     (if  (nil? time)
+   (defn format-timestamp->date-for-ui [timestring]
+     (if  (nil? timestring)
        " " ;: if nil - print empty string
-       (->> time
+       (->> timestring
+            coerce/from-string
             t/to-default-time-zone
             (format/unparse (format/formatter "dd.MM.yyyy"))))))
 
 #?(:cljs
-   (defn date-fields-from-timestamp [timestamp]
-     (if  (nil? timestamp)
+   (defn date-fields-from-timestamp [timestring]
+     (if  (nil? timestring)
        nil
-       (->> timestamp
+       (->> timestring
+            coerce/from-string
             t/to-default-time-zone
             (date-fields)))))
 

--- a/ote/src/cljc/ote/time.cljc
+++ b/ote/src/cljc/ote/time.cljc
@@ -31,35 +31,26 @@
 (s/def ::specql-data-types/time #(instance? Time %))
 
 #?(:cljs
-   (defn format-timestamp-for-ui [timestamp]
-     (if (nil? timestamp)
+   (defn format-timestamp-for-ui [dt]
+     (if (nil? dt)
        " " ;: if nil - print empty string
-       (->>
-         (if (string? timestamp)
-           (coerce/from-string timestamp)
-           timestamp)
+       (->> dt
          t/to-default-time-zone
          (format/unparse (format/formatter "dd.MM.yyyy HH:mm"))))))
 
 #?(:cljs
-   (defn format-timestamp->date-for-ui [timestamp]
-     (if (nil? timestamp)
+   (defn format-timestamp->date-for-ui [dt]
+     (if (nil? dt)
        " " ;: if nil - print empty string
-       (->>
-         (if (string? timestamp)
-           (coerce/from-string timestamp)
-           timestamp)
+       (->> dt
          t/to-default-time-zone
          (format/unparse (format/formatter "dd.MM.yyyy"))))))
 
 #?(:cljs
-   (defn date-fields-from-timestamp [timestamp]
-     (if (nil? timestamp)
+   (defn date-fields-from-timestamp [dt]
+     (if (nil? dt)
        nil
-       (->>
-         (if (string? timestamp)
-           (coerce/from-string timestamp)
-           timestamp)
+       (->> dt
          t/to-default-time-zone
          (date-fields)))))
 

--- a/ote/src/cljc/ote/time.cljc
+++ b/ote/src/cljc/ote/time.cljc
@@ -31,31 +31,37 @@
 (s/def ::specql-data-types/time #(instance? Time %))
 
 #?(:cljs
-(defn format-timestamp-for-ui [timestring]
-  (if  (nil? timestring)
-    " " ;: if nil - print empty string
-    (->> timestring
-         coerce/from-string
+   (defn format-timestamp-for-ui [timestamp]
+     (if (nil? timestamp)
+       " " ;: if nil - print empty string
+       (->>
+         (if (string? timestamp)
+           (coerce/from-string timestamp)
+           timestamp)
          t/to-default-time-zone
          (format/unparse (format/formatter "dd.MM.yyyy HH:mm"))))))
 
 #?(:cljs
-   (defn format-timestamp->date-for-ui [timestring]
-     (if  (nil? timestring)
+   (defn format-timestamp->date-for-ui [timestamp]
+     (if (nil? timestamp)
        " " ;: if nil - print empty string
-       (->> timestring
-            coerce/from-string
-            t/to-default-time-zone
-            (format/unparse (format/formatter "dd.MM.yyyy"))))))
+       (->>
+         (if (string? timestamp)
+           (coerce/from-string timestamp)
+           timestamp)
+         t/to-default-time-zone
+         (format/unparse (format/formatter "dd.MM.yyyy"))))))
 
 #?(:cljs
-   (defn date-fields-from-timestamp [timestring]
-     (if  (nil? timestring)
+   (defn date-fields-from-timestamp [timestamp]
+     (if (nil? timestamp)
        nil
-       (->> timestring
-            coerce/from-string
-            t/to-default-time-zone
-            (date-fields)))))
+       (->>
+         (if (string? timestamp)
+           (coerce/from-string timestamp)
+           timestamp)
+         t/to-default-time-zone
+         (date-fields)))))
 
 #?(:cljs
    (defn format-js-time [time]

--- a/ote/src/cljs/ote/views/ckan_service_viewer.cljs
+++ b/ote/src/cljs/ote/views/ckan_service_viewer.cljs
@@ -20,7 +20,8 @@
             [reagent.core :as r]
             [ote.util.values :as values]
             cljsjs.leaflet
-            [ote.time :as time]))
+            [ote.time :as time]
+            [cljs-time.coerce :as coerce]))
 
 (defn ignore-key? [key]
   (let [ends-with-keys-to-ignore ["-imported" "-csv-url" "operator-id"]
@@ -37,8 +38,8 @@
 (defmethod transform-value "homepage" [_ value] (linkify value value {:target "_blank"}))
 (defmethod transform-value "csv-url" [_ value] (linkify value (tr [:service-search :load-csv-file]) {:target "_blank"}))
 (defmethod transform-value "contact-email" [_ value] (linkify (str "mailto:" value) value))
-(defmethod transform-value "available-to" [_ value] (time/format-timestamp->date-for-ui value))
-(defmethod transform-value "available-from" [_ value] (time/format-timestamp->date-for-ui value))
+(defmethod transform-value "available-to" [_ value] (time/format-timestamp->date-for-ui (coerce/from-string value)))
+(defmethod transform-value "available-from" [_ value] (time/format-timestamp->date-for-ui (coerce/from-string value)))
 (defmethod transform-value "maximum-stay" [_ value]
   (when value
     (let [interval (time/iso-8601-period->interval value)]


### PR DESCRIPTION
# Fixed
* Fixed bugs in timestamp conversion in ote.time. Previously, the convert functions just returned todays date no matter what timestring was used as a parameter.
