### PR TITLE
161407877 Do not show operators search suggestions if they have no business-id

### DIFF
--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -292,7 +292,8 @@
                          ;; No filter, back-end returns what we want
                          :filter (constantly true)
                          :suggestions-config {:text :operator :value :business-id}
-                         :suggestions (:results data)
+                         ;; Filter away transport-operators that have no business-id. (Note: It should be mandatory!)
+                         :suggestions (filter :business-id (:results data))
                          :open-on-focus? true
                          :on-update-input #(e! (ss/->SetOperatorName %))
                          ;; Select first match from autocomplete filter result list after pressing enter


### PR DESCRIPTION
# Fixed
* Null business-ids are breaking operator search suggestions. Do not show operators in search suggestion list if they have null business-id. Business-id is used as an unique identifier and should be mandatory for all operators.