### PR TITLE
162080404 improve route detection

### DIFF
--- a/database/src/main/resources/db/migration/V1_124__add_index_to_gtfs_package.sql
+++ b/database/src/main/resources/db/migration/V1_124__add_index_to_gtfs_package.sql
@@ -1,0 +1,2 @@
+-- Add index to speed up order by using e_id
+CREATE INDEX "interface-id" ON gtfs_package ("external-interface-description-id");

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -144,7 +144,7 @@ SELECT x.date::text, string_agg(x.hash,' ' ORDER BY x.e_id asc) as hash
           JOIN "gtfs-date-hash" dh ON (dh."package-id" = package_id AND dh.date = d.date)
           -- Join unnested per route hashes
           JOIN LATERAL unnest(dh."route-hashes") rh ON TRUE
-         WHERE COALESCE(rh."route-hash-id", '') = COALESCE(:route-hash-id::VARCHAR, '')) x
+         WHERE rh."route-hash-id" = :route-hash-id::VARCHAR) x
  GROUP BY x.date, x.e_id;
 
 

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -262,7 +262,7 @@
     (specql/delete! db ::t-service/service-company {::t-service/transport-service-id (::t-service/id transport-service)}))
 
 (defn save-external-companies
-  "Service can contain an url that contains company nmes and business-id. Sevice can also contain an imported csv file
+  "Service can contain an url that contains company names and business-id. Sevice can also contain an imported csv file
   with company names and business-ids."
   [db transport-service]
   (let [current-data (first (fetch db ::t-service/service-company (specql/columns ::t-service/service-company)

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -5,13 +5,15 @@ WITH dates AS (
     FROM generate_series(0, :end-date::DATE - :start-date::DATE) s (d)
 )
 SELECT d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign", rh."route-hash-id",
-       string_agg(rh.hash::text, ' ') as hash
+       string_agg(rh.hash::text, ' ' ORDER BY p."external-interface-description-id" ASC) as hash
   FROM dates d
   LEFT JOIN "gtfs-date-hash" dh
     ON (dh.date = d.date AND
         dh."package-id" = ANY(gtfs_service_packages_for_date(:service-id::INTEGER, d.date)))
+  -- Join gtfs_package to get external-interface-description-id
+  JOIN gtfs_package p ON p.id = dh."package-id"
   LEFT JOIN LATERAL unnest(dh."route-hashes") AS rh ON TRUE
- GROUP BY d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign", rh."route-hash-id", dh."package-id"
+ GROUP BY d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign", rh."route-hash-id"
  ORDER BY d.date;
 
 -- name: service-packages-for-date-range
@@ -40,8 +42,20 @@ SELECT t."package-id", trip."trip-id",
    AND ROW(r."package-id", t."service-id")::service_ref IN
        (SELECT * FROM gtfs_services_for_date(
         (SELECT gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)), :date::DATE))
-   AND r."route-hash-id" = :route-hash-id::TEXT
+   AND COALESCE(r."route-short-name",'') = COALESCE(:route-short-name::TEXT,'')
+   AND COALESCE(r."route-long-name",'') = COALESCE(:route-long-name::TEXT,'')
+   AND COALESCE(trip."trip-headsign",'') = COALESCE(:trip-headsign::TEXT,'')
  ORDER BY p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence";
 
 -- name: generate-date-hashes
 SELECT gtfs_generate_date_hashes(:package-id::INTEGER);
+
+-- name: fetch-services-packages
+SELECT p.id as "package-id"
+  FROM "external-interface-description" e, "gtfs_package" p
+ WHERE e.id = p."external-interface-description-id"
+   AND e."transport-service-id" = :service-id;
+
+-- name: fetch-distinct-services-from-transit-changes
+SELECT distinct t."transport-service-id" as id
+  FROM "gtfs-transit-changes" t;

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -30,7 +30,8 @@ SELECT * FROM gtfs_service_routes_with_daterange(:service-id::INTEGER);
 SELECT t."package-id", trip."trip-id",
        stoptime."stop-id", stoptime."departure-time", stoptime."stop-sequence",
         stop."stop-name", stop."stop-lat", stop."stop-lon"
-  FROM "gtfs-route" r
+  FROM "detection-route" r
+  JOIN "gtfs_package" p ON p.id = r."package-id"
   JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
   JOIN LATERAL unnest(t.trips) trip ON true
   JOIN LATERAL unnest(trip."stop-times") as stoptime ON TRUE
@@ -39,10 +40,8 @@ SELECT t."package-id", trip."trip-id",
    AND ROW(r."package-id", t."service-id")::service_ref IN
        (SELECT * FROM gtfs_services_for_date(
         (SELECT gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)), :date::DATE))
-   AND COALESCE(r."route-short-name",'') = COALESCE(:route-short-name::TEXT,'')
-   AND COALESCE(r."route-long-name",'') = COALESCE(:route-long-name::TEXT,'')
-   AND COALESCE(trip."trip-headsign",'') = COALESCE(:trip-headsign::TEXT,'')
- ORDER BY t."package-id", trip."trip-id", stoptime."stop-sequence";
+   AND r."route-hash-id" = :route-hash-id::TEXT
+ ORDER BY p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence";
 
 -- name: generate-date-hashes
 SELECT gtfs_generate_date_hashes(:package-id::INTEGER);

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -42,9 +42,7 @@ SELECT t."package-id", trip."trip-id",
    AND ROW(r."package-id", t."service-id")::service_ref IN
        (SELECT * FROM gtfs_services_for_date(
         (SELECT gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)), :date::DATE))
-   AND COALESCE(r."route-short-name",'') = COALESCE(:route-short-name::TEXT,'')
-   AND COALESCE(r."route-long-name",'') = COALESCE(:route-long-name::TEXT,'')
-   AND COALESCE(trip."trip-headsign",'') = COALESCE(:trip-headsign::TEXT,'')
+   AND r."route-hash-id" = :route-hash-id
  ORDER BY p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence";
 
 -- name: generate-date-hashes

--- a/ote/src/cljc/ote/db/gtfs.cljc
+++ b/ote/src/cljc/ote/db/gtfs.cljc
@@ -32,6 +32,8 @@
   ["gtfs-route-change-type" :gtfs/route-change-type (specql.transform/transform (specql.transform/to-keyword))]
   ["gtfs-route-change-info" :gtfs/route-change-info]
   ["gtfs-transit-changes" :gtfs/transit-changes]
+  ["gtfs-route-hash" :gtfs/route-hash]
+  ["gtfs-date-hash" :gtfs/date-hash]
   ["gtfs_stoptime_display" :gtfs/stoptime-display]
   ["detection-route" :gtfs/detection-route]
   ["detection-service-route-type" :gtfs/detection-service-route-type])
@@ -60,7 +62,12 @@
        (str (if lower-inclusive? "[" "(")
             lower ","
             upper
-            (if upper-inclusive? "]" ")")))))
+            (if upper-inclusive? "]" ")")))
+
+
+     ;; bytea
+     (defmethod composite/parse-value "bytea" [_ string]
+         string)))
 
 
 (defn date? [dt]

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -333,6 +333,9 @@
   (let [service-id (get-in app [:params :service-id])
         current-week-date (or (get-in app [:transit-visualization :changes :gtfs/current-week-date])
                               (t/now))
+        route-hash-id (if (:gtfs/route-hash-id route)
+                        (:gtfs/route-hash-id route)
+                        (str (:gtfs/route-short-name route) "-" (:gtfs/route-long-name route) "-" (:gtfs/trip-headsign route)))
         ;; Use dates in route, or default to current week date and 7 days after that.
         date1 (or (:gtfs/current-week-date route) current-week-date)
         date2 (or (:gtfs/different-week-date route)
@@ -345,8 +348,7 @@
                             {:long-name long})
                           (when-let [headsign (:gtfs/trip-headsign route)]
                             {:headsign headsign})
-                          (when-let [route-hash-id (:gtfs/route-hash-id route)]
-                            {:route-hash-id route-hash-id}))
+                            {:route-hash-id route-hash-id})
                 :on-success (tuck/send-async! ->RouteCalendarHashResponse)})
 
     (-> app


### PR DESCRIPTION
# Added
* Route-hash-id as a default way to match routes between gtfs packages

# Fixed
* "zero" row detection by ensuring that routes are matched between packages and date hashes are ordered similar way between packages using external-interface-description-id as a ordering key
  