### PR TITLE
Remove show-next-year checkbox and show next years calendar always

### DIFF
--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -337,10 +337,7 @@
         (assoc-in [:transit-visualization :compare :differences]
                   (select-keys route #{:gtfs/added-trips :gtfs/removed-trips
                                        :gtfs/trip-stop-sequence-changes
-                                       :gtfs/trip-stop-time-changes}))
-        ;; Show next year in calendar, if date2 is in next year.
-        (assoc-in [:transit-visualization :show-next-year?]
-                  (> (time/year date2) (time/year (time/now)))))))
+                                       :gtfs/trip-stop-time-changes})))))
 
 (define-event ToggleRouteDisplayDate [date]
   {:path [:transit-visualization :compare]}
@@ -369,10 +366,6 @@
 
 (define-event ToggleShowPreviousYear []
   {:path [:transit-visualization :show-previous-year?]}
-  (not app))
-
-(define-event ToggleShowNextYear []
-  {:path [:transit-visualization :show-next-year?]}
   (not app))
 
 (define-event ToggleSection [section]

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -495,9 +495,7 @@
    (when (seq diff)
      [change-icons diff true])])
 
-(defn route-service-calendar [e! {:keys [date->hash hash->color
-                                         show-previous-year? show-next-year?
-                                         compare open-sections]}]
+(defn route-service-calendar [e! {:keys [date->hash hash->color show-previous-year? compare open-sections]}]
   (let [current-year (time/year (time/now))]
     [:div.route-service-calendar
      [section {:toggle! #(e! (tv/->ToggleSection :route-service-calendar))
@@ -510,10 +508,7 @@
                                         :margin-bottom "1rem"}))
         [ui/checkbox {:label "Näytä myös edellinen vuosi"
                       :checked show-previous-year?
-                      :on-check #(e! (tv/->ToggleShowPreviousYear))}]
-        [ui/checkbox {:label "Näytä myös tuleva vuosi"
-                      :checked show-next-year?
-                      :on-check #(e! (tv/->ToggleShowNextYear))}]]]
+                      :on-check #(e! (tv/->ToggleShowPreviousYear))}]]]
       [:div.route-service-calendar-content
 
 
@@ -525,8 +520,7 @@
                                            :years (vec (concat (when show-previous-year?
                                                                  [(dec current-year)])
                                                                [current-year]
-                                                               (when show-next-year?
-                                                                 [(inc current-year)])))
+                                                               [(inc current-year)]))
                                            :hover-style #(let [d (time/format-date-iso-8601 %)
                                                                hash (date->hash d)
                                                                hash-color (hash->color hash)]


### PR DESCRIPTION
# Changed
* Show next years calendar on transit visualization page always
   