### PR TITLE
162262078 transport operator ytj merge section

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -671,6 +671,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :help-about-ytj-link "https://www.ytj.fi/en/index/whatisbis.html"
   :help-ytj-contact-change-link-desc "Change details of your business online"
   :help-ytj-contact-change-link "https://www.ytj.fi/en/index/notifications/notificationsofchanges.html"
+  :merge-operator-to-ytj "will be renamed as"
   }
 
  :passenger-transportation-page

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -330,6 +330,7 @@ You can also draw the operating area or point to the map with drawing tools. You
  :buttons
  {:save "Save"
   :cancel "Cancel"
+  :continue "Continue"
   :delete "Delete"
   :delete-operator "Delete transport operator"
   :close "Close"
@@ -655,6 +656,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :organization-new-title "Create a new transport operator"
   :help-desc-1 "The information given in this form will seen in the public pages of NAP-service."
   :help-desc-2 (:md "**Transport operators** are companies, communities and organizations, which provide transport services. Transport services are 1) passenger transport services (e.g. taxi and buss services), 2) stations, ports and terminals, 3) general commercial parking services, 4) vehicle rental services and commercial ridesharing services and 5) brokering and dispatch services.")
+  :help-merge-company-names "You have previously created one or more NAP service providers whose names do not correspond to the business names or auxiliary names registered for the business ID. \nPlease select the NAP service provider name which you want to replace using a name fetched from YTJ registry"
   :basic-info-tooltip "Fill in to Basic information -section information about the company, community or organization you are representing."
   :contact-types-tooltip "Phone and email -section information is meant for utilisers of NAP-interfaces - not to the end users (customers) of your transport service."
   :ckan-description-tooltip "The purpose of the transport operator description is to give NAP utilisers an idea about what kind of transport operator they are dealing with. E.g. Example Ltd. is a company conducting scheduled transport and charter traffic in Southern Finland."
@@ -945,6 +947,8 @@ You can also draw the operating area or point to the map with drawing tools. You
   :invalid-business-id "The business ID has to be in the form of: 7 numbers, hyphen and a check number."
   :invalid-postal-code "Please, check the postalcode (5 numbers)"
   :invalid-file-type "Invalid file type"
+  :save-failure "Saving failed."
+  :save-success "Successfully saved."
   :transport-service-saved "Transport service information has been saved!"
   :transport-operator-saved "Transport operator information has been saved!"
   :footer-livi-logo "Finnish Transport and Communications Agency"
@@ -977,7 +981,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :minutes-placeholder "mm"
 
   :server-error "Error in server call. Contact support if the problem persists."
-  :server-error-try-later "Problems with a service. Please try again later."
+  :server-error-try-later "Please try again later."
 
   :forbidden "Forbidden"
   :optionally-fill-manually "Optionally you may proceed to enter details manually."

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -331,6 +331,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
  :buttons
  {:save "Tallenna"
   :cancel "Peruuta"
+  :continue "Jatka"
   :delete "Poista"
   :delete-operator "Poista palveluntuottaja"
   :close "Sulje"
@@ -661,6 +662,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :organization-new-title "Lisää palveluntuottaja"
   :help-desc-1 "Tämän sivun lomakkeella syötettävät tiedot tulevat näkyviin NAP-palvelukatalogin julkisille sivuille."
   :help-desc-2 (:md "**Palveluntuottajia** ovat yritykset, yhteisöt ja organisaatiot, joiden palveluntarjontaan kuuluu liikkumispalveluita. Liikkumispalveluilla tarkoitetaan 1) henkilöiden kuljetuspalveluita (esim. taksi- ja linja-autoliikenne), 2) asemia, satamia ja terminaaleja, 3) pysäköintilaitoksia, 4) liikennevälineiden vuokrauspalveluita ja kaupallisia yhteiskäyttöpalveluita, sekä 5) välityspalveluita.")
+  :help-merge-company-names "Olet aiemmin luonut NAP-palveluun yhden tai useamman palveluntuottajan, joiden nimet eivät vastaa Y-tunnukselle rekisteröityjä toiminimiä tai aputoiminimiä. Valitse alasvetovalikoista toiminimi, jolla haluat korvata aiemmin ilmoittamasi palveluntuottajan nimen."
   :basic-info-tooltip "Täytä Perustiedot-osioon edustamasi yrityksen, yhteisön tai organisaation tiedot."
   :contact-types-tooltip "Yhteystavat-osion tiedot on tarkoitettu NAP-rajapintojen hyödyntäjille, ei liikkumispalvelunne loppukäyttäjille."
   :ckan-description-tooltip "Palveluntuottajan kuvauksen on tarkoitus antaa NAP-tietojen hyödyntäjille käsitys siitä, minkälaisen palveluntuottajan kanssa hän on tekemisissä. Esim. \"Parasbussi Oy on säännöllistä reittiliikennettä ja tilausliikennettä harjoittava Porin kaupunkiliikenteen omistama yhtiö\"."
@@ -955,6 +957,8 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :invalid-business-id "Y-tunnuksen tulee olla muotoa: 7 numeroa, väliviiva ja tarkistusnumero."
   :invalid-postal-code "Tarkista postinumero (5 numeroa)"
   :invalid-file-type "Virheellinen tiedostotyyppi"
+  :save-failure "Tallennus ei onnistunut."
+  :save-success "Tallennus onnistui."
   :transport-service-saved "Liikkumispalvelun tiedot tallennettu!"
   :transport-operator-saved "Palveluntarjoajan tiedot tallennettu!"
   :footer-livi-logo "Traficom"
@@ -987,7 +991,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :minutes-placeholder "mm"
 
   :server-error "Virhe palvelinkutsussa. Jos ongelma jatkuu, ota yhteyttä tukeen."
-  :server-error-try-later "Ongelmia palvelussa. Yritä hetken kuluttua uudelleen."
+  :server-error-try-later "Yritä hetken kuluttua uudelleen."
 
   :forbidden "Käyttöoikeutesi eivät riitä sisällön katseluun."
   :optionally-fill-manually "Vaihtoehtoisesti voit jatkaa tietojen syöttämistä käsin."

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -677,6 +677,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :help-about-ytj-link "https://www.ytj.fi/index/tietoapalvelusta.html"
   :help-ytj-contact-change-link-desc "Tietojen muutosilmoitus Yritys- ja yhteisötietojärjestelmässä (YTJ)"
   :help-ytj-contact-change-link "https://www.ytj.fi/index/ilmoittaminen/muutosilmoitus.html"
+  :merge-operator-to-ytj "korvataan nimellä"
   }
 
  :passenger-transportation-page

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -338,6 +338,7 @@
  :buttons
  {:save "Spara"
   :cancel "Ångra"
+  :continue "Fortsätta"
   :delete "Ta bort"
   :delete-operator "Ta bort tjänsteproducent"
   :close "Stäng"
@@ -663,6 +664,7 @@
   :organization-new-title "Lägg till tjänsteproducent"
   :help-desc-1 "Uppgifterna som förs in på blanketten på den här sidan kommer att synas på NAP-tjänstekatalogens offentliga sidor."
   :help-desc-2 (:md "Med **tjänsteproducenter** avses företag, sammanslutningar och organisationer som tillhandahåller mobilitetstjänster. Med mobilitetstjänster avses 1) persontransporttjänster (t.ex. taxi- och busstrafik), 2) stationer, hamnar och terminaler, 3) parkeringsanläggningar, 4) tjänster för uthyrning av färdmedel och kommersiella samåkningstjänster, samt 5) förmedlingstjänster.")
+  :help-merge-company-names "Du har tidigare skapat en eller flera NAP-tjänsteleverantörer vars namn inte stämmer med företagsnamn eller hjälpnamn som registrerats för företags-ID. \nVänligen välja NAP-tjänsteleverantörens namn som du vill ersätta med ett namn hämtade från YTJ-registret"
   :basic-info-tooltip "Här fyller du i uppgifterna för företaget, sammanslutningen eller organisationen som du representerar."
   :contact-types-tooltip "Uppgifterna här är avsedda för dem som använder NAP-gränssnitten, inte för mobilitetstjänsternas slutanvändare."
   :ckan-description-tooltip "Beskrivningen av tjänsteproducenten görs för att de som använder NAP-informationen ska kunna bilda sig en bättre uppfattning om tjänsteproducenten. T.ex. \"Parasbussi Oy är ett bolag som idkar regelbunden linjebaserad trafik och beställningstrafik. Bolaget ägs av Björneborgs stadstrafik\"."
@@ -949,6 +951,8 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :invalid-business-id "FO-nummer måste vara i form av: 7 siffror, bindestreck och ett kontrollnummer." ;; Google translated
   :invalid-postal-code "Kolla postnumret (5 siffror)"
   :invalid-file-type "Ogiltig filtyp"
+  :save-failure "Sparade misslyckades."
+  :save-success "Sparad."
   :transport-service-saved "Uppgifterna sparade!"
   :transport-operator-saved "Uppgifterna sparade!"
   :footer-livi-logo "Traficom"
@@ -981,7 +985,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :minutes-placeholder "mm"
 
   :server-error "Fel i serveranropet. Om problemet fortsätter, kontakta NAP HelpDesk."
-  :server-error-try-later "Problem med tjänsten. Vänligen försök igen senare."
+  :server-error-try-later "Vänligen försök igen senare."
 
   :forbidden "Du har inte behörighet att visa innehållet."
   :optionally-fill-manually "Alternativt kan du fortsätta att skriva in detaljer manuellt"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -679,6 +679,7 @@
   :help-about-ytj-link "https://www.ytj.fi/sv/index/mikaonytj.html"
   :help-ytj-contact-change-link-desc "Anmäl ändringar på nätet"
   :help-ytj-contact-change-link "https://www.ytj.fi/sv/index/ilmoittaminen/muutosilmoitus.html"
+  :merge-operator-to-ytj "kommer att namnas som"
   }
 
  :passenger-transportation-page

--- a/ote/src/clj/ote/services/operators.sql
+++ b/ote/src/clj/ote/services/operators.sql
@@ -39,3 +39,8 @@ SELECT u.id as "user-id"
  WHERE op."business-id" = :business-id
    AND u.id != :user-id
  GROUP BY "user-id";
+ 
+-- name: group-id-for-op
+SELECT "ckan-group-id" FROM "transport-operator" op
+ WHERE op."id" = :id
+ LIMIT 1;

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -279,6 +279,14 @@
                 ::t-operator/email
                 ::t-operator/homepage]))
 
+;; Takes db and transport-operator. Resolves optional data for updating operator and returns a transport-operator map.
+(defn resolve-update-operator-data [db op]
+  (let [ckan-id (when (nil? (::t-operator/ckan-group-id op))
+                  (group-id-for-op db {:id (::t-operator/id op)}))]
+    ;; cond used just in case there are mode fields to handle in the future
+    (cond-> op
+            (some? ckan-id) (assoc ::t-operator/ckan-group-id (:ckan-group-id (first ckan-id))))))
+
 (defn- update-transport-operator-nap [db user {id ::t-operator/id :as data}]
   ;; Edit transport operator
   {:pre [(coll? data) (number? (::t-operator/id data))]}
@@ -289,7 +297,7 @@
        (update! db ::t-operator/transport-operator
                 (select-op-keys-to-update data)
                 {::t-operator/id (::t-operator/id data)})
-       (update-group! db data))))
+       (update-group! db (resolve-update-operator-data db data)))))
 
 (defn- upsert-transport-operator
   "Creates or updates a transport operator for each company name. Operators will have the same details, except the name"

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -281,8 +281,7 @@
 
 ;; Takes db and transport-operator. Resolves optional data for updating operator and returns a transport-operator map.
 (defn resolve-update-operator-data [db op]
-  (let [ckan-id (when (nil? (::t-operator/ckan-group-id op))
-                  (group-id-for-op db {:id (::t-operator/id op)}))]
+  (let [ckan-id (group-id-for-op db {:id (::t-operator/id op)})]
     ;; cond used just in case there are mode fields to handle in the future
     (cond-> op
             (some? ckan-id) (assoc ::t-operator/ckan-group-id (:ckan-group-id (first ckan-id))))))

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -196,3 +196,7 @@
 (def msg-warning
   {:color (str colors/warning)
    :fill (str colors/warning)})
+
+(def msg-success
+  {:color (str colors/success)
+   :fill (str colors/success)})

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -96,9 +96,14 @@
 
 (def title {:font-weight "bold"})
 
-
 (defn flex-container [dir]
   {:display "flex" :flex-direction dir})
+
+(defn align-items [dir]
+  {:align-items dir})
+
+(defn justify-content [dir]
+  {:justify-content dir})
 
 (def flex-child {:flex 1 })
 

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -192,3 +192,7 @@
                           (align-items "center")))
 
 (def msg-item-column-margin {:margin-left "0.25rem"})
+
+(def msg-warning
+  {:color (str colors/warning)
+   :fill (str colors/warning)})

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -105,6 +105,12 @@
 (defn justify-content [dir]
   {:justify-content dir})
 
+(def wizard-container
+  {:border-style "solid"
+   :border-width "2px"
+   :border-color colors/orange-basic
+   :padding "0rem 1.25rem 2rem 1.25rem"})
+
 (def flex-child {:flex 1 })
 
 (def item-list-container

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -187,3 +187,8 @@
 
 (def checkbox-addition {:padding-left "1.25rem"
                         :padding-bottom "2px"})
+
+(def msg-container (merge (flex-container "row")
+                          (align-items "center")))
+
+(def msg-item-column-margin {:margin-left "0.25rem"})

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -180,6 +180,9 @@
                                :width "48px"
                                :margin-bottom "8px"}}})
 
+(def disabled-control {:opacity 0.5
+                       :pointer-events "none"})
+
 (def disabled-color {:color "rgba(0, 0, 0, 0.247059)"})
 (def checkbox-label {:float "left"
                      :position "relative"

--- a/ote/src/cljs/ote/style/form.cljs
+++ b/ote/src/cljs/ote/style/form.cljs
@@ -59,3 +59,6 @@
 (def organization-padding {:padding-top "20px"})
 
 (def padding-top {:padding-top "20px"})
+
+(def action-control-section-margin {:margin-top "2rem"})
+

--- a/ote/src/cljs/ote/style/form.cljs
+++ b/ote/src/cljs/ote/style/form.cljs
@@ -15,7 +15,7 @@
                               (base/flex-container "column")))
 (def form-group-row (merge form-group-base
                            (base/flex-container "row")
-                           {:flex-wrap "wrap"}))
+                           {:flex-wrap "wrap" :align-items "center"}))
 
 (def form-group-container {:padding-bottom "1em" :width "100%"})
 

--- a/ote/src/cljs/ote/style/form_fields.cljs
+++ b/ote/src/cljs/ote/style/form_fields.cljs
@@ -26,6 +26,7 @@
   (merge localized-text-language
          {:background-color "#06c"}))
 
+(def checkbox-group-base {:margin-bottom "2rem"})
 (def checkbox-group-label {:margin-bottom "4px" :width "100%"})
 
 (def table-header {:overflow "visible" :border-bottom "0px solid white"})

--- a/ote/src/cljs/ote/theme/colors.cljs
+++ b/ote/src/cljs/ote/theme/colors.cljs
@@ -10,7 +10,18 @@
 (def gray600 "#505050")
 (def gray900 "#323232")
 
+(def green-basic "#00AA00")
+
 (def primary blue)
 (def primary-light blue-light)
+
+(def red-basic "#DD0000")
+
 (def secondary gray900)
+
+(def orange-basic "#FF8800")
+
+(def warning red-basic)
+
+(def success green-basic)
 

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -908,7 +908,7 @@
   (let [selected (set (or data #{}))
         option-enabled? (or option-enabled? (constantly true))
         label-style (if use-label-width? style-base/checkbox-label-with-width style-base/checkbox-label)]
-    [:div.checkbox-group {:style (if checkbox-group-style checkbox-group-style {})}
+    [:div.checkbox-group {:style (if checkbox-group-style checkbox-group-style style-form-fields/checkbox-group-base)}
      (when (not (false? header?))
        [:h4 (stylefy/use-style style-form-fields/checkbox-group-label) label])
      (when help

--- a/ote/src/cljs/ote/ui/select_field.cljs
+++ b/ote/src/cljs/ote/ui/select_field.cljs
@@ -9,10 +9,10 @@
   ;; Because material-ui selection value can't be an arbitrary JS object, use index
   (let [int-value-atom (r/atom 0)
         int-cb (fn [ix]
-                 (reset! int-value-atom ix)
-                 (update! (nth options ix)))]
+                 (reset! int-value-atom ix))]
     ;; Wrapper fn required to get reagent re-render element after changes
-    (fn []
+    (fn [{label :label options :options :as all}]
+
       [ui/select-field
        (merge
          {:auto-width (boolean auto-width?)
@@ -20,7 +20,8 @@
           :floating-label-text (when-not table? label)
           :floating-label-fixed true
           :value @int-value-atom
-          :on-change #(int-cb %2)
+          :on-change #(do (int-cb %2)
+                         (update! (nth options %2)))
           :error-text (or error warning "")                 ;; Show error text or warning text or empty string
           :error-style (if error                            ;; Error is more critical than required - showing it first
                          style-base/error-element

--- a/ote/src/cljs/ote/ui/select_field.cljs
+++ b/ote/src/cljs/ote/ui/select_field.cljs
@@ -24,8 +24,8 @@
           :error-text (or error warning "")                 ;; Show error text or warning text or empty string
           :error-style (if error                            ;; Error is more critical than required - showing it first
                          style-base/error-element
-                         style-base/required-element)}
-         (when class-name {:className class-name})
+                         style-base/required-element)
+          :className (if class-name class-name "mui-select-button")}
          (when disabled?
            {:disabled true}))
        (doall

--- a/ote/src/cljs/ote/ui/success_msg.cljs
+++ b/ote/src/cljs/ote/ui/success_msg.cljs
@@ -7,5 +7,5 @@
   [:div
    {:style (merge style-base/msg-container style-base/msg-success)}
    [ic/action-check-circle {:style style-base/msg-success}]
-   [:div {:style style-base/msg-item-column-margin} content]])
+   (when content [:div {:style style-base/msg-item-column-margin} content])])
 

--- a/ote/src/cljs/ote/ui/success_msg.cljs
+++ b/ote/src/cljs/ote/ui/success_msg.cljs
@@ -1,0 +1,11 @@
+(ns ote.ui.success_msg
+  (:require [ote.localization :refer [tr tr-key]]
+            [cljs-react-material-ui.icons :as ic]
+            [ote.style.base :as style-base]))
+
+(defn success-msg [content]
+  [:div
+   {:style (merge style-base/msg-container style-base/msg-success)}
+   [ic/action-check-circle {:style style-base/msg-success}]
+   [:div {:style style-base/msg-item-column-margin} content]])
+

--- a/ote/src/cljs/ote/ui/warning_msg.cljs
+++ b/ote/src/cljs/ote/ui/warning_msg.cljs
@@ -1,0 +1,11 @@
+(ns ote.ui.warning_msg
+  (:require [ote.localization :refer [tr tr-key]]
+            [cljs-react-material-ui.icons :as ic]
+            [ote.style.base :as style-base]))
+
+(defn warning-msg [content]
+  [:div
+   {:style (merge style-base/msg-container style-base/msg-warning)}
+   [ic/alert-warning {:style style-base/msg-warning}]
+   [:div {:style style-base/msg-item-column-margin} content]])
+

--- a/ote/src/cljs/ote/ui/warning_msg.cljs
+++ b/ote/src/cljs/ote/ui/warning_msg.cljs
@@ -7,5 +7,5 @@
   [:div
    {:style (merge style-base/msg-container style-base/msg-warning)}
    [ic/alert-warning {:style style-base/msg-warning}]
-   [:div {:style style-base/msg-item-column-margin} content]])
+   (when content [:div {:style style-base/msg-item-column-margin} content])])
 

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -274,15 +274,13 @@
                         (= (::t-operator/id item) my-id)))
            ytj-company-names))
 
-(defn- operator-merge-section [e! {nap-orphans :ytj-orphan-nap-operators ops-to-save :transport-operators-to-save :as operator} ytj-company-names app]
+(defn- operator-merge-section [e! {nap-orphans :ytj-orphan-nap-operators :as operator} ytj-company-names app]
   [:div {:style style-base/wizard-container}
    [:div [:h3 (tr [:organization-page :heading-operator-edit])]]
    [info/info-toggle (tr [:common-texts :instructions]) (tr [:organization-page :help-merge-company-names]) true]
    (for [n nap-orphans
          :let [nap-op (:transport-operator n)
-               control-disabled? false
-               ops-to-save1 (:transport-operators-to-save operator)
-               ]
+               control-disabled? false]
          :when n]
      ^{:key (str "operator-merge-section-item-" (::t-operator/name nap-op))}
      [:div {:style (merge

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -345,7 +345,6 @@
         show-details? (and (:transport-operator-loaded? state) (some? (:ytj-response state)))
         show-merge-companies? (and (pos-int? (count (get-in state [:transport-operator :ytj-orphan-nap-operators])))
                                    (pos-int? (count (:ytj-company-names state))))
-        ;form-options (operator-form-options e! state show-details?)
         form-groups (cond-> []
                             show-id-entry? (conj (business-id-selection e! state))
                             show-details? (conj (operator-form-groups e! state)))]

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -64,7 +64,8 @@
         status (get-in state [:ytj-response :status])
         ytj-loading? (fn [state] (:ytj-response-loading state))]
     (form/group
-      {:card?           false}
+      {:card?  false
+       :layout :row}
 
       {:name      ::t-operator/business-id
        :type      :string

--- a/ote/test/clj/ote/services/admin_test.clj
+++ b/ote/test/clj/ote/services/admin_test.clj
@@ -48,7 +48,7 @@
         parsed-response (:transit response)
         id (::t-service/id parsed-response)
         deleted-response  (http-post "admin" (str "admin/transport-service/delete") {:id id})
-        auditlog (first (fetch
+        auditlog (last (fetch
                    (:db ote.test/*ote*)
                    ::auditlog/auditlog
                    #{::auditlog/id ::auditlog/event-attributes ::auditlog/event-type}


### PR DESCRIPTION
# Added
* some themed colours
* re-usable components for displaying a themed icon-lable, e.g. for conveying a result next to an UI control
* (re-usable) styling for several UI components
* transport-operator (ytj) operator name merging wizard section
* localisation strings with initial values
   
# Changed

# fixed
* test: fix admin_test to evaluate last auditlog event, not last
* ui: select-field support for dynamically changing options
* controller: transport-operator remove debug logs

