### PR TITLE
157991591 Use a secured url for the osm tile layer.

### DIFF
--- a/ote/src/cljs/ote/ui/leaflet.cljs
+++ b/ote/src/cljs/ote/ui/leaflet.cljs
@@ -87,7 +87,7 @@
     (.addControl m zoom)))
 
 (defn background-tile-map []
-  [TileLayer {:url "http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+  [TileLayer {:url "https://{s}.tile.osm.org/{z}/{x}/{y}.png"
               :attribution "&copy; <a href=\"https://gist.github.com/hrbrmstr/91ea5cc9474286c72838\">Continents</a>
 | &copy; <a href=\"https://www.maanmittauslaitos.fi/en/opendata-licence-cc40\">MML</a>
 | &copy; <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors<br>"}])


### PR DESCRIPTION
# Fixed
* Use a secured url for the osm tile layer. Prevents mixed content warnings in production.
