### PR TITLE
161982166 transport-operator-selection separated from operator

### DIFF
--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -26,7 +26,7 @@
             [reagent.core :as r]
             [ote.ui.form-fields :as form-fields]
             [ote.ui.common :as ui-common]
-            [ote.views.transport-operator :as t-operator-view]
+            [ote.views.transport-operator-selection :as t-operator-sel]
             [ote.ui.list-header :as list-header]
             [clojure.string :as str]))
 
@@ -129,8 +129,8 @@
                                       (e! (ts/->OpenTransportServiceTypePage)))
                          :primary  true
                          :icon     (ic/content-add)}])
-    [t-operator-view/transport-operator-selection e! state true]]
-    [:div.row
+    [t-operator-sel/transport-operator-selection e! state true]]
+   [:div.row
     [:div {:class "col-xs-12 col-md-12"}
      (if (and has-services? (not (empty? operator-services)))
        ;; TRUE -> Table for transport services

--- a/ote/src/cljs/ote/views/pre_notices/listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/listing.cljs
@@ -8,7 +8,7 @@
             [ote.db.transit :as transit]
             [ote.db.modification :as modification]
             [ote.db.transport-operator :as t-operator]
-            [ote.views.transport-operator :as t-operator-view]
+            [ote.views.transport-operator-selection :as t-operator-sel]
             [cljs-react-material-ui.icons :as ic]
             [cljs-react-material-ui.reagent :as ui]
             [ote.time :as time]
@@ -79,7 +79,7 @@
                                          (e! (pre-notice/->CreateNewPreNotice)))
                             :primary true
                             :icon (ic/content-add)}]
-         [t-operator-view/transport-operator-selection e! app]]]
+         [t-operator-sel/transport-operator-selection e! app]]]
        [:div {:style {:margin-bottom "40px"}}
         [pre-notices-table e! pre-notices :draft]
         (when delete-pre-notice-dialog

--- a/ote/src/cljs/ote/views/route/route_list.cljs
+++ b/ote/src/cljs/ote/views/route/route_list.cljs
@@ -5,7 +5,7 @@
     [cljs-react-material-ui.reagent :as ui]
     [ote.app.controller.route.route-list :as route-list]
     [cljs-react-material-ui.icons :as ic]
-    [ote.views.transport-operator :as t-operator-view]
+    [ote.views.transport-operator-selection :as t-operator-sel]
     [ote.app.controller.transport-operator :as to]
     [ote.db.transport-operator :as t-operator]
     [ote.ui.form-fields :as form-fields]
@@ -115,7 +115,7 @@
                           :primary  true
                           :disabled (empty? operators)
                           :icon     (ic/content-add)}]]
-      [t-operator-view/transport-operator-selection e! app]
+      [t-operator-sel/transport-operator-selection e! app]
       [buttons/open-link
        (tr [:route-list-page :link-to-help-pdf-url])
        (tr [:route-list-page :link-to-help-pdf])]]

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -41,53 +41,6 @@
                     :on-click  #(e! (to/->DeleteTransportOperator (::t-operator/id operator)))}])]}
      (tr [:dialog :delete-transport-operator :confirm] {:name (::t-operator/name operator)})]))
 
-(defn transport-operator-selection [e! {operator :transport-operator
-                                        operators :transport-operators-with-services
-                                        show-add-member-dialog? :show-add-member-dialog?} & extended]
-  [:span
-   ;; Show operator selection if there are operators and we are not creating a new one
-   (when (and (not (empty? operators))
-              (not (:new? operator)))
-     [:div.row
-     [:div.col-sm-4.col-md-3
-      [form-fields/field
-       {:label (tr [:field-labels :select-transport-operator])
-        :name        :select-transport-operator
-        :type        :selection
-        :show-option #(if (nil? %)
-                        (tr [:buttons :add-new-transport-operator])
-                        (::t-operator/name %))
-        :update!   #(if (nil? %)
-                      (e! (to/->CreateTransportOperator))
-                      (e! (to/->SelectOperatorForService %)))
-        :options     (into (mapv :transport-operator operators)
-                           [:divider nil])
-        :auto-width? true}
-       operator]]
-
-      (when extended
-       [:div.col-xs-12.col-sm-3.col-md-2
-       [ui/flat-button {:label (tr [:buttons :edit])
-                        :style {:margin-top "1.5em"
-                                :font-size "8pt"}
-                        :icon (ic/content-create {:style {:width 16 :height 16}})
-                        :on-click #(do
-                                     (.preventDefault %)
-                                     (e! (fp/->ChangePage :transport-operator {:id (::t-operator/id operator)})))}]])
-      (when extended
-       [:div.col-xs-12.col-sm-3.col-md-2
-        [ui/flat-button {:label (tr [:buttons :add-new-member])
-                         :style {:margin-top "1.5em"
-                                 :font-size "8pt"}
-                         :icon (ic/content-add {:style {:width 16 :height 16}})
-                         :on-click #(do
-                                      (.preventDefault %)
-                                      (e! (fp/->ToggleAddMemberDialog)))}]
-        (when show-add-member-dialog?
-          [ui-common/ckan-iframe-dialog (::t-operator/name operator)
-           (str "/organization/member_new/" (::t-operator/ckan-group-id operator))
-           #(e! (fp/->ToggleAddMemberDialog))])])])])
-
 (defn- operator-form-groups []
   [(form/group
     {:label (tr [:common-texts :title-operator-basic-details])

--- a/ote/src/cljs/ote/views/transport_operator_selection.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_selection.cljs
@@ -1,0 +1,68 @@
+(ns ote.views.transport-operator-selection
+  "Component for selecting a transport operator"
+  (:require [reagent.core :as r]
+            [cljs-react-material-ui.reagent :as ui]
+            [cljs-react-material-ui.icons :as ic]
+
+            [ote.ui.form :as form]
+            [ote.ui.form-groups :as form-groups]
+            [ote.ui.buttons :as buttons]
+            [ote.ui.validation :as ui-validation]
+            [stylefy.core :as stylefy]
+            [ote.style.form :as style-form]
+            [ote.ui.common :as ui-common]
+            [ote.ui.form-fields :as form-fields]
+
+            [ote.app.controller.transport-operator :as to]
+            [ote.app.controller.front-page :as fp]
+
+            [ote.db.transport-operator :as t-operator]
+            [ote.db.common :as common]
+            [ote.localization :refer [tr tr-key]]))
+
+(defn transport-operator-selection [e! {operator :transport-operator
+                                        operators :transport-operators-with-services
+                                        show-add-member-dialog? :show-add-member-dialog?} & extended]
+  [:span
+   ;; Show operator selection if there are operators and we are not creating a new one
+   (when (and (not (empty? operators))
+              (not (:new? operator)))
+     [:div.row
+     [:div.col-sm-4.col-md-3
+      [form-fields/field
+       {:label       (tr [:field-labels :select-transport-operator])
+        :name        :select-transport-operator
+        :type        :selection
+        :show-option #(if (nil? %)
+                        (tr [:buttons :add-new-transport-operator])
+                        (::t-operator/name %))
+        :update!     #(if (nil? %)
+                        (e! (to/->CreateTransportOperator)) ; dropdownist napiksi
+                        (e! (to/->SelectOperatorForService %))) ; nimeä
+        :options     (into (mapv :transport-operator operators)
+                           [:divider nil])
+        :auto-width? true}
+       operator]]
+
+      (when extended
+       [:div.col-xs-12.col-sm-3.col-md-2
+       [ui/flat-button {:label (tr [:buttons :edit])
+                        :style {:margin-top "1.5em"
+                                :font-size "8pt"}
+                        :icon (ic/content-create {:style {:width 16 :height 16}})
+                        :on-click #(do
+                                     (.preventDefault %)
+                                     (e! (fp/->ChangePage :transport-operator {:id (::t-operator/id operator)})))}]])
+      (when extended
+       [:div.col-xs-12.col-sm-3.col-md-2
+        [ui/flat-button {:label (tr [:buttons :add-new-member])
+                         :style {:margin-top "1.5em"
+                                 :font-size "8pt"}
+                         :icon (ic/content-add {:style {:width 16 :height 16}})
+                         :on-click #(do
+                                      (.preventDefault %)
+                                      (e! (fp/->ToggleAddMemberDialog)))}]
+        (when show-add-member-dialog?
+          [ui-common/ckan-iframe-dialog (::t-operator/name operator)
+           (str "/organization/member_new/" (::t-operator/ckan-group-id operator))
+           #(e! (fp/->ToggleAddMemberDialog))])])])])


### PR DESCRIPTION
# Changed
* Operator selection is re-used from different places, so separate it to a
re-usable component. Upcoming YTJ-integration will benefit out of this as well.

(Note:  Omat palvelutiedot > Uusi palvelu (transport-service.cljs) i.e. new service creation implements service operator selection independently from this)
 