### PR TITLE
Update contact details from reset password email

### DIFF
--- a/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/emails/reset_password.txt
+++ b/nap/docker/ckan/ckan-plugins/ckanext-napote_theme/ckanext/napote_theme/templates/emails/reset_password.txt
@@ -3,7 +3,7 @@ Olette pyytänyt NAP-sovelluksen salasananne uudelleenasettamista.
 Voitte vaihtaa salasanan klikkaamalla alla olevaa linkkiä:
 {{ reset_link }}
 P.S Mikäli salasanan vaihto ei onnistu, olkaa yhteydessä NAP-HelpDeskiin,
-joukkoliikenne@liikennevirasto.fi tai 0295 34 3434 (arkisin 10-16).
+joukkoliikenne@traficom.fi tai 029 534 5454 (arkisin 10-16).
 
 ------------
 
@@ -12,7 +12,7 @@ Du har bett om återställning av ditt lösenord.
 Var vänlig klicka på länken nedan för att bekräfta:
 {{ reset_link }}
 P.S Om inte återställningen av ditt lösenord lyckades ta kontakt med NAP-HelpDesk,
-joukkoliikenne@liikennevirasto.fi eller tfn 0295 34 3434 (Mån-Fre kl 10-16).
+joukkoliikenne@traficom.fi eller tfn 029 534 5454 (Mån-Fre kl 10-16).
 
 ------------
 
@@ -21,7 +21,7 @@ You have requested your password on NAP to be reset.
 Please click the following link to confirm this request:
 {{ reset_link }}
 P.S If you do not manage to reset your password, please contact NAP-HelpDesk,
-email joukkoliikenne@liikennevirasto.fi or phone +358 295 34 3434 (Mon-Fri 10am-4pm).
+email joukkoliikenne@traficom.fi or phone +358 29 534 5454 (Mon-Fri 10am-4pm).
 
 ------------
 

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1369,7 +1369,7 @@ You can also draw the operating area or point to the map with drawing tools. You
                           :reset-link
                           "\nThis link expires in one hour."
                           "\nP.S If you do not manage to reset your password, please contact NAP-HelpDesk,\n"
-                          "email joukkoliikenne@liikennevirasto.fi or phone +358 295 34 3434 (Mon-Fri 10am-4pm)."
+                          "email joukkoliikenne@traficom.fi or phone +358 29 534 5454 (Mon-Fri 10am-4pm)."
                           "\n\n------------\n"
                           "This message was sent by NAP\n"
                           "(www.finap.fi)"]}}}

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1385,7 +1385,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
                           :reset-link
                           "\nTämä linkki vanhenee tunnin kuluttua."
                           "\nP.S Mikäli salasanan vaihto ei onnistu, olkaa yhteydessä NAP-HelpDeskiin,\n"
-                          "joukkoliikenne@liikennevirasto.fi tai 0295 34 3434 (arkisin 10-16)."
+                          "joukkoliikenne@traficom.fi tai 029 534 5454 (arkisin 10-16)."
                           "\n\n------------\n"
                           "Tämän viestin lähetti NAP\n"
                           "(www.finap.fi)"]}}}

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1374,7 +1374,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
                           :reset-link
                           "\nDen här länken löper ut på en timme"
                           "\nP.S Om inte återställningen av ditt lösenord lyckades ta kontakt med NAP-HelpDesk,\n"
-                          "joukkoliikenne@liikennevirasto.fi eller tfn 0295 34 3434 (Mån-Fre kl 10-16)."
+                          "joukkoliikenne@traficom.fi eller tfn 029 534 5454 (Mån-Fre kl 10-16)."
                           "\n\n------------\n"
                           "Detta meddelande är skickat av NAP\n"
                           "(www.finap.fi)"]}}


### PR DESCRIPTION
# Fixed
* In previous pr I missed reset password email. Now traficom contact details are updated to there as well.
