### PR TITLE
161874264 transport-operator field edit logic and other improvements

### DIFF
--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -107,7 +107,7 @@
         ytj-contact-web (preferred-ytj-field ["Kotisivun www-osoite" "www-adress" "Website address"] (:contactDetails response))
         use-ytj-web? (not (empty? ytj-contact-web))
         ytj-company-names (when (some? (:name response)) (ytj->nap-companies
-                                                           (into [{:name (:name response)}] (:auxiliaryNames response)) ; Insert company name first to checkbox list before aux names
+                                                           (into [{:name (:name response)}] (sort-by :name (:auxiliaryNames response))) ; Insert company name first to checkbox list before aux names
                                                            (:transport-operators-with-services app)))
         ytj-changed-fields? (and ytj-business-id-hit?
                                  (or (not= ytj-address-billing (::t-operator/billing-address t-op))

--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -144,7 +144,7 @@
              {:on-success (send-async! ->FetchYtjOperatorResponse)
               :on-failure (send-async! ->FetchYtjOperatorResponse)})
   (-> app
-      (dissoc :ytj-response)
+      (strip-ytj-metadata)
       (assoc :ytj-response-loading true)))
 
 (define-event FetchYtjOperator [id]


### PR DESCRIPTION
# Fixed
* controller: transport-operator clear ytj metadata before new fetch
   
# Changed
* controller: transport operator allow edit if YTJ fetch changed a field
Previously saving was enabled only after user interaction with the fields.
* controller: transport-operator company aux names alphabetically, primary name first

