### PR TITLE
161439932 remove old changes from detection email

### DIFF
--- a/ote/src/clj/ote/tasks/pre_notices.sql
+++ b/ote/src/clj/ote/tasks/pre_notices.sql
@@ -24,6 +24,8 @@ WITH changes_with_regions AS (
                     FROM gtfs_package p
                    WHERE p.id = ANY(chg."package-ids")) x) AS "finnish-regions"
     FROM "gtfs-transit-changes" chg
+    WHERE chg.date = CURRENT_DATE
+
 )
 SELECT to_char(chg."change-date", 'dd.mm.yyyy') as "change-date",
        ("change-date" - CURRENT_DATE) AS "days-until-change",
@@ -37,8 +39,11 @@ SELECT to_char(chg."change-date", 'dd.mm.yyyy') as "change-date",
        ts.id AS "transport-service-id"
   FROM changes_with_regions chg
   JOIN "transport-service" ts ON ts.id = chg."transport-service-id"
-  JOIN "transport-operator" op ON op.id = ts."transport-operator-id"
+  JOIN "transport-operator" op ON op.id = ts."transport-operator-id",
+       gtfs_package p
  WHERE chg.date = CURRENT_DATE
+    AND p.id = ANY(chg."package-ids")
+   AND p.created > CURRENT_DATE - interval '8 hours'
    AND chg."change-date" IS NOT NULL
    AND (chg."finnish-regions" IS NULL OR
         :regions::CHAR(2)[] IS NULL OR

--- a/ote/src/clj/ote/tasks/pre_notices.sql
+++ b/ote/src/clj/ote/tasks/pre_notices.sql
@@ -42,7 +42,7 @@ SELECT to_char(chg."change-date", 'dd.mm.yyyy') as "change-date",
   JOIN "transport-operator" op ON op.id = ts."transport-operator-id",
        gtfs_package p
  WHERE chg.date = CURRENT_DATE
-    AND p.id = ANY(chg."package-ids")
+   AND p.id = ANY(chg."package-ids")
    AND p.created > CURRENT_DATE - interval '8 hours'
    AND chg."change-date" IS NOT NULL
    AND (chg."finnish-regions" IS NULL OR

--- a/ote/test/clj/ote/tasks/pre_notices_test.clj
+++ b/ote/test/clj/ote/tasks/pre_notices_test.clj
@@ -83,8 +83,8 @@
 
     (specql/insert! (:db *ote*) :gtfs/transit-changes
                     {:gtfs/transport-service-id 1
-                     :gtfs/date                 (java.util.Date.)
-                     :gtfs/current-week-date    (java.util.Date.)
+                     :gtfs/date                 (tc/to-sql-date (time/now))
+                     :gtfs/current-week-date    (tc/to-sql-date (time/now))
                      :gtfs/different-week-date  (tc/to-sql-date (time/days-from (time/now) 70))
                      :gtfs/change-date          (tc/to-sql-date (time/days-from (time/now) 67))
                      :gtfs/package-ids          [1]

--- a/ote/test/clj/ote/tasks/pre_notices_test.clj
+++ b/ote/test/clj/ote/tasks/pre_notices_test.clj
@@ -71,16 +71,27 @@
     (is (empty? @outbox)))
 
   (testing "inserted change is found and sent"
+    ;; Stupid way to clean up database. But package is hard coded to these test. So it must remain the same.
+    (specql/delete! (:db *ote*) :gtfs/package
+                    {:gtfs/id 1})
+    ;; Create package-id (email content is dependent on this id)
+    (specql/insert! (:db *ote*) :gtfs/package
+                    {:gtfs/id 1
+                     :gtfs/transport-operator-id 1
+                     :gtfs/transport-service-id  1
+                     :gtfs/created               (tc/to-sql-date (time/now))})
+
     (specql/insert! (:db *ote*) :gtfs/transit-changes
                     {:gtfs/transport-service-id 1
-                     :gtfs/date (java.util.Date.)
-                     :gtfs/current-week-date (java.util.Date.)
-                     :gtfs/different-week-date (tc/to-sql-date (time/days-from (time/now) 70))
-                     :gtfs/change-date (tc/to-sql-date (time/days-from (time/now) 67))
-                     :gtfs/package-ids [1]
-                     :gtfs/removed-routes 1
-                     :gtfs/added-routes 2
-                     :gtfs/changed-routes 3})
+                     :gtfs/date                 (java.util.Date.)
+                     :gtfs/current-week-date    (java.util.Date.)
+                     :gtfs/different-week-date  (tc/to-sql-date (time/days-from (time/now) 70))
+                     :gtfs/change-date          (tc/to-sql-date (time/days-from (time/now) 67))
+                     :gtfs/package-ids          [1]
+                     :gtfs/removed-routes       1
+                     :gtfs/added-routes         2
+                     :gtfs/changed-routes       3})
+
     (send!)
     (is (= 1 (count @outbox)))
     (is (str/includes? (email-content) "tunnistetut"))))


### PR DESCRIPTION
# Fixed
* Remove old changes from detected changes email. chg.date in with clau…se will remove most of the packages out of "inner table" and it will speed up the query.
* By taking gtfs_package into account we can check that the relevant new changes happens for packets that are downloaded (created) in current day.
