### PR TITLE
163146424 disable ytj querty btn

### DIFF
--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -457,7 +457,10 @@
       (when (nil? business-id-validation-error)
         (comm/get! (str "transport-operator/ensure-unique-business-id/" business-id)
                    {:on-success (send-async! ->EnsureUniqueBusinessIdResponse)}))
-      (assoc-in app [:transport-operator :business-id-exists] false)))
+      (-> app
+          (assoc-in [:transport-operator :business-id-exists] false)
+          ;; UI displays a message about ytj fetch results based on :ytj-response, clear message when user edits business id input field.
+          (dissoc :ytj-response))))
 
   EnsureUniqueBusinessIdResponse
   (process-event [{response :response} app]

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -95,9 +95,11 @@
        :primary true
        :secondary true
        :on-click #(e! (to/->FetchYtjOperator (::t-operator/business-id operator)))
-       :disabled (or (not (nil? (get-in state [:transport-operator :ote.ui.form/errors ::t-operator/business-id])))
-                     (get-in state [:transport-operator :business-id-exists])
-                     (ytj-loading? state))}
+       :disabled (or
+                   (empty? (::t-operator/business-id operator))
+                   (not (nil? (get-in state [:transport-operator :ote.ui.form/errors ::t-operator/business-id])))
+                   (:business-id-exists operator)
+                   (ytj-loading? state))}
 
       {:name :loading-spinner-ytj
        :type :loading-spinner


### PR DESCRIPTION
# Changed
* views: transport-operator disable ytj fetch button when input not valid
* controller: transport-operator hide ytj result msg when business-id changes
  UI displays a message about ytj fetch results, those should be removed when user edits business id input field.
