### PR TITLE
161874264 improvements for transport-operator ytj creation

### DIFF
--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -3,7 +3,6 @@
   (:require [com.stuartsierra.component :as component]
             [ote.components.http :as http]
             [specql.core :refer [fetch update! insert! upsert! delete!] :as specql]
-            [clj-time.core :as time]
             [specql.op :as op]
             [ote.db.transport-operator :as t-operator]
             [ote.db.transport-service :as t-service]
@@ -26,9 +25,7 @@
             [ote.nap.ckan :as ckan]
             [clojure.set :as set]
             [ote.util.feature :as feature])
-  (:import (java.time LocalTime)
-           (java.sql Timestamp)
-           (java.util UUID)))
+  (:import (java.util UUID)))
 
 ; TODO: split file to transport-service and transport-operator
 

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -145,7 +145,7 @@
 (defn- create-group!
   "Takes `op` operator and `user` and pairs user to organization in db using the member table. Sets role (Capacity) to 'admin'"
   [db op user]
-  {:pre [(some? op)]}
+  {:pre [(some? op) (some? (::t-operator/name op))]}
   (let [group (specql/insert! db ::t-operator/group
                               {::t-operator/group-id        (str (UUID/randomUUID))
                                ::t-operator/group-name      (str "transport-operator-" (::t-operator/id op))


### PR DESCRIPTION
# Changed
When :open-ytj-integration is set
- services: cleanup transport require dependencies
- services: transport cleanup code
- services: operator group created, state, approval_satus fields set when ytj. Some relevant-looking group table's fields were previously not set.
Also code rearranged to match table schema order, for convenience.
- services: transport operator insert group assert if name is nil 
   