### PR TITLE
161173800 Add missing COALESCEs in fetch-route-differences.

### DIFF
--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -170,15 +170,15 @@ SELECT gtfs_route_differences(
           (SELECT tripdata
                      FROM gtfs_route_trips_for_date(
                             gtfs_service_packages_for_date(:service-id::INTEGER, :date1::DATE), :date1::DATE) trips
-            WHERE trips."route-short-name" = :route-short-name
-              AND trips."route-long-name" = :route-long-name
-              AND trips."trip-headsign" = :trip-headsign),
+            WHERE COALESCE(trips."route-short-name", '') = COALESCE(:route-short-name, '')
+              AND COALESCE(trips."route-long-name", '') = COALESCE(:route-long-name, '')
+              AND COALESCE(trips."trip-headsign", '') = COALESCE(:trip-headsign, '')),
           (SELECT tripdata
                      FROM gtfs_route_trips_for_date(
                             gtfs_service_packages_for_date(:service-id::INTEGER, :date2::DATE), :date2::DATE) trips
-            WHERE trips."route-short-name" = :route-short-name
-              AND trips."route-long-name" = :route-long-name
-              AND trips."trip-headsign" = :trip-headsign))::TEXT;
+            WHERE COALESCE(trips."route-short-name", '') = COALESCE(trips."route-short-name", '')
+              AND COALESCE(trips."route-long-name", '') = COALESCE(:route-long-name, '')
+              AND COALESCE(trips."trip-headsign", '') = COALESCE(:trip-headsign, '')))::TEXT;
 
 
 -- name: fetch-gtfs-packages-for-service


### PR DESCRIPTION
# Fixed
* Added missing COALESCEs in fetch-route-differences. Fixes missing changes under calendar when manually choosing dates for comparison.