### PR TITLE
162234002 Calculate route-hash-id for all routes

### DIFF
--- a/database/src/main/resources/db/migration/R__GTFS_query.sql
+++ b/database/src/main/resources/db/migration/R__GTFS_query.sql
@@ -798,3 +798,22 @@ BEGIN
           "package-ids" = package_ids;
 END
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION calculate_route_hash_id_using_headsign(package_id INTEGER)
+RETURNS VOID
+AS $$
+BEGIN
+
+  DELETE FROM "detection-route" WHERE "package-id" = package_id;
+
+  INSERT INTO "detection-route" ("gtfs-route-id", "package-id", "route-id", "route-short-name", "route-long-name", "route-hash-id", "trip-headsign")
+    SELECT r.id, r."package-id", r."route-id", r."route-short-name", r."route-long-name",
+           concat(trim(r."route-short-name"), '-', trim(r."route-long-name"), '-', trim(trip."trip-headsign")), trip."trip-headsign"
+     FROM "gtfs-route" r
+     JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
+     JOIN LATERAL unnest(t.trips) trip ON true
+    WHERE r."package-id" = package_id
+    GROUP BY r.id, trip."trip-headsign";
+
+END
+$$ LANGUAGE plpgsql;

--- a/database/src/main/resources/db/migration/V1_122__add_route_hash_ids_to_all_packages.sql
+++ b/database/src/main/resources/db/migration/V1_122__add_route_hash_ids_to_all_packages.sql
@@ -1,0 +1,20 @@
+-- Create function that generates routes to detection-route table using default route-hash-id (short-long-headsign)
+CREATE OR REPLACE FUNCTION generate_route_hash_ids_for_packages() RETURNS VOID AS $$
+DECLARE
+ p_id RECORD;
+BEGIN
+
+  -- Delete all
+  DELETE FROM "detection-route";
+
+  -- Generate new
+  FOR p_id IN SELECT id FROM "gtfs_package"
+   LOOP PERFORM
+    calculate_route_hash_id_using_headsign(p_id.id);
+  END LOOP;
+
+END
+$$ LANGUAGE plpgsql;
+
+-- Call function to start the process - this might take about a minute or so.
+SELECT generate_route_hash_ids_for_packages();

--- a/database/src/main/resources/db/migration/V1_122__add_route_hash_ids_to_all_packages.sql
+++ b/database/src/main/resources/db/migration/V1_122__add_route_hash_ids_to_all_packages.sql
@@ -4,10 +4,7 @@ DECLARE
  p_id RECORD;
 BEGIN
 
-  -- Delete all
-  DELETE FROM "detection-route";
-
-  -- Generate new
+  -- Generate new route-hash-ids for all packages
   FOR p_id IN SELECT id FROM "gtfs_package"
    LOOP PERFORM
     calculate_route_hash_id_using_headsign(p_id.id);


### PR DESCRIPTION
# Added
* Add postgres functions to calculate route-hash-id for all routes using default "short-long-headsign" pattern.
   
