### PR TITLE
161874264 operator ytj integration

### DIFF
--- a/cypress/integration/pre-notice_spec.js
+++ b/cypress/integration/pre-notice_spec.js
@@ -48,7 +48,7 @@ describe('Pre notice tests', () => {
         cy.get('#add-new-pre-notice').click({"force": true});
 
         // Select type
-        cy.get('#0_termination').click();
+        cy.get('[type="checkbox"]').first().click();
 
         // Give a description
 

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -877,7 +877,15 @@ You can also draw the operating area or point to the map with drawing tools. You
  {:loading-routes "Loading service routes."}
 
  :common-texts
- {:front-page-help-text "You have not yet registered any transport services to NAP-service catalog.
+ {:business-id-and-aux-names "Company name and auxiliary names"
+  :contact-details-plural "Contact details for company and auxiliary names"
+  :contact-details "Contact details"
+  :fetch-from-ytj "Fetch data from YTJ"
+  :check-your-input "Please check that the details you entered are correct."
+  :no-aux-names-for-business-id "There were no auxiliary business names for the business id."
+
+
+  :front-page-help-text "You have not yet registered any transport services to NAP-service catalog.
         You can register an external interface about your service or essential data about your service by using
         the NAP-service which Finnish Transport Aggency has developed for this purpose."
   :front-page-start-ote-query-header "Do you want to register essential data of your transport service?"
@@ -950,7 +958,11 @@ You can also draw the operating area or point to the map with drawing tools. You
   :minutes-placeholder "mm"
 
   :server-error "Error in server call. Contact support if the problem persists."
+  :server-error-try-later "Problems with a service. Please try again later."
+
   :forbidden "Forbidden"
+  :optionally-fill-manually "Optionally you may proceed to enter details manually."
+
   :nap-data-license (:md "The information you fill in on this form will be published in the NAP service catalog as open data. The published data will be licensed with [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/deed.en).")
 
   :save-user-success "Account info saved"
@@ -964,6 +976,7 @@ You can also draw the operating area or point to the map with drawing tools. You
 
   :delete-transport-operator
   {:title "Want to delete a transport operator?"
+   :title-base-view "Palveluntuottajan poistaminen"
    :confirm ["Are you sure you want to delete operator named \"" :name "\" permanently?"]}
 
   :navigation-prompt

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -887,7 +887,14 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
  {:loading-routes "Palvelun reittejä ladataan."}
 
  :common-texts
- {:front-page-help-text "Et ole vielä kirjannut liikkumispalvelutietoja NAP-palveluun.
+ {:business-id-and-aux-names "Toiminimi ja aputoiminimet"
+  :contact-details-plural "Toiminimiin liittyvät yhteystiedot"
+  :contact-details "Yhteystiedot"
+  :fetch-from-ytj "Hae tiedot YTJ:stä"
+  :check-your-input "Ole hyvä ja arkista, että syötit tiedot oikein."
+  :no-aux-names-for-business-id "Y-tunnukselle ei löytynyt aputoiminimiä"
+
+  :front-page-help-text "Et ole vielä kirjannut liikkumispalvelutietoja NAP-palveluun.
         Voit lisätä olemassaolevan palvelurajapintasi tai täyttää palvelusi olennaiset tiedot käyttämällä
         Liikenneviraston tähän tarkoitukseen kehittämää OTE-palvelua."
   :front-page-start-ote-query-header "Haluat tallentaa liikkumispalvelusi olennaisia tietoja?"
@@ -960,7 +967,10 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :minutes-placeholder "mm"
 
   :server-error "Virhe palvelinkutsussa. Jos ongelma jatkuu, ota yhteyttä tukeen."
+  :server-error-try-later "Ongelmia palvelussa. Yritä hetken kuluttua uudelleen."
+
   :forbidden "Käyttöoikeutesi eivät riitä sisällön katseluun."
+  :optionally-fill-manually "Vaihtoehtoisesti voit jatkaa tietojen syöttämistä käsin."
 
   :nap-data-license (:md "Tälle lomakkeelle täytetyt tiedot julkaistaan NAP-palvelussa avoimena datana. Julkaistujen tietojen lisenssi on [Creative Commons Nimeä 4.0 Kansainvälinen (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/deed.fi).")
 
@@ -974,7 +984,9 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
 
   :delete-transport-operator
   {:title "Poista palveluntuottaja?"
+   :title-base-view "Palveluntuottajan poistaminen"
    :confirm ["Haluatko varmasti poistaa palveluntuottajan: \"" :name "\" pysyvästi?"]}
+
 
   :navigation-prompt
   {:title "Sivulta poistumisen varmistus"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -882,7 +882,14 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
  {:loading-routes "Laddar rutterna för tjänsten."}
 
  :common-texts
- {:front-page-help-text "Du har inte ännu sparat mobilitetstjänster i NAP-tjänsten.
+ {:business-id-and-aux-names "Företagsnamn och hjälpnamn"
+  :contact-details-plural "Kontaktuppgifter för företagsnamn"
+  :contact-details "Kontaktuppgifter"
+  :fetch-from-ytj "Hämta data från YTJ"
+  :check-your-input "Please check that the details you entered are correct."
+  :no-aux-names-for-business-id "Det fanns inga extra företagsnamn för id."
+
+  :front-page-help-text "Du har inte ännu sparat mobilitetstjänster i NAP-tjänsten.
         Voit lisätä olemassaolevan palvelurajapintasi tai täyttää palvelusi olennaiset tiedot käyttämällä
         Liikenneviraston tähän tarkoitukseen kehittämää OTE-palvelua."
   :front-page-start-ote-query-header "Haluat tallentaa liikkumispalvelusi olennaisia tietoja?"
@@ -955,7 +962,11 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :minutes-placeholder "mm"
 
   :server-error "Fel i serveranropet. Om problemet fortsätter, kontakta NAP HelpDesk."
+  :server-error-try-later "Problem med tjänsten. Vänligen försök igen senare."
+
   :forbidden "Du har inte behörighet att visa innehållet."
+  :optionally-fill-manually "Alternativt kan du fortsätta att skriva in detaljer manuellt"
+  
   :nap-data-license (:md "Informationen Du ger i detta formulär publiceras i NAP-katalogen som öppen data med licensen [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/deed.sv).")
 
   :save-user-success "Profil sparad"
@@ -969,6 +980,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
 
   :delete-transport-operator
   {:title "Ta bort hela tjänsteproducenter?"
+   :title-base-view "Palveluntuottajan poistaminen"
    :confirm ["Vill du ta bort tjänsteproducenter \"" :name "\" slutgiltigt?"]}
 
   :navigation-prompt

--- a/ote/src/clj/ote/main.clj
+++ b/ote/src/clj/ote/main.clj
@@ -59,7 +59,7 @@
    :robots (component/using (robots/->RobotsTxt (get-in config [:http :allow-robots?])) [:http])
 
    ;; Services for the frontend
-   :transport (component/using (transport-service/->Transport (:nap config)) [:http :db])
+   :transport (component/using (transport-service/->Transport config) [:http :db])
    :viewer (component/using (viewer/->Viewer) [:http])
    :external (component/using (external/->External (:nap config)) [:http :db])
    :routes (component/using (routes/->Routes (:nap config)) [:http :db])

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -8,6 +8,7 @@
             [ote.db.transport-operator :as t-operator]
             [ote.db.transport-service :as t-service]
             [ote.db.common :as common]
+            [ote.db.user :as user]
             [compojure.core :refer [routes GET POST DELETE]]
             [taoensso.timbre :as log]
             [clojure.java.jdbc :as jdbc]
@@ -23,9 +24,13 @@
             [ote.access-rights :as access]
             [clojure.string :as str]
             [ote.nap.ckan :as ckan]
-            [clojure.set :as set])
+            [clojure.set :as set]
+            [ote.util.feature :as feature])
   (:import (java.time LocalTime)
-           (java.sql Timestamp)))
+           (java.sql Timestamp)
+           (java.util UUID)))
+
+; TODO: split file to transport-service and transport-operator
 
 (defqueries "ote/services/places.sql")
 (defqueries "ote/services/transport.sql")
@@ -140,8 +145,45 @@
      :transport-service-vector transport-services-vector
      :user cleaned-user}))
 
+(defn- create-group!
+  "Takes `op` operator and `user` and pairs user to organization in db using the member table. Sets role (Capacity) to 'admin'"
+  [db op user]
+  {:pre [(some? op)]}
+  (let [group (specql/insert! db ::t-operator/group
+                              {::t-operator/group-id (str (UUID/randomUUID))
+                               ::t-operator/group-name (str "transport-operator-" (::t-operator/id op))
+                               ::t-operator/is_organization true ;; TODO: verify is this needed?
+                               ::t-operator/type "organization"
+                               ::t-operator/description (or (::t-operator/ckan-description op) "")
+                               ::t-operator/title (::t-operator/name op)})
+        member (specql/insert! db ::user/member
+                               {::user/id (str (UUID/randomUUID))
+                                ::user/table_id (get-in user [:user :id])
+                                ::user/group_id (:ote.db.transport-operator/group-id group)
+                                ::user/table_name "user"
+                                ::user/capacity "admin"
+                                ::user/state "active"})]
+    (log/debug "create-group!: op=" op "\n user=" user "\n group=" group "\n member=" member)
+    group))
+
+(defn- update-group!
+  "Takes `op` operator and updates the group table for matching row. Returns number of affected rows."
+  [db op]
+  {:pre [(coll? op)
+         (and (some? (::t-operator/ckan-group-id op)) (string? (::t-operator/ckan-group-id op)))]}
+  (log/debug "update-group!: op=" op)
+  (let [group-resp (update! db ::t-operator/group
+                            {::t-operator/title       (::t-operator/name op)
+                             ::t-operator/description (or (::t-operator/ckan-description op) "")}
+                            {::t-operator/group-id (::t-operator/ckan-group-id op)})]
+
+    (when (not= 1 group-resp) (log/error (prn-str "update-group!: updating groups, expected 1 but got number of records=" group-resp)))
+    group-resp))
+
 (defn- create-transport-operator [nap-config db user data]
   ;; Create new transport operator
+  (log/debug (prn-str "create-transport-operator: data=" data))
+
   (tx/with-transaction db
     (let [ckan (ckan/->CKAN (:api nap-config) (get-in user [:user :apikey]))
 
@@ -163,8 +205,29 @@
                {::t-operator/id (::t-operator/id operator)})
       operator)))
 
+(defn- create-transport-operator-nap
+  "Takes `db`, `user` and operator `data`. Creates a new transport-operator and a group (organization) for it.
+   Links the transport-operator to group via member table"
+  [db user data]
+  {:pre [(some? data)]}
+  (log/debug (prn-str "create-transport-operator-nap: data=" data))
+  (tx/with-transaction db
+    (let [op (insert! db ::t-operator/transport-operator
+                      (dissoc data
+                              ::t-operator/id
+                              ::t-operator/ckan-description
+                              ::t-operator/ckan-group-id))
+          group (create-group! db op user)]
+
+      (update! db ::t-operator/transport-operator
+               {::t-operator/ckan-group-id (::t-operator/group-id group)} ;;TODO: miksi alias, me niskö suoraan id:llä?
+               {::t-operator/id (::t-operator/id op)})
+      op)))
+
 (defn- update-transport-operator [nap-config db user {id ::t-operator/id :as data}]
   ;; Edit transport operator
+  (log/debug (prn-str "update-transport-operator: data=" data))
+
   (authorization/with-transport-operator-check
     db user id
     #(tx/with-transaction db
@@ -180,6 +243,7 @@
                (fetch db ::t-operator/transport-operator
                       #{::t-operator/ckan-group-id}
                       {::t-operator/id id})))]
+
          ;; We show only title in ckan side - so no need to update other values
          (ckan/update-organization!
           ckan
@@ -190,10 +254,51 @@
          ;; Return operator
          operator))))
 
-(defn- save-transport-operator [nap-config db user data]
-  ((if (:new? data)
-     create-transport-operator
-     update-transport-operator) nap-config db user data))
+(defn- select-op-keys-to-update [op]
+  (select-keys op
+               [::t-operator/name
+                ::t-operator/billing-address
+                ::t-operator/visiting-address
+                ::t-operator/phone
+                ::t-operator/gsm
+                ::t-operator/email
+                ::t-operator/homepage]))
+
+(defn- update-transport-operator-nap [db user {id ::t-operator/id :as data}]
+  ;; Edit transport operator
+  {:pre [(coll? data)
+         (number? (::t-operator/id data))]}
+  (log/debug (prn-str "update-transport-operator: data=" data))
+  (authorization/with-transport-operator-check
+    db user id
+    #(tx/with-transaction
+       db
+       (update! db ::t-operator/transport-operator
+                (select-op-keys-to-update data)
+                {::t-operator/id (::t-operator/id data)})
+       (update-group! db data))))
+
+(defn- upsert-transport-operator
+  "Creates or updates a transport operator for each company name. Operators will have the same details, except the name"
+  [nap-config db user data]
+  {:pre [(some? data)]}
+  ;(log/debug (prn-str "upsert-transport-operator: data= " data " \n   user=" user " \n   config=" nap-config))
+  (let [operator data]
+      ;(log/debug (prn-str "upsert-transport-operator: operator= " operator))
+      (if (::t-operator/id operator)
+        (update-transport-operator-nap db user operator)
+        (create-transport-operator-nap db user operator))))
+
+(defn- save-transport-operator [config db user data]
+  {:pre [(some? data)]}
+  (log/debug (prn-str "save-transport-operator " data))
+
+  (if (feature/feature-enabled? config :open-ytj-integration)
+    (upsert-transport-operator (:nap config) db user data)
+    ((if (:new? data)
+       create-transport-operator
+       update-transport-operator) (:nap config) db user data))
+  )
 
 (defn ensure-bigdec [value]
   (when (not (nil? value )) (bigdec value)))
@@ -349,67 +454,69 @@
 
 (defn- transport-routes-auth
   "Routes that require authentication"
+  [db config]
+  (let [nap-config (:nap config)]
+    (routes
 
-  [db nap-config]
-  (routes
+      (GET "/transport-service/:id" [id]
+        (let [ts (get-transport-service db (Long/parseLong id))]
+          (if-not ts
+            {:status 404}
+            (http/no-cache-transit-response ts))))
 
-    (GET "/transport-service/:id" [id]
-      (let [ts (get-transport-service db (Long/parseLong id))]
-        (if-not ts
-          {:status 404}
-          (http/no-cache-transit-response ts))))
+      (GET "/t-operator/:id" [id :as {user :user}]
+        (let [to (edit-transport-operator db user (Long/parseLong id))]
+          (if-not to
+            {:status 404}
+            (http/no-cache-transit-response to))))
 
-    (GET "/t-operator/:id" [id :as {user :user}]
-      (let [to (edit-transport-operator db user (Long/parseLong id))]
-        (if-not to
-          {:status 404}
-          (http/no-cache-transit-response to))))
+      (POST "/transport-operator/group" {user :user}
+        (http/transit-response
+          (get-transport-operator db {::t-operator/ckan-group-id (get (-> user :groups first) :id)})))
 
-    (POST "/transport-operator/group" {user :user}
-      (http/transit-response
-        (get-transport-operator db {::t-operator/ckan-group-id (get (-> user :groups first) :id)})))
+      (POST "/transport-operator/data" {user :user}
+        (http/transit-response
+          (get-user-transport-operators-with-services db (:groups user) (:user user))))
 
-    (POST "/transport-operator/data" {user :user}
-      (http/transit-response
-        (get-user-transport-operators-with-services db (:groups user) (:user user))))
+      (POST "/transport-operator" {form-data :body
+                                   user      :user}
+        (http/transit-response
+          (save-transport-operator config db user
+                                   (http/transit-request form-data))))
 
-    (POST "/transport-operator" {form-data :body
-                                 user      :user}
-      (http/transit-response
-        (save-transport-operator nap-config db user
-                                 (http/transit-request form-data))))
+      (POST "/transport-service" {form-data :body
+                                  user      :user}
+        (save-transport-service-handler nap-config db user (http/transit-request form-data)))
 
-    (POST "/transport-service" {form-data :body
-                                user      :user}
-      (save-transport-service-handler nap-config db user (http/transit-request form-data)))
+      (POST "/transport-service/delete" {form-data :body
+                                         user      :user}
+        (http/transit-response
+          (delete-transport-service! nap-config db user
+                                     (:id (http/transit-request form-data)))))
 
-    (POST "/transport-service/delete" {form-data :body
-                                       user      :user}
-      (http/transit-response
-        (delete-transport-service! nap-config db user
-                                   (:id (http/transit-request form-data)))))
-
-    (POST "/transport-operator/delete" {form-data :body
-                                        user      :user}
-      (http/transit-response
-        (delete-transport-operator! nap-config db user
-                                    (:id (http/transit-request form-data)))))))
+      (POST "/transport-operator/delete" {form-data :body
+                                          user      :user}
+        (http/transit-response
+          (delete-transport-operator! nap-config db user
+                                      (:id (http/transit-request form-data))))))))
 
 (defn- transport-routes
   "Unauthenticated routes"
-  [db nap-config]
+  [db config]
   (routes
     (GET "/transport-operator/:ckan-group-id" [ckan-group-id]
       (http/transit-response
-        (get-transport-operator db {::t-operator/ckan-group-id ckan-group-id})))))
+        (get-transport-operator db {::t-operator/ckan-group-id ckan-group-id})))
 
-(defrecord Transport [nap-config]
+    ))
+
+(defrecord Transport [config]
   component/Lifecycle
   (start [{:keys [db http] :as this}]
     (assoc
       this ::stop
-      [(http/publish! http (transport-routes-auth db nap-config))
-       (http/publish! http {:authenticated? false} (transport-routes db nap-config))]))
+      [(http/publish! http (transport-routes-auth db config))
+       (http/publish! http {:authenticated? false} (transport-routes db config))]))
   (stop [{stop ::stop :as this}]
     (doseq [s stop]
       (s))

--- a/ote/src/cljc/ote/db/user.cljc
+++ b/ote/src/cljc/ote/db/user.cljc
@@ -21,8 +21,8 @@
   ["user" ::user]
   ["password-reset-request" ::password-reset-request
    {"created" :ote.db.modification/created
-    "created-by" :ote.db.modification/created-by}])
-
+    "created-by" :ote.db.modification/created-by}]
+  ["member" ::member])
 
 (defn username-valid? [username]
   (boolean (and (string? username)

--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -6,7 +6,359 @@
             [ote.db.transport-operator :as t-operator]
             [ote.app.routes :as routes]
             [tuck.core :refer [define-event send-async! Event]]
-            [ote.app.controller.common :refer [->ServerError]]))
+            [ote.app.controller.common :refer [->ServerError]]
+            [ote.app.controller.flags :as flags]
+            [ote.db.common :as common]))
+
+;; TODO: serialize ytj fetches? What if user back-forwards on UI, would old resp complete and mix up app state?
+
+(if (flags/enabled? :open-ytj-integration) ;;;;;;;;;;;;;;;;;;; TODO: remove condition check when feature is approved
+(do
+
+(defn- strip-ytj-metadata [app] (dissoc app :ytj-response :ytj-company-names :ytj-flags :transport-operator-save-q))
+
+(defn- address-of-type [type addresses]
+  "Returns from a vector the first map whose type key matches to YTJ address type."
+  (let [item (first (filter #(= type (:type %)) addresses))]
+    {::common/post_office (:city item)
+     ::common/postal_code (:postCode item)
+     ::common/street      (:street item)}))
+
+(defn- filter-coll-type [type collection]
+  "Returns a filtered a collection of maps based on :type key"
+  (first (filter #(some (fn [pred] (pred %)) [(comp #{type} :type)]) collection)))
+
+(defn- preferred-ytj-contact [types contacts]
+  "Takes 'types' vector of key names as strings in order of preference, 'contacts' collection of maps
+  and finds the first contacts map which has a key with a matching name.
+  Key names are searched in the order they are in `types`.
+  Returns the value of the forst matching key from the first matching map"
+  (loop [[type & remaining] types
+         result []]
+    (if (and type (empty? result))
+      (let [match (:value (filter-coll-type type contacts))]
+        ;(.debug js/console "Contact match=" (clj->js match))
+        (recur remaining (if match (conj result match) result)))
+      (do
+        ;(.debug js/console "Contact result=" (clj->js result))
+        (first result)))))                                  ;; Return first because expected value is string not vector
+
+;; Keys for saving fields common with all companies sharing the same Y-tunnus/business-id
+(defn- take-common-op-keys [coll] (select-keys coll [::t-operator/business-id
+                                                     ::t-operator/billing-address
+                                                     ::t-operator/visiting-address
+                                                     ::t-operator/phone
+                                                     ::t-operator/gsm
+                                                     ::t-operator/email
+                                                     ::t-operator/homepage]))
+
+;; Keys unique to operator when creating a company
+(defn- take-new-op-keys [coll] (select-keys coll [::t-operator/name]))
+
+; Keys unique to an operator when editing existing company. Extra to `take-common-op-keys`
+(defn- take-update-op-keys [coll] (select-keys coll [::t-operator/id ::t-operator/ckan-description ::t-operator/ckan-group-id]))
+
+;; Take keys supported by backend transport-operator API
+(defn take-operator-api-keys [op] (merge (take-new-op-keys op) (take-update-op-keys op) (take-common-op-keys op)))
+
+;; Takes 'ytj-name' and finds the first from `nap-operators` whose name is a match, or nil.
+(defn- name->nap-operator [ytj-name nap-operators]
+  ;(.debug js/console "name->nap-operator: " "ytj-name=" (clj->js ytj-name) "nap-names=" (clj->js nap-operators))
+  (let [nap-item (some  #(when (= (get-in % [:transport-operator ::t-operator/name]) ytj-name) %) ;; Return whole item or nil
+                   nap-operators)]
+    (:transport-operator nap-item)))
+
+(defn- ytj->nap-companies [operators-ytj operators-nap]
+  "Takes `operators-ytj` and if there's a name match to an item in `operators-nap`,
+  copies into the ytj item nap keys which are not shared with other nap companies which have the same business-id."
+  ;(.debug js/console "ytj->nap-companies operators-ytj=" (clj->js operators-ytj) " \n operators-nap=" (clj->js operators-nap))
+  (doall
+    (map (fn [ytj]
+           (let [nap-item (name->nap-operator (:name ytj) operators-nap)
+                 nap-id (::t-operator/id nap-item)]
+             (cond-> ytj
+                     true (assoc ::t-operator/name (:name ytj)) ;; All operators must have name set to allow updating operator and group data if necessary
+                     true (dissoc :name)                        ;; Remove ytj namespace key
+                     (some? nap-id) (merge (take-update-op-keys nap-item)) ;; nap fields user is allowed to edit
+                     ;(some? nap-id) (assoc ::t-operator/id nap-id) ;; Set id of existing operators so they get updated and not created by nap service
+                     ;; Remove keys not supported by nap service
+                     true (take-operator-api-keys))))
+         operators-ytj)))
+
+;; Use-cases:
+;; Create new op, business-id found in YTJ
+;; Create new op, business-id not found in YTJ
+;; Edit op, business id found in YTJ
+;; Edit op, business id not found in YTJ
+(defn- process-ytj-data [app response]
+  ;(.debug js/console "process-ytj-data response=" (clj->js response))
+  (let [ytj-business-id-hit? (= 200 (:status response))
+        ytj-address-billing (address-of-type 1 (:addresses response))
+        use-ytj-addr-billing? ytj-business-id-hit?
+        ytj-address-visiting (address-of-type 2 (:addresses response))
+        use-ytj-addr-visiting? ytj-business-id-hit?
+        ytj-contact-phone (first (preferred-ytj-contact ["Puhelin" "Telefon" "Telephone"] (:contactDetails response)))
+        use-ytj-phone? (and (not-empty ytj-contact-phone) (empty? (::t-operator/phone app)))
+        ytj-contact-gsm (preferred-ytj-contact ["Matkapuhelin" "Mobiltelefon" "Mobile phone"] (:contactDetails response))
+        use-ytj-gsm? (and (not-empty ytj-contact-gsm) (empty? (::t-operator/gsm app)))
+        ;ytj-contact-email (first (preferred-ytj-contact ["Matkapuhelin" "Mobiltelefon" "Mobile phone"] (:contactDetails response))) ;TODO: check ytj field types, does it return email?
+        use-ytj-email? false
+        ytj-contact-web (first (preferred-ytj-contact ["Kotisivun www-osoite" "www-adress" "Website address"] (:contactDetails response)))
+        use-ytj-web? (and (not-empty ytj-contact-web) (empty? (::t-operator/homepage app)))
+        ytj-company-names (when (some? (:name response)) (ytj->nap-companies
+                                                           (into [{:name (:name response)}] (:auxiliaryNames response)) ; Insert company name first to checkbox list before aux names
+                                                           (:transport-operators-with-services app)))]
+    (.debug js/console "process-ytj-data ytj-company-names=" (clj->js ytj-company-names) " app=" (clj->js app))
+    (cond-> app
+            true (assoc
+                   :ytj-response response
+                   :ytj-response-loading false
+                   :transport-operator-loaded? true)
+            true (assoc-in [:transport-operator :transport-operators-to-save] []) ;; Init to empty vector to allow populating it in different scenarios
+            ;; Set data sources for form fields and if user allowed to edit
+            use-ytj-addr-billing? (assoc-in [:transport-operator ::t-operator/billing-address] ytj-address-billing)
+            true (assoc-in [:ytj-flags :use-ytj-addr-billing?] use-ytj-addr-billing?)
+            use-ytj-addr-visiting? (assoc-in [:transport-operator ::t-operator/visiting-address] ytj-address-visiting)
+            true (assoc-in [:ytj-flags :use-ytj-addr-visiting?] use-ytj-addr-visiting?)
+            use-ytj-phone? (assoc-in [:transport-operator ::t-operator/phone] ytj-contact-phone)
+            use-ytj-phone? (assoc-in [:ytj-flags :use-ytj-phone?] true)
+            use-ytj-gsm? (assoc-in [:transport-operator ::t-operator/gsm] ytj-contact-gsm)
+            use-ytj-gsm? (assoc-in [:ytj-flags :use-ytj-gsm?] true)
+            ;use-ytj-email? (assoc-in [:transport-operator ::t-operator/email] ytj-contact-email) ;TODO: check ytj field types, does it return email?
+            use-ytj-email? (assoc-in [:ytj-flags :use-ytj-email?] true)
+            use-ytj-web? (assoc-in [:transport-operator ::t-operator/homepage] ytj-contact-web)
+            use-ytj-web? (assoc-in [:ytj-flags :use-ytj-homepage?] true)
+            ;; Set data source for company selection list
+            (not-empty ytj-company-names) (assoc :ytj-company-names ytj-company-names)
+            ;; Set checkbox list items selected if they have an ytj name match in nap:
+            (not-empty ytj-company-names) (assoc-in [:transport-operator :transport-operators-to-save] (filterv ::t-operator/id ytj-company-names)))))
+
+(define-event FetchYtjOperatorResponse [response]
+              {}
+              (process-ytj-data app response))
+
+(defn- send-fetch-ytj [app id]
+  "Takes app state and business id, initiates details fetch for id from YTJ. Returns a new app state."
+  {:pre [(some? id)]}
+  (comm/get! (str "fetch/ytj?company-id=" id)
+             {:on-success (send-async! ->FetchYtjOperatorResponse)
+              :on-failure (send-async! ->FetchYtjOperatorResponse)})
+  (-> app
+      (dissoc :ytj-response)
+      (assoc :ytj-response-loading true)))
+
+(define-event FetchYtjOperator [id]
+              {}
+              (send-fetch-ytj app id))
+
+(define-event CancelTransportOperator []
+              {}
+              (.debug js/console "transport-operator/CancelTransportOperator")
+              (routes/navigate! :own-services)
+              (update-in app [:transport-operator] dissoc :new?))
+
+(define-event VerifyCreateState []
+              {}
+              ;; To avoid app state problems redirect to own services if user refreshes on operator creation view
+              (when-not (get-in app [:transport-operator :new?])
+                (routes/navigate! :own-services))
+              app)
+
+(define-event ToggleTransportOperatorDeleteDialog []
+              {:path [:transport-operator :show-delete-dialog?]
+               :app show?}
+              (not show?))
+
+(define-event DeleteTransportOperatorResponse [response]
+              {}
+              (routes/navigate! :own-services)
+              (-> app
+                  (assoc-in [:transport-operator :show-delete-dialog?] false)
+                  (assoc :flash-message (tr [:common-texts :delete-operator-success])
+                         :services-changed? true)))
+
+(define-event DeleteTransportOperator [id]
+              {}
+              (comm/post! "transport-operator/delete"  {:id id}
+                          {:on-success (send-async! ->DeleteTransportOperatorResponse)
+                           :on-failure (send-async! ->ServerError)})
+              app)
+
+(defrecord SelectOperator [data])
+(defrecord SelectOperatorForTransit [data])
+(defrecord EditTransportOperator [id])
+(defrecord EditTransportOperatorResponse [response])
+(defrecord EditTransportOperatorState [data])
+(defrecord SaveTransportOperator [])
+(defrecord SaveTransportOperatorResponse [data])
+(defrecord FailedTransportOperatorResponse [response])
+
+(defrecord TransportOperatorResponse [response])
+(defrecord CreateTransportOperator [])
+
+;; Takes `app`, POSTs the next transport operator in queue and updates the queue.
+;; Returns a new app state.
+(defn- save-next-operator! [app]
+  (let [ops-to-save (:transport-operator-save-q app)
+        op-next (first ops-to-save)
+        ops-rest (rest ops-to-save)]
+    (.debug js/console "save-next-operator! app=" (clj->js app) " \n next=" (clj->js op-next) " \n in queue=" (count ops-rest)) ;; TODO: disable from production
+
+    (if (some? op-next)
+      (do (comm/post! "transport-operator" op-next
+                      {:on-success (send-async! ->SaveTransportOperatorResponse)
+                       :on-failure (send-async! ->FailedTransportOperatorResponse)})
+          (assoc app :transport-operator-save-q ops-rest))
+      (dissoc app :transport-operator-save-q))))
+
+(defn transport-operator-by-ckan-group-id[id]
+  (comm/get! (str "transport-operator/" id) {:on-success (send-async! ->TransportOperatorResponse)}))
+
+(extend-protocol Event
+
+  CreateTransportOperator
+  (process-event [_ app]
+    (.debug js/console "transport-operator: CreateTransportOperator")
+    (let [res (-> app
+                    (strip-ytj-metadata)
+                    (assoc
+                      :transport-operator {:new? true}
+                      :services-changed? true))]
+      (routes/navigate! :transport-operator)
+      res))
+
+  SelectOperator
+  (process-event [{data :data} app]
+    (let [id (get data ::t-operator/id)
+          service-operator (some #(when (= id (get-in % [:transport-operator ::t-operator/id]))
+                                    %)
+                                 (:transport-operators-with-services app))
+          route-operator (some #(when (= id (get-in % [:transport-operator ::t-operator/id]))
+                                  %)
+                               (:route-list app))]
+      (assoc app
+        :transport-operator (:transport-operator service-operator)
+        :transport-service-vector (:transport-service-vector service-operator)
+        :routes-vector (:routes route-operator))))
+
+  SelectOperatorForTransit
+  (process-event [{data :data} app]
+    (let [id (get data ::t-operator/id)
+          selected-operator (some #(when (= id (get-in % [:transport-operator ::t-operator/id]))
+                                     %)
+                                  (:route-list app))]
+      (assoc app
+        :transport-operator (:transport-operator selected-operator)
+        :routes-vector (:routes selected-operator))))
+
+  EditTransportOperator
+  (process-event [{id :id} app]
+    ;(.debug js/console "EditTransportOperator id=" (clj->js id))
+    (if id
+      (do
+        (comm/get! (str "t-operator/" id)
+                   {:on-success (send-async! ->EditTransportOperatorResponse)})
+        (assoc app :transport-operator-loaded? false))
+      (assoc app :transport-operator-loaded? true)))
+
+  EditTransportOperatorResponse                             ;; todo: pois
+  (process-event [{response :response} app]
+    ;(.debug js/console "EditTransportOperatorResponse response=" (clj->js response))
+
+    (let [state (assoc app :transport-operator response
+                           :transport-operator-loaded? true)
+          nap-business-id (get-in state [:transport-operator ::t-operator/business-id])
+          op-ytj-cache-miss? (or (empty? (:ytj-company-names state)) (not= nap-business-id (get-in state [:ytj-response :businessId])))]
+
+      (if op-ytj-cache-miss?
+        (send-fetch-ytj state nap-business-id)
+        (process-ytj-data state (:ytj-response state))
+        )
+      ))
+
+  EditTransportOperatorState
+  (process-event [{data :data} app]
+    (dissoc
+      (update app :transport-operator merge data)
+      :transport-operator-save-q))
+
+  ;; Start saving sequence after user action.
+  ;; Two categories of operators:
+  ;; 1) Those affected directly: name or description updated/created
+  ;; 2) Those affected indirectly: update fields shared with all companies using the same business-id/y-tunnus. In practise contact fields.
+  ;; Creates an operator map queue to save each affected operator, but select fields based on which category operator falls in. Backend should save fields found under operator map which it receives.
+  SaveTransportOperator
+  (process-event [_ app]
+    (let [ytj-ops-selected (get-in app [:transport-operator :transport-operators-to-save])
+          op-new? (nil? (get-in app [:params :id]))
+          op-nap? (empty? ytj-ops-selected)
+          op-update-nap? (and (not op-new?) op-nap?)
+          data-fields (-> app
+                          :transport-operator
+                          (dissoc :new?)
+                          form/without-form-metadata)
+          operators-to-save (if op-nap?
+                              ;; Copy all user's fields to operator map because user sets all fields for non-ytj operator.
+                              (vector (merge (take-common-op-keys data-fields)
+                                             (take-new-op-keys data-fields)
+                                             (when op-update-nap?) (take-update-op-keys data-fields)))
+                              ;; Copy only fields allowed for user to edit to ytj-matching operator maps because other values are already set
+                              (mapv #(merge % (take-common-op-keys data-fields)) ytj-ops-selected))]
+      ;(.debug js/console "SaveTransportOperator data-fields=" (clj->js data-fields) " \n ytj-ops-selected=" (clj->js ytj-ops-selected) " \n operators-to-save=" (clj->js operators-to-save) )
+      (save-next-operator!
+        (assoc app :transport-operator-save-q operators-to-save))))
+
+  FailedTransportOperatorResponse
+  (process-event [{response :response} app]
+    (let [sending-done? (empty? (:transport-operator-save-q app))
+          state (-> app
+                    (assoc :flash-message-error (tr [:common-texts :save-failed]))
+                    (save-next-operator!))]
+
+      ;; Stay on page as long as there's items to send - otherwise there will be app state inconsistency problems
+      (when sending-done?
+        (routes/navigate! :own-services))
+
+      state))
+
+  SaveTransportOperatorResponse
+  (process-event [{data :data} app]
+    (.debug js/console "SaveTransportOperatorResponse: sending?=" (clj->js (:transport-operator-save-q app)))
+
+    (let [sending-done? (empty? (:transport-operator-save-q app))
+          state (cond-> app
+                        true (assoc
+                               :flash-message (tr [:common-texts :transport-operator-saved]))
+                        sending-done? (assoc
+                                        :transport-operator data
+                                        :transport-operators-with-services (map (fn [{:keys [transport-operator] :as operator-with-services}]
+                                                                                  (if (= (::t-operator/id data) (::t-operator/id transport-operator))
+                                                                                    (assoc operator-with-services :transport-operator data)
+                                                                                    operator-with-services))
+                                                                                (:transport-operators-with-services app))
+                                        :services-changed? true)
+                        true (save-next-operator!))]
+      ;; Stay on page as long as there's items to send - otherwise there will be app state inconsistency problems
+      (when sending-done?
+        (routes/navigate! :own-services))
+
+      state))
+
+  TransportOperatorResponse
+  (process-event [{response :response} app]
+    (assoc app
+      :transport-operator (assoc response
+                            :loading? false))))
+
+(defmethod routes/on-navigate-event :transport-operator [{id :params}]
+  (.debug js/console "transport-operator/on-navigate-event: id=" (clj->js id))
+  (if (some? (:id id))
+    (->EditTransportOperator (:id id))
+    (->VerifyCreateState)
+    ))
+
+)
+(do  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; TODO: remove this no-YTJ branch when feature is approved
 
 (define-event ToggleTransportOperatorDeleteDialog []
   {:path [:transport-operator :show-delete-dialog?]
@@ -79,15 +431,9 @@
 
   EditTransportOperator
   (process-event [{id :id} app]
-    (if id
-      (do
-        (comm/get! (str "t-operator/" id)
-                   {:on-success (send-async! ->EditTransportOperatorResponse)})
-        (assoc app
-               :transport-operator-loaded? false))
-      (do
-        (assoc app
-               :transport-operator-loaded? true))))
+    (comm/get! (str "t-operator/" id)
+               {:on-success (send-async! ->EditTransportOperatorResponse)})
+    (assoc app :transport-operator-loaded? false))
 
   EditTransportOperatorResponse
   (process-event [{response :response} app]
@@ -131,4 +477,4 @@
   (process-event [{response :response} app]
     (assoc app
       :transport-operator (assoc response
-                            :loading? false))))
+                            :loading? false))))))

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -75,6 +75,11 @@
 (defn flex-container [dir]
   {:display "flex" :flex-direction dir})
 
+(defn flex-container2 []
+  {:display "flex" :flex-direction "row" :width "100%"})
+
+(def flex-child {:flex 1 })
+
 (def item-list-container
   (merge (flex-container "row")
          {:flex-wrap "wrap"}))

--- a/ote/src/cljs/ote/style/form.cljs
+++ b/ote/src/cljs/ote/style/form.cljs
@@ -38,6 +38,9 @@
 
 (def full-width {:width "100%"})
 
+(def half-width {:width "50%"})
+
+
 (def subtitle (merge full-width
                      {:margin "1em 0 0 0.5em"}))
 (def subtitle-h {:margin "0"})

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -867,7 +867,7 @@
              ^{:key i}
              [:div {:style {:display "flex" :padding-top "10px"}}
               [:span
-               [ui/checkbox {:id (str i "_" (name option))
+               [ui/checkbox {:id (str i "_" (str option))
                              :label      (when-not table? (show-option option))
                              :checked    checked?
                              :disabled   (not (option-enabled? option))
@@ -1017,3 +1017,27 @@
           :form [company-input-fields update! companies data]
           ;; default
           ""))]]))
+
+(defmethod field :external-button [{:keys [label on-click disabled primary secondary style]}]
+  ;; Options
+  ; :label Button label text for displaying
+  ; :on-click On-click callback fn
+  ; :disabled Boolean property for disabling button
+  ; primary
+  ; secondary
+  [:div
+   [ui/raised-button
+    {:label     label
+     :primary   primary
+     :secondary secondary
+     :on-click  #(on-click)
+     :disabled  disabled
+     :style     style
+     }]]
+  )
+
+(defmethod field :text-label [{:keys [label style h-style]}]
+  ;; Options
+  ; :label Text for displaying
+  [:div (when style {:style style}) (if h-style [h-style label] [:p label])]
+  )

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -6,6 +6,7 @@
             [cljs-react-material-ui.icons :as ic]
             [ote.ui.common :refer [linkify ckan-iframe-dialog]]
             [ote.views.transport-operator :as to]
+            [ote.views.transport-operator-ytj :as to-ytj]
             [ote.views.front-page :as fp]
             [ote.app.controller.front-page :as fp-controller]
             [ote.views.transport-service :as t-service]
@@ -118,7 +119,7 @@
                     :front-page [fp/front-page e! app]
                     :own-services [fp/own-services e! app]
                     :transport-service [t-service/select-service-type e! app]
-                    :transport-operator [to/operator e! app]
+                    :transport-operator (if (flags/enabled? :open-ytj-integration) [to-ytj/operator-ytj e! app] [to/operator e! app]) ; TODO: ytj replaces old solution when ready
 
                     ;; Routes for the service form, one for editing an existing one by id
                     ;; and another when creating a new service

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -1,0 +1,292 @@
+(ns ote.views.transport-operator-ytj
+  "Form to edit transport operator information." ; TODO: this ytj replaces old solution when ready
+  (:require [reagent.core :as r]
+            [cljs-react-material-ui.reagent :as ui]
+            [cljs-react-material-ui.icons :as ic]
+
+            [ote.ui.form :as form]
+            [ote.ui.form-groups :as form-groups]
+            [ote.ui.buttons :as buttons]
+            [ote.ui.validation :as ui-validation]
+            [stylefy.core :as stylefy]
+            [ote.style.form :as style-form]
+            [ote.ui.common :as ui-common]
+            [ote.ui.form-fields :as form-fields]
+
+            [ote.app.controller.transport-operator :as to]
+            [ote.app.controller.front-page :as fp]
+
+            [ote.db.transport-operator :as t-operator]
+            [ote.db.common :as common]
+            [ote.localization :refer [tr tr-key]]
+            [ote.style.base :as style-base]))
+
+(defn- delete-operator [e! operator]
+  (when (:show-delete-dialog? operator)
+    [ui/dialog
+     {:id "delete-transport-operator-dialog"
+      :open    true
+      :title   (tr [:dialog :delete-transport-operator :title])
+      :actions [(r/as-element
+                  [ui/flat-button
+                   {:label    (tr [:buttons :cancel])
+                    :primary  true
+                    :on-click #(e! (to/->ToggleTransportOperatorDeleteDialog))}])
+                (r/as-element
+                  [ui/raised-button
+                   {:id "confirm-operator-delete"
+                    :label     (tr [:buttons :delete])
+                    :icon      (ic/action-delete-forever)
+                    :secondary true
+                    :primary   true
+                    :on-click  #(e! (to/->DeleteTransportOperator (::t-operator/id operator)))}])]}
+     (tr [:dialog :delete-transport-operator :confirm] {:name (::t-operator/name operator)})]))
+
+(defn- operator-selection-group [e! state]
+  "Form group for querying business id from user and triggering data fetch for it from YTJ"
+  (let [operator (:transport-operator state)
+        status (get-in state [:ytj-response :status])
+        ytj-loading? (fn [state] (:ytj-response-loading state))]
+    (form/group
+      {
+       ;:columns         1
+       :card?           false
+       :container-style (style-base/flex-container2)  ;Full-width to have groups stack vertically
+       ;:container-style style-form/full-width
+       }
+
+      {:name      ::t-operator/business-id
+       :type      :string
+       :validate  [[:business-id]]
+       :required? true
+       :warning   (tr [:common-texts :required-field])
+       :should-update-check form/always-update
+       ;:style style-form/half-width
+       :style style-base/flex-child
+       }
+
+      {:name      ::t-operator/btn-submit-business-id
+       :type      :external-button
+       :label     (tr [:common-texts :fetch-from-ytj])
+       :primary   true
+       :secondary true
+       :on-click  #(e! (to/->FetchYtjOperator (::t-operator/business-id operator)))
+       :disabled  (ytj-loading? state)
+       ;:style style-form/half-width
+       :style style-base/flex-child
+       }
+
+      (when (:ytj-response state); label composition for error message
+        (cond
+          (= 200 status)
+          (do )
+          (= 404 status)
+          {:name  :ytj-msg-results-not-found
+           :type  :text-label
+           :label (tr [:common-texts :data-not-found])}
+          :else
+          {:name  :ytj-msq-query-error
+           :type  :text-label
+           :label (tr [:common-texts :server-error-try-later])})
+        )
+
+      ; label composition for user instructions how to continue
+      (when (and (:ytj-response state) (not= 200 status))
+        {:name  :ytj-query-tip-whatnext
+         :type  :text-label
+         :label (str (tr [:common-texts :check-your-input]) " " (tr [:common-texts :optionally-fill-manually]))})
+      )))
+
+(defn- operator-form-groups [e! state]
+  "Creates a napote form and resolves data to fields. Assumes expired fields are already filtered from ytj-response."
+  ;(.debug js/console "operator-form-groups: state=" (clj->js state))
+  (let [response-ok? (= 200 (get-in state [:ytj-response :status]))
+        disable-ytj-address-billing? (= (get-in state [:ytj-flags :use-ytj-addr-billing?]) true)
+        disable-ytj-address-visiting? (= (get-in state [:ytj-flags :use-ytj-addr-visiting?]) true)
+        ytj-company-names (:ytj-company-names state)
+        ytj-company-names-found? (< 1 (count ytj-company-names))]
+    (form/group
+      {:label (tr [:common-texts :title-operator-basic-details])
+       :columns 1
+       :tooltip (tr [:organization-page :basic-info-tooltip])
+       :tooltip-length "large"
+       :card? false
+       :container-style (style-base/flex-container2)
+       }
+
+      {:name       :msg-business-id
+       :label      (if ytj-company-names-found?
+                     (tr [:common-texts :business-id-and-aux-names])
+                     "Toiminimi")
+       :type       :text-label
+       :h-style    :h3
+       :max-length 70
+       :full-width? true
+       }
+
+      (if response-ok?                                      ; Input field if not YTJ results, checkbox-group otherwise
+        {:name                :transport-operators-to-save
+         ;:label
+         ;:help
+         :type                :checkbox-group
+         :show-option         ::t-operator/name
+         :option-enabled?     #(nil? (::t-operator/id %))
+         :options             ytj-company-names
+         :full-width?         true
+         :should-update-check form/always-update
+         :required?           true
+         }
+        {:name       ::t-operator/name
+         :label      ""
+         :type       :string
+         :required?  true
+         :full-width? true
+         :max-length 70})
+
+      (when (and response-ok? (not ytj-company-names-found?))
+        {:name :msg-no-aux-names-for-business-id
+         :label (tr [:common-texts :no-aux-names-for-business-id])
+         :type :text-label
+         :max-length 128})
+
+      {:name       :msg-business-id-contact-details
+       :label      (if ytj-company-names-found?
+                     (tr [:common-texts :contact-details-plural])
+                     (tr [:common-texts :contact-details])
+                     )
+       :type       :text-label
+       :max-length 128
+       :h-style    :h3}
+
+      {:name ::ote.db.transport-operator/billing-address
+       :type :text-label
+       :max-length 128
+       :h-style :h4}
+
+      {:name        ::common/billing-street
+       :label       (tr [:field-labels :ote.db.common/street])
+       :type        :string
+       :disabled?   disable-ytj-address-billing?
+       :max-length  128
+       :full-width? true
+       :read        (comp ::common/street ::t-operator/billing-address)
+       :write       (fn [data street]
+                      (assoc-in data [::t-operator/billing-address ::common/street] street))}
+
+      {:name ::common/billing-postal_code
+       :label (tr [:field-labels :ote.db.common/postal_code])
+       :type :string
+       :disabled? disable-ytj-address-billing?
+       :full-width? true
+       :regex #"\d{0,5}"
+       :read (comp ::common/postal_code ::t-operator/billing-address)
+       :write (fn [data postal-code]
+                (assoc-in data [::t-operator/billing-address ::common/postal_code] postal-code))}
+
+      {:name ::common/billing-post_office
+       :label (tr [:field-labels :ote.db.common/post_office])
+       :type :string
+       :disabled? disable-ytj-address-billing?
+       :full-width? true
+       :max-length 64
+       :read (comp :ote.db.common/post_office :ote.db.transport-operator/billing-address)
+       :write (fn [data post-office]
+                (assoc-in data [:ote.db.transport-operator/billing-address :ote.db.common/post_office] post-office))}
+
+      {:name ::ote.db.transport-operator/visiting-address
+       :type :text-label
+       :max-length 128
+       :h-style :h4}
+
+      {:name ::common/street
+       :type :string
+       :disabled? disable-ytj-address-visiting?
+       :full-width? true
+       :max-length 128
+       :read (comp ::common/street ::t-operator/visiting-address)
+       :write (fn [data street]
+                (assoc-in data [::t-operator/visiting-address ::common/street] street))}
+
+      {:name ::common/postal_code
+       :type :string
+       :disabled? disable-ytj-address-visiting?
+       :full-width? true
+       :regex #"\d{0,5}"
+       :read (comp ::common/postal_code ::t-operator/visiting-address)
+       :write (fn [data postal-code]
+                (assoc-in data [::t-operator/visiting-address ::common/postal_code] postal-code))}
+
+      {:name :ote.db.common/post_office
+       :type :string
+       :disabled? disable-ytj-address-visiting?
+       :full-width? true
+       :max-length 64
+       :read (comp :ote.db.common/post_office :ote.db.transport-operator/visiting-address)
+       :write (fn [data post-office]
+                (assoc-in data [:ote.db.transport-operator/visiting-address :ote.db.common/post_office] post-office))}
+
+      {:name ::t-operator/phone :type :string :disabled? (get-in state [:ytj-flags :use-ytj-phone?] false) :full-width? true :regex ui-validation/phone-number-regex}
+
+      {:name ::t-operator/gsm :type :string :disabled? (get-in state [:ytj-flags :use-ytj-gsm?] false) :full-width? true :regex ui-validation/phone-number-regex}
+
+      {:name ::t-operator/email :type :string :disabled? (get-in state [:ytj-flags :use-ytj-email?] false) :full-width? true :max-length 200}
+
+      {:name ::t-operator/homepage :type :string :disabled? (get-in state [:ytj-flags :use-ytj-homepage?] false) :full-width? true :max-length 200})))
+
+(defn- allow-manual-creation? [state] (some? (:ytj-response state)))
+
+(defn- operator-form-options [e! state show-actions?]
+  {:name->label (tr-key [:field-labels])
+   ;:layout :row
+   ;:style style-form/form-group-row
+   :container-style (style-base/flex-container2)
+   :update!     #(e! (to/->EditTransportOperatorState %))
+   :footer-fn   (fn [data]
+                  [:div
+                   [:div
+                    (when show-actions?
+                      [buttons/save {:on-click #(e! (to/->SaveTransportOperator))
+                                     :disabled (form/disable-save? data)}
+                       (tr [:buttons :save])])
+
+                    [buttons/save {:on-click #(e! (to/->CancelTransportOperator))}
+                     (tr [:buttons :cancel])]]
+
+                   (when show-actions?
+                     (when (not (get-in state [:transport-operator :new?]))
+                       [:div
+                        [:br]
+                        [ui/divider]
+                        [:br]
+                        [:div [:h3 (tr [:dialog :delete-transport-operator :title-base-view])]]
+                        [buttons/save {:on-click #(e! (to/->ToggleTransportOperatorDeleteDialog))
+                                         :disabled (if (::t-operator/id data) false true)}
+                         (tr [:buttons :delete-operator])]]))])})
+
+(defn operator-ytj [e! {operator :transport-operator :as state}]
+  ;(e! (to/->EditTransportOperator (get-in state [:params :id])))
+  (fn [e! {operator :transport-operator :as state}]
+    (let [show-id-entry? (empty? (get-in state [:params :id]))
+          show-details? (and (:transport-operator-loaded? state) (some? (:ytj-response state)))
+          form-options (operator-form-options e! state show-details?)
+          form-groups (cond-> []
+                              show-id-entry? (conj (operator-selection-group e! state))
+                              show-details? (conj (operator-form-groups e! state)))]
+      [:div
+       [:div
+        [:div
+         [:h1 (tr [:organization-page
+                   (if (:new? operator)
+                     :organization-new-title
+                     :organization-form-title)])]]]
+
+       [:div.row {:style {:white-space "pre-wrap"}}
+        [:p (tr [:organization-page :help-desc-1])]
+        [:p (tr [:organization-page :help-desc-2])]]
+       [ui/divider]
+       [delete-operator e! operator]
+        [form/form
+         form-options
+         form-groups
+         operator]
+       ])))


### PR DESCRIPTION
# Added
* Feature flag variation in controller transport_operator.cljs: previous non-ytj functionality and new with ytj-integration.
* transport_operator view variation done using a new "-ytj" view
* Under the feature flag modified transport operator creation logic: fields from ytj, option to create multiple operators if companies share the business id/y-tunnus, retains support for creating an operator which doesn't have a business-id from YTJ.
* WIP UI localisation strings
   
# Fixed
* integration/import/ytj tweaks to pass more detailed ytj results to allow view error handling
   
# Changed
* services/transport.clj feature flag variated ytj integration support
   * Under the feature flag group and member table updating directly without CKAN i.e. dependency removed from operator creation/updating
   
# TODO
* group table created_time updating
* UI style
* email field handling from YTJ
