### PR TITLE
162110175 foreign key

### DIFF
--- a/database/src/main/resources/db/migration/V1_125__add_delted_to_gtfs_package.sql
+++ b/database/src/main/resources/db/migration/V1_125__add_delted_to_gtfs_package.sql
@@ -1,0 +1,29 @@
+-- Add possibility to mark gtfs_package as deleted
+ALTER TABLE gtfs_package
+  ADD COLUMN "deleted?" bool default FALSE;
+
+-- Remove foreign key to external-interface-description
+ALTER TABLE gtfs_package
+  DROP CONSTRAINT "gtfs_package_external-interface-description-id_fkey";
+
+-- Drop foreign key from detection-service-route-type to transport-service
+ALTER TABLE "detection-service-route-type"
+  DROP CONSTRAINT "detection-service-route-type_transport-service-id_fkey";
+
+-- Add dropped foreign key and add delete cascade and update cascade
+ALTER TABLE "detection-service-route-type"
+  ADD CONSTRAINT "detection-service-route-type_transport-service-id_fkey"
+  FOREIGN KEY ("transport-service-id") REFERENCES "transport-service" (id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Drop foreign key
+ALTER TABLE "gtfs-transit-changes"
+  DROP CONSTRAINT "gtfs-transit-changes_transport-service-id_fkey";
+
+-- Add dropped foreign key and add delete cascade and update cascade
+ALTER TABLE "gtfs-transit-changes"
+  ADD CONSTRAINT "gtfs-transit-changes_transport-service-id_fkey"
+  FOREIGN KEY ("transport-service-id") REFERENCES "transport-service" (id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Drop foreign key from detection-route to gtfs_package and gtfs-route because package will stay in database even if routes and service are removed
+ALTER TABLE "detection-route" DROP CONSTRAINT "detection-route_package-id_fkey";
+ALTER TABLE "detection-route" DROP CONSTRAINT "detection-route_gtfs-route-id_fkey";

--- a/ote/src/clj/ote/integration/import/gtfs.clj
+++ b/ote/src/clj/ote/integration/import/gtfs.clj
@@ -287,7 +287,8 @@
      (first
       (specql/fetch db :gtfs/package
                     #{:gtfs/etag :gtfs/sha256}
-                    {:gtfs/external-interface-description-id interface-id}
+                    {:gtfs/external-interface-description-id interface-id
+                     :gtfs/deleted? false}
                     {::specql/order-by :gtfs/created
                      ::specql/order-direction :descending
                      ::specql/limit 1}))))

--- a/ote/src/clj/ote/services/transit_changes.sql
+++ b/ote/src/clj/ote/services/transit_changes.sql
@@ -42,7 +42,7 @@ SELECT ts.id AS "transport-service-id",
          WHERE id = ANY(c."package-ids")) AS "finnish-regions",
        (SELECT (upper(gtfs_package_date_range(p.id)) - '1 day'::interval)::date
           FROM gtfs_package p
-         WHERE p."transport-service-id" = ts.id
+         WHERE p."transport-service-id" = ts.id AND p."deleted?" = FALSE
          ORDER BY p.id DESC limit 1) as "max-date"
   FROM "transport-service" ts
   JOIN "transport-operator" op ON ts."transport-operator-id" = op.id

--- a/ote/src/clj/ote/tasks/pre_notices.sql
+++ b/ote/src/clj/ote/tasks/pre_notices.sql
@@ -22,8 +22,9 @@ WITH changes_with_regions AS (
          (SELECT array_agg(x.reg)
             FROM (SELECT DISTINCT unnest(p."finnish-regions") as reg
                     FROM gtfs_package p
-                   WHERE p.id = ANY(chg."package-ids")) x) AS "finnish-regions"
-                     AND p."deleted?" = FALSE
+                   WHERE p.id = ANY(chg."package-ids")
+                     AND p."deleted?" = FALSE) x) AS "finnish-regions"
+
     FROM "gtfs-transit-changes" chg
     WHERE chg.date = CURRENT_DATE
 

--- a/ote/src/clj/ote/tasks/pre_notices.sql
+++ b/ote/src/clj/ote/tasks/pre_notices.sql
@@ -23,6 +23,7 @@ WITH changes_with_regions AS (
             FROM (SELECT DISTINCT unnest(p."finnish-regions") as reg
                     FROM gtfs_package p
                    WHERE p.id = ANY(chg."package-ids")) x) AS "finnish-regions"
+                     AND p."deleted?" = FALSE
     FROM "gtfs-transit-changes" chg
     WHERE chg.date = CURRENT_DATE
 
@@ -43,6 +44,7 @@ SELECT to_char(chg."change-date", 'dd.mm.yyyy') as "change-date",
        gtfs_package p
  WHERE chg.date = CURRENT_DATE
    AND p.id = ANY(chg."package-ids")
+   AND p."deleted?" = FALSE
    AND p.created > CURRENT_DATE - interval '8 hours'
    AND chg."change-date" IS NOT NULL
    AND (chg."finnish-regions" IS NULL OR
@@ -58,6 +60,7 @@ WITH changes_with_regions AS (
             FROM (SELECT DISTINCT unnest(p."finnish-regions") as reg
                     FROM gtfs_package p
                    WHERE p.id = ANY(chg."package-ids")) x) AS "finnish-regions"
+                     AND p."deleted?" = FALSE
     FROM "gtfs-transit-changes" chg
 )
 SELECT to_char(chg."change-date", 'dd.mm.yyyy') as "change-date",

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -21,7 +21,8 @@
 (defn get-gtfs-packages [db service-id package-count]
   (let [id-map (map :gtfs/id (specql/fetch db :gtfs/package
                                            #{:gtfs/id}
-                                           {:gtfs/transport-service-id service-id}
+                                           {:gtfs/transport-service-id service-id
+                                            :gtfs/deleted? false}
                                            {:specql.core/order-by        :gtfs/id
                                             :specql.core/order-direction :desc
                                             :specql.core/limit           package-count}))

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -11,7 +11,7 @@ SELECT d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign", 
     ON (dh.date = d.date AND
         dh."package-id" = ANY(gtfs_service_packages_for_date(:service-id::INTEGER, d.date)))
   -- Join gtfs_package to get external-interface-description-id
-  JOIN gtfs_package p ON p.id = dh."package-id"
+  JOIN gtfs_package p ON p.id = dh."package-id" AND p."deleted?" = FALSE
   LEFT JOIN LATERAL unnest(dh."route-hashes") AS rh ON TRUE
  GROUP BY d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign", rh."route-hash-id"
  ORDER BY d.date;
@@ -33,7 +33,7 @@ SELECT t."package-id", trip."trip-id",
        stoptime."stop-id", stoptime."departure-time", stoptime."stop-sequence",
         stop."stop-name", stop."stop-lat", stop."stop-lon"
   FROM "detection-route" r
-  JOIN "gtfs_package" p ON p.id = r."package-id"
+  JOIN "gtfs_package" p ON p.id = r."package-id" AND p."deleted?" = FALSE
   JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
   JOIN LATERAL unnest(t.trips) trip ON true
   JOIN LATERAL unnest(trip."stop-times") as stoptime ON TRUE


### PR DESCRIPTION

# Fixed
* Transport service could not be removed or transport services external interface could not be removed if interface url did contain something that our system added as gtfs package to db.
Removing interface or service caused foreign key error due to delete "no action".
I added delete cascade when could and removed link to gtfs_package because we want to keep gtfs packages in our db in situations where service or interface is removed.
   
