### PR TITLE
160162515 Add missing companies info in search results

### DIFF
--- a/database/src/main/resources/db/migration/V1_107__add_companies_from_ts_companies.sql
+++ b/database/src/main/resources/db/migration/V1_107__add_companies_from_ts_companies.sql
@@ -1,0 +1,23 @@
+-- Drop old
+DROP VIEW transport_service_search_result;
+
+-- Create new with t.companies in service-companies
+CREATE VIEW transport_service_search_result AS
+  SELECT t.*, op.name as "operator-name", op."business-id" as "business-id",
+              -- Changed Start
+              COALESCE((SELECT sc."companies"
+                          FROM "service_company" sc
+                         WHERE sc."transport-service-id" = t.id), t."companies") AS "service-companies",
+              -- Changed End
+              (SELECT array_agg(oaf."operation-area")
+               FROM "operation-area-facet" oaf
+               WHERE oaf."transport-service-id" = t.id) AS "operation-area-description",
+              (SELECT array_agg(ROW(ei."external-interface", ei.format,
+                                ei."ckan-resource-id",
+                                ei.license, ei."data-content",
+                                ei."gtfs-import-error",
+                                ei."gtfs-db-error")::external_interface_search_result)
+               FROM "external-interface-description" ei
+               WHERE ei."transport-service-id" = t.id)::external_interface_search_result[] AS "external-interface-links"
+  FROM "transport-service" t
+    JOIN  "transport-operator" op ON op.id = t."transport-operator-id";

--- a/ote/src/clj/ote/services/service_search.sql
+++ b/ote/src/clj/ote/services/service_search.sql
@@ -43,7 +43,7 @@ SELECT COUNT(*)
          WHERE ts."published?" = TRUE
         UNION
         SELECT DISTINCT (x.c)."business-id"
-          FROM (SELECT unnest(COALESCE(ts.companies, sc.companies)) c
+          FROM (SELECT unnest(COALESCE(sc.companies, ts.companies)) c
                   FROM "transport-service" ts
                   LEFT JOIN service_company sc ON sc."transport-service-id" = ts.id
                  WHERE ts."published?" = TRUE) x) y;


### PR DESCRIPTION
# Fixed
* Added missing company info in service search results in case user filled the companies info manually using the service form.

   
# Datamodel
* Changes in transport_service_search_result. Using also transport-service "companies" in search results.
