### PR TITLE
161009873 Make business ids mandatory for csv company source

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -323,6 +323,9 @@ You can also draw the operating area or point to the map with drawing tools. You
   :csv-parse-failed "Failed to parse .csv file."
   :parsing-success ["Found  " :count " companies."]}
 
+ :companies-csv
+ {:invalid "Imported CSV file is missing business IDs or business names or it might contain invalid business IDs."}
+
 
  ;; Action buttons
  :buttons

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -323,6 +323,9 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :csv-parse-failed ".csv-tiedoston parsiminen epäonnistui."
   :parsing-success ["Antamastasi tiedostosta löydettiin  " :count " yritystä."]}
 
+ :companies-csv
+ {:invalid "CSV tiedostosta puuttuu y-tunnuksia tai yritysten nimiä tai se sisältää virheellisiä y-tunnuksia."}
+
 
  ;; Action buttons
  :buttons

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -332,6 +332,8 @@ Om tjänsten tillhandahålls av flera tjänsteproducenter eller om man via tjän
   :csv-parse-failed "Felaktigt format. .csv-filen gick inte att läsa"
   :parsing-success ["I listan hittades " :count " företag."]}
 
+ :companies-csv
+ {:invalid "Imported CSV file is missing business IDs or business names or it might contain invalid business IDs."}
 
  ;; Action buttons
  :buttons

--- a/ote/src/clj/ote/services/external.clj
+++ b/ote/src/clj/ote/services/external.clj
@@ -35,7 +35,7 @@
                                {::t-service/business-id business-id
                                 ::t-service/name name}))
                             (rest csv-data)))
-        validated-data (filter #(csv-util/valid-business-id? (::t-service/business-id %)) parsed-data)]
+        validated-data (filter #(and (csv-util/valid-business-id? (::t-service/business-id %)) (not (empty? (::t-service/name %)))) parsed-data)]
     {:result validated-data
      :failed-count (- (count parsed-data) (count validated-data))}))
 

--- a/ote/src/cljs/ote/app/controller/transport_service.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_service.cljs
@@ -549,12 +549,11 @@
          (rest csv-data))]
     companies))
 
-(defn read-companies-csv! [e! file-input]
+(defn read-companies-csv! [e! file-input filename]
   (let [fr (js/FileReader.)]
     (set! (.-onload fr)
           (fn [e]
-            (let [filename (-> (aget (.-files file-input) 0) .-name)
-                  txt (-> e .-target .-result)
+            (let [txt (-> e .-target .-result)
                   separator (csv-util/csv-separator txt)
                   csv (parse-csv-response->company-map (csv/read-csv txt :newline :lf :separator separator))]
               (e! (->AddImportedCompaniesToService csv filename)))))

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -940,8 +940,8 @@
          (cond
            (and imported? valid?) [:span {:style {:color "green"}} (tr [:csv :parsing-success]
                                                                        {:count (count (get data ::t-service/companies))})]
-           (and imported? (not valid?)) [:span {:style {:color "red"}} "CSV tiedostosta puuttuu y-tunnuksia tai yritysten nimiä tai se sisältää virheellisiä y-tunnuksia."]
-           (not imported?) [:span {:style {:color "red"}} "CSV tiedoston parsinta epäonnistui"])))]]])
+           (and imported? (not valid?)) [:span {:style {:color "red"}} (tr [:companies-csv :invalid])]
+           (not imported?) [:span {:style {:color "red"}} (tr [:csv :csv-parse-failed])])))]]])
 
 (defn company-input-fields [update! companies data]
   (let [table-fields [{:name ::t-service/name

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -890,7 +890,7 @@
     (ote.ui.common/linkify "/ote/csv/palveluyritykset.csv"  (tr [:form-help :csv-file-example]) {:target "_blank"})]])
 
 
-(defn company-csv-url-input [update! on-url-given companies-csv-url data]
+(defn company-csv-url-input [update! on-url-given companies-csv-url {data :csv-count}]
   [:div
    [:div.row (stylefy/use-style style-base/divider)]
    [:div.row
@@ -906,17 +906,18 @@
              :type            :string}
       companies-csv-url]]]
 
-   (let [success (if (= :success (get-in data [:csv-count :status]))
-                   true
-                   false)
-         amount (if (get-in data [:csv-count :count])
-                  (get-in data [:csv-count :count])
-                  nil)]
-     (cond
-       (and data success) [:div.row {:style {:color "green"}} (tr [:csv :parsing-success] {:count amount})]
-       (and data (= false success)) [:div.row (stylefy/use-style style-base/required-element)
-                                     (tr [:csv (get-in data [:csv-count :error])])]
-       :else [:span]))])
+   (let [success? (= :success (:status data))
+         companies-count (:count data)
+         invalid-count (:failed-count data)
+         valid? (= 0 invalid-count)]
+
+     (when data
+       (cond
+         (and success? valid?) [:div.row {:style {:color "green"}} (tr [:csv :parsing-success] {:count companies-count})]
+         (and success? (not valid?)) [:span {:style {:color "red"}} (tr [:companies-csv :invalid])]
+         (not success?) [:div.row (stylefy/use-style style-base/required-element)
+                                   (tr [:csv (get-in data [:csv-count :error])])]
+         :else [:span])))])
 
 (defn company-csv-file-input [on-file-selected data]
   [:div

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -180,7 +180,11 @@
            {:id "hidden-file-input"
             :type "file"
             :name name
-            :on-change on-change
+            :on-change #(do
+                          ;; Pass filename before setting target value to nil, or it will become inaccessible.
+                          (on-change % (-> (aget (.-files (.-target %)) 0) .-name))
+                          ;; Set file input value to nil to allow uploading a file with a same name again.
+                          (aset (.-target %) "value" nil))
             ;; Hack to hide file input tooltip on different browsers.
             ;; String with space -> hide title on Chrome, FireFox and some other browsers. Not 100% reliable.
             :title " "}
@@ -926,8 +930,7 @@
                           (tr [:buttons :update-csv])
                           (tr [:buttons :upload-csv]))
              :accept    ".csv"
-             :on-change on-file-selected
-             }]]
+             :on-change on-file-selected}]]
     (when (get data ::t-service/company-csv-filename)
       [:div.row {:style {:padding-top "20px"}} (get data ::t-service/company-csv-filename)])
     [:div.row {:style {:padding-top "20px"}}

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -16,7 +16,8 @@
             [ote.style.form :as style-form]
             [ote.db.transport-service :as t-service]
             [ote.util.values :as values]
-            [goog.string :as gstr]))
+            [goog.string :as gstr]
+            [ote.ui.validation :as validation]))
 
 
 
@@ -938,29 +939,32 @@
          [:span {:style {:color "green"}} (tr [:csv :parsing-success] {:count amount})]))]]])
 
 (defn company-input-fields [update! companies data]
-  [:div.row
-   [:div.row (stylefy/use-style style-base/divider)]
-   [:div.row
-    [field {:name                ::t-service/companies
-            :type                :table
-            :update!             #(update! {::t-service/companies %})
-            :table-wrapper-style {:max-height "300px" :overflow "scroll"}
-            :prepare-for-save    values/without-empty-rows
-            :table-fields        [{:name      ::t-service/name
-                                   :type      :string
-                                   :label     (tr [:field-labels :transport-service-common ::t-service/company-name])
-                                   :required? true
-                                   }
-                                  {:name      ::t-service/business-id
-                                   :type      :string
-                                   :label     (tr [:field-labels :transport-service-common ::t-service/business-id])
-                                   :validate  [[:business-id]]
-                                   :required? true
-                                   :regex     #"\d{0,7}(-\d?)?"}]
-            :delete?             true
-            :add-label           (tr [:buttons :add-new-company])
-            :error-data          (::t-service/companies (:ote.ui.form/warnings data))}
-     companies]]])
+  (let [table-fields [{:name ::t-service/name
+                       :type :string
+                       :label (tr [:field-labels :transport-service-common ::t-service/company-name])
+                       :required? true}
+
+                      {:name ::t-service/business-id
+                       :type :string
+                       :label (tr [:field-labels :transport-service-common ::t-service/business-id])
+                       :validate [[:business-id]]
+                       :required? true
+                       :regex #"\d{0,7}(-\d?)?"}]
+        error-data (validation/validate-table companies table-fields)]
+    [:div.row
+     [:div.row (stylefy/use-style style-base/divider)]
+     [:div.row
+      [field {:name ::t-service/companies
+              :type :table
+              :update! #(update! {::t-service/companies %})
+              :table-wrapper-style {:max-height "300px" :overflow "scroll"}
+              :prepare-for-save values/without-empty-rows
+              :required true
+              :table-fields table-fields
+              :delete? true
+              :add-label (tr [:buttons :add-new-company])
+              :error-data error-data}
+       companies]]]))
 
 (defmethod field :company-source [{:keys [update! enabled-label on-file-selected on-url-given] :as opts}
                                   {::t-service/keys [company-source companies companies-csv-url passenger-transportation] :as data}]

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -284,7 +284,8 @@
      :type :company-source
      :enabled-label (tr [:field-labels :parking :maximum-stay-limited])
      :container-style style-form/full-width
-     :on-file-selected #(ts/read-companies-csv! e! (.-target %))
+     :on-file-selected (fn [evt filename]
+                         (ts/read-companies-csv! e! (.-target evt) filename))
      :on-url-given #(e! (ts/->EnsureCsvFile))
      :validate [(fn [data row]
                   (let [companies (::t-service/companies row)]

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -285,7 +285,17 @@
      :enabled-label (tr [:field-labels :parking :maximum-stay-limited])
      :container-style style-form/full-width
      :on-file-selected #(ts/read-companies-csv! e! (.-target %))
-     :on-url-given #(e! (ts/->EnsureCsvFile))}))
+     :on-url-given #(e! (ts/->EnsureCsvFile))
+     :validate [(fn [data row]
+                  (let [companies (::t-service/companies row)]
+                    (case (::t-service/company-source data)
+                      :form
+                      (when (some #(or (empty? (::t-service/name %))
+                                       (or (empty? (::t-service/business-id %))
+                                           (validation/validate-rule :business-id nil (::t-service/business-id %))))
+                                  companies)
+                        (tr [:common-texts :required-field]))
+                      nil)))]}))
 
 (defn brokerage-group
   "Creates a form group for brokerage selection."


### PR DESCRIPTION
# Changed
* Made business ids and business names mandatory for csv import fields. Added better error messaging for invalid companies csvs.

# Fixed
* Fixed a problem with :file type form fields that caused it not to trigger on-change event if a new file with a same name was uploaded multiple times. 

