### PR TITLE
Email settings update

### DIFF
--- a/ote/src/clj/ote/services/settings.clj
+++ b/ote/src/clj/ote/services/settings.clj
@@ -10,24 +10,32 @@
             [clojure.string :as str]
             [jeesql.core :refer [defqueries]]))
 
+(defqueries "ote/services/pre_notices/regions.sql")
+
 (defn save-notifications! [user db form-data]
   (let [data (merge form-data
                     {::user-notifications/created-by (get-in user [:user :id])
-                     ::user-notifications/created (java.sql.Timestamp. (System/currentTimeMillis))
-                     ::user-notifications/modified (java.sql.Timestamp. (System/currentTimeMillis))})]
+                     ::user-notifications/created    (java.sql.Timestamp. (System/currentTimeMillis))
+                     ::user-notifications/modified   (java.sql.Timestamp. (System/currentTimeMillis))})]
     (upsert! db ::user-notifications/user-notifications data)))
 
-(defn get-notifications [user db]
-  (first (fetch db ::user-notifications/user-notifications
-                (specql/columns ::user-notifications/user-notifications)
-                {::user-notifications/created-by (get-in user [:user :id])})))
+(defn get-notifications
+  "Fetch all regions and user notifications from server and merge them to same map."
+  [user db]
+  (let [user-settings (first (fetch db ::user-notifications/user-notifications
+                                    (specql/columns ::user-notifications/user-notifications)
+                                    {::user-notifications/created-by (get-in user [:user :id])}))
+        regions (fetch-regions db)]
+    (-> {:email-settings {}}
+        (assoc-in [:email-settings :regions] regions)
+        (assoc-in [:email-settings :user-notifications] user-settings))))
 
-(define-service-component Settings {}
-  ^{:format :transit}
-  (POST "/settings/email-notifications" {form-data :body
-                                         user      :user}
-      (save-notifications! user db
-                           (http/transit-request form-data)))
-  ^{:format :transit}
-  (GET "/settings/email-notifications" {user :user}
-      (get-notifications user db)))
+    (define-service-component Settings {}
+      ^{:format :transit}
+      (POST "/settings/email-notifications" {form-data :body
+                                             user      :user}
+        (save-notifications! user db
+                             (http/transit-request form-data)))
+      ^{:format :transit}
+      (GET "/settings/email-notifications" {user :user}
+        (get-notifications user db)))

--- a/ote/src/clj/ote/tasks/pre_notices.sql
+++ b/ote/src/clj/ote/tasks/pre_notices.sql
@@ -26,5 +26,5 @@ SELECT id, "pre-notice-type", "route-description", created, modified, descriptio
   FROM "pre_notice" n
  WHERE "pre-notice-state" = 'sent'
    AND sent IS NOT NULL
-   AND ((:regions::int[])[1] IS NULL OR (:regions::int[]) && n.regions::integer[])
+   AND ((:regions::char(2)[]) IS NULL OR (:regions::char(2)[]) && n.regions)
    AND (sent > (current_timestamp - :interval::interval));

--- a/ote/src/clj/ote/tasks/pre_notices.sql
+++ b/ote/src/clj/ote/tasks/pre_notices.sql
@@ -26,5 +26,5 @@ SELECT id, "pre-notice-type", "route-description", created, modified, descriptio
   FROM "pre_notice" n
  WHERE "pre-notice-state" = 'sent'
    AND sent IS NOT NULL
-   AND ((:regions::int[])[1] IS NULL OR (:regions::int[])[1] = ANY(n.regions::integer[]))
+   AND ((:regions::int[])[1] IS NULL OR (:regions::int[]) && n.regions::integer[])
    AND (sent > (current_timestamp - :interval::interval));

--- a/ote/src/cljs/ote/views/email_notification_settings.cljs
+++ b/ote/src/cljs/ote/views/email_notification_settings.cljs
@@ -9,7 +9,7 @@
             [ote.ui.buttons :as buttons]
             [ote.app.controller.email-notification-settings :as email-settings]))
 
-(defn select-province [e! email-settings]
+(defn select-province [e! regions]
   [(form/group
      {:label   ""
       :columns 3
@@ -20,7 +20,7 @@
       :name                 ::user-notifications/finnish-regions
       :type                 :checkbox-group
       :show-option          (tr-key [:regions])
-      :options              (map #(:id %) (get email-settings :regions))
+      :options              (map #(:id %) regions)
       :full-width?          true
       :container-class      "col-xs-12 col-sm-12 col-md-12"
       :use-label-width?     true
@@ -44,10 +44,10 @@
      [:p (tr [:email-notification-settings-page :regions-description-text])]
      [form/form
       (form-options e!)
-      (select-province e! (:email-settings state))
+      (select-province e! (get-in state [:email-settings :regions]))
       form-data]]))
 
 (defn email-notification-settings [e! state]
-  (if (and (not (get-in state [:email-settings :regions-loading])) (not (get-in state [:email-settings :user-notifications-loading])))
+  (if (not (get-in state [:email-settings :regions-loading]))
     [email-notification-settings-form e! state]
     [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]]))


### PR DESCRIPTION
# Fixed
* Pre-notices weren't send to in everybody in some cases because sql query didn't work.
Now the sql query is fixed and it uses && to check if regions arrays overlap each other.
* Also ui in email notification settings is changed so that it shows like has selected all regions when he/she isn't selected any in situation where there isn't row in user_notifications table.
   
