### PR TITLE
162383037 route hash id options

### DIFF
--- a/ote/src/clj/ote/services/transit_changes.sql
+++ b/ote/src/clj/ote/services/transit_changes.sql
@@ -58,3 +58,7 @@ SELECT calculate_route_hash_id_using_headsign(:package-id);
 SELECT calculate_route_hash_id_using_short_long(:package-id);
 -- name: calculate-routes-route-hashes-using-route-id
 SELECT calculate_route_hash_id_using_route_id(:package-id);
+-- name: calculate-routes-route-hashes-using-long-headsign
+SELECT calculate_route_hash_id_using_long_headsign(:package-id);
+-- name: calculate-routes-route-hashes-using-long
+SELECT calculate_route_hash_id_using_long(:package-id);

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -73,8 +73,8 @@ SELECT trip."trip-id", trip."trip-headsign", stop."stop-name", stoptime."departu
  ORDER BY stoptime."stop-sequence") x
  GROUP BY x."trip-id", x."trip-headsign";
 
--- name: fetch-route-trips-by-name-and-date
--- Fetch geometries of route trips for given date by route short and long name
+-- name: fetch-route-trips-by-hash-and-date
+-- Fetch geometries of route trips for given date by route hash-id
 SELECT ST_AsGeoJSON(COALESCE(
           -- If there exists a "gtfs-shape" row for this package and trip shape id,
           -- use that to generate the detailed route line
@@ -91,14 +91,12 @@ SELECT ST_AsGeoJSON(COALESCE(
                ST_MakeLine(ST_MakePoint(stop."stop-lon", stop."stop-lat") ORDER BY stoptime."stop-sequence") as "route-line",
                string_agg(CONCAT(stop."stop-lon", ',', stop."stop-lat", ',', stop."stop-name"), '||' ORDER BY stoptime."stop-sequence") as stops,
                trip."shape-id", r."package-id"
-          FROM "gtfs-route" r
+          FROM "detection-route" r
           JOIN "gtfs-trip" t ON (r."package-id" = t."package-id" AND r."route-id" = t."route-id")
           JOIN LATERAL unnest(t.trips) trip ON TRUE
           JOIN LATERAL unnest(trip."stop-times") stoptime ON TRUE
           JOIN "gtfs-stop" stop ON (r."package-id" = stop."package-id" AND stoptime."stop-id" = stop."stop-id")
-         WHERE COALESCE(:route-short-name::VARCHAR,'') = COALESCE(r."route-short-name",'')
-           AND COALESCE(:route-long-name::VARCHAR,'') = COALESCE(r."route-long-name",'')
-           AND COALESCE(:trip-headsign::VARCHAR,'') = COALESCE(trip."trip-headsign",'')
+         WHERE COALESCE(:route-hash-id::VARCHAR,'') = COALESCE(r."route-hash-id",'')
            AND ROW(r."package-id", t."service-id")::service_ref IN
                (SELECT * FROM gtfs_services_for_date(gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE),
                           :date::DATE))
@@ -120,36 +118,8 @@ SELECT trip."package-id", (trip.trip)."trip-id",
  JOIN LATERAL unnest(rt.tripdata) trip ON TRUE
  JOIN LATERAL unnest((trip.trip)."stop-times") stoptime ON TRUE
  JOIN "gtfs-stop" s ON (s."package-id" = trip."package-id" AND s."stop-id" = stoptime."stop-id")
- WHERE COALESCE(:route-short-name::VARCHAR,'') = COALESCE(rt."route-short-name",'')
-   AND COALESCE(:route-long-name::VARCHAR,'') = COALESCE(rt."route-long-name",'')
-   AND COALESCE(:trip-headsign::VARCHAR,'') = COALESCE(rt."trip-headsign",'')
+ WHERE COALESCE(:route-hash-id::VARCHAR,'') = COALESCE(rt."route-hash-id",'')
  GROUP BY trip."package-id", (trip.trip)."trip-id";
-
--- name: fetch-date-hashes-for-route-with-route-names
--- Fetch the date/hash pairs for a given route
-WITH dates AS (
-  -- Calculate a series of dates from beginning of last year
-  -- to the end of the next year.
-  SELECT ts::date AS date
-    FROM generate_series(
-            (date_trunc('year', CURRENT_DATE) - '1 year'::interval)::date,
-            (date_trunc('year', CURRENT_DATE) + '2 years'::interval)::date,
-            '1 day'::interval) AS g(ts)
-)
-SELECT x.date::text, string_agg(x.hash,' ' ORDER BY x.package_id) as hash
-  FROM (SELECT d.date, package_id, rh.hash::text
-          FROM dates d
-          -- Join packages for each date
-          JOIN LATERAL unnest(gtfs_service_packages_for_date(:service-id::INTEGER, d.date))
-            AS ps (package_id) ON TRUE
-          -- Join all date hashes for packages
-          JOIN "gtfs-date-hash" dh ON (dh."package-id" = package_id AND dh.date = d.date)
-          -- Join unnested per route hashes
-          JOIN LATERAL unnest(dh."route-hashes") rh ON TRUE
-         WHERE COALESCE(rh."route-short-name", '') = COALESCE(:route-short-name::VARCHAR, '')
-           AND COALESCE(rh."route-long-name", '') = COALESCE(:route-long-name::VARCHAR, '')
-           AND COALESCE(rh."trip-headsign", '') = COALESCE(:trip-headsign::VARCHAR, '')) x
- GROUP BY x.date;
 
 -- name: fetch-date-hashes-for-route-with-route-hash-id
 -- Fetch the date/hash pairs for a given route using route-hash-id which isn't used for all services

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -92,7 +92,7 @@
               (detection/store-transit-changes!
                db service-id
                (detection/service-package-ids-for-date-range db query-params)
-               (detection/route-changes db query-params)))
+               (detection/detect-route-changes-for-service db query-params)))
             (catch Exception e
               (log/warn e "Change detection failed for service " service-id))))))))))
 

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -30,7 +30,7 @@ SELECT * FROM gtfs_service_routes_with_daterange(:service-id::INTEGER);
 SELECT t."package-id", trip."trip-id",
        stoptime."stop-id", stoptime."departure-time", stoptime."stop-sequence",
         stop."stop-name", stop."stop-lat", stop."stop-lon"
-  FROM "gtfs-route" r
+  FROM "detection-route" r
   JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
   JOIN LATERAL unnest(t.trips) trip ON true
   JOIN LATERAL unnest(trip."stop-times") as stoptime ON TRUE
@@ -39,9 +39,7 @@ SELECT t."package-id", trip."trip-id",
    AND ROW(r."package-id", t."service-id")::service_ref IN
        (SELECT * FROM gtfs_services_for_date(
         (SELECT gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)), :date::DATE))
-   AND COALESCE(r."route-short-name",'') = COALESCE(:route-short-name::TEXT,'')
-   AND COALESCE(r."route-long-name",'') = COALESCE(:route-long-name::TEXT,'')
-   AND COALESCE(trip."trip-headsign",'') = COALESCE(:trip-headsign::TEXT,'')
+   AND COALESCE(r."route-hash-id",'') = COALESCE(:route-hash-id::TEXT,'')
  ORDER BY t."package-id", trip."trip-id", stoptime."stop-sequence";
 
 -- name: generate-date-hashes

--- a/ote/src/cljc/ote/transit_changes.cljc
+++ b/ote/src/cljc/ote/transit_changes.cljc
@@ -25,7 +25,10 @@
 (defn merge-by-closest-time [time-fn left-items right-items]
   (let [left-items-with-closest (mapv #(item-with-closest-time time-fn % right-items) left-items)
         right-items-with-closest (mapv (comp flip-vec #(item-with-closest-time time-fn % left-items)) right-items)
-        time-diff (fn [[l r]] (time/time-difference (time-fn l) (time-fn r)))
+        time-diff (fn [[l r]]
+                    (if (and (nil? (complement r)) (nil? (complement l)))
+                      (time/time-difference (time-fn l) (time-fn r))
+                      0))
         sorted-pairs (remove
                       ;; Remove pairs whose time-difference is over 30 minutes
                       #(> (time-diff %) 30)

--- a/ote/src/cljc/ote/transit_changes.cljc
+++ b/ote/src/cljc/ote/transit_changes.cljc
@@ -25,10 +25,7 @@
 (defn merge-by-closest-time [time-fn left-items right-items]
   (let [left-items-with-closest (mapv #(item-with-closest-time time-fn % right-items) left-items)
         right-items-with-closest (mapv (comp flip-vec #(item-with-closest-time time-fn % left-items)) right-items)
-        time-diff (fn [[l r]]
-                    (if (and (nil? (complement r)) (nil? (complement l)))
-                      (time/time-difference (time-fn l) (time-fn r))
-                      0))
+        time-diff (fn [[l r]] (time/time-difference (time-fn l) (time-fn r)))
         sorted-pairs (remove
                       ;; Remove pairs whose time-difference is over 30 minutes
                       #(> (time-diff %) 30)

--- a/ote/src/cljs/ote/views/admin/detected_changes.cljs
+++ b/ote/src/cljs/ote/views/admin/detected_changes.cljs
@@ -89,12 +89,8 @@
          :required? true}
         {:name        :route-id-type
          :type        :selection
-         :options     ["short-long" "short-long-headsign" "route-id"]
+         :options     ["short-long" "short-long-headsign" "route-id" "long-headsign" "long"]
          :show-option (fn [x] x)
          :required?   true})]
-     (get-in app-state [:admin :transit-changes :route-hash-values])]]
-
-   [:div
-    [linkify "/transit-changes/force-calculate-route-hash-id/2/100/short-long" "Laske route hash id palvelulle 2 short-long tunnistuksella"]
-    [:div "Tyypit: " "short-long" "short-long-headsign"]]])
+     (get-in app-state [:admin :transit-changes :route-hash-values])]]])
 

--- a/ote/src/cljs/ote/views/admin/detected_changes.cljs
+++ b/ote/src/cljs/ote/views/admin/detected_changes.cljs
@@ -147,9 +147,7 @@
   [:div
     [:h4 "Lataa palvelulle gtfs tiedosto tietylle päivälle"]
     [form/form
-     {:update!   #(e! (admin-controller/->UpdateUploadValues %))
-      :footer-fn (fn [data]
-                   [:span])}
+     {:update!   #(e! (admin-controller/->UpdateUploadValues %))}
      [(form/group
         {:label   ""
          :columns 3


### PR DESCRIPTION
# Added
* Few more options to calculate route-hash-id
   
# Fixed
* Null pointer when we can't find trips for route
   
# Changed
* route long name, route short name and trip headsign queries to use only route-hash-id as a key
   
