### PR TITLE
Make sure that docker container ports are exposed only on localhost.

### DIFF
--- a/nap/docker/docker-compose.yml
+++ b/nap/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - napote-solr
       - napote-redis
     ports:
-      - "${CKAN_PORT}:5000"
+      - "127.0.0.1:${CKAN_PORT}:5000"
     environment:
       - CKAN_SQLALCHEMY_URL=postgresql://ckan:@napotedb:5432/napote
       - CKAN_SOLR_URL=http://napote-solr:8983/solr/ckan
@@ -45,7 +45,7 @@ services:
     networks:
       - napote
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 30s
@@ -59,7 +59,7 @@ services:
     networks:
       - napote
     ports:
-      - "8983:8983"
+      - "127.0.0.1:8983:8983"
 
   napote-redis:
     container_name: napote-redis
@@ -68,7 +68,7 @@ services:
     networks:
       - napote
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
   napote-nginx:
     restart: always
@@ -82,4 +82,4 @@ services:
     extra_hosts:
       - "dockerhost:${DOCKER_HOST_IP}"
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"


### PR DESCRIPTION
# Fixed
* Fixed security issue with docker-compose. By default docker exposes container ports to all interfaces. We do not want that, so now they are strictly locahost only. https://www.techrepublic.com/article/how-to-fix-the-docker-and-ufw-security-flaw/

