### PR TITLE
Add no-cache-headers to GET /viewer request

### DIFF
--- a/ote/src/clj/ote/services/viewer.clj
+++ b/ote/src/clj/ote/services/viewer.clj
@@ -15,7 +15,9 @@
                   (http-server/send! response-ch
                                      {:status status
                                       :body body
-                                      :headers {"Content-Type" (:content-type headers)}}
+                                      :headers (merge
+                                              {"Content-Type" (:content-type headers)}
+                                              http/no-cache-headers)}
                                      true)))))
 
 


### PR DESCRIPTION
# Fixed
* GET /viewer response was cached with ie11. Added no-cache-headers
   
