### PR TITLE
163220298 transition in delete operator

### DIFF
--- a/ote/src/cljs/ote/app/controller/admin.cljs
+++ b/ote/src/cljs/ote/app/controller/admin.cljs
@@ -411,7 +411,10 @@
   EditTransportOperatorResponse
   (process-event [{response :response} app ]
     (routes/navigate! :transport-operator {:id (::t-operator/id (:transport-operator (first response)))})
-    (assoc app :admin-transport-operators response))
+    (-> app
+        ;; Clean up admins own services to enable operator deletion. 
+        (dissoc :transport-service-vector)
+        (assoc :admin-transport-operators response)))
 
   ToggleAddMemberDialog
   (process-event [{id :id} app]

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -43,7 +43,7 @@
                                                            service-vector))]
   (when (:show-delete-dialog? operator)
     [ui/dialog
-     {:id "delete-transport-operator-dialog"
+     {:id (str "delete-transport-operator-dialog-" (::t-operator/id operator))
       :open    true
       :title   (tr [:dialog :delete-transport-operator :title])
       :actions [(r/as-element
@@ -335,7 +335,7 @@
 
                         [buttons/save {:on-click #(e! (to/->CancelTransportOperator))}
                          (tr [:buttons :cancel])]]
-                       (when (and show-actions? (nil? (:ytj-company-names state)))
+                       (when (and show-actions? (empty? (:ytj-company-names state)))
                          (when (not (get-in state [:transport-operator :new?]))
                            [:div
                             [:br]
@@ -376,7 +376,7 @@
         [uicommon/extended-help-link (tr [:organization-page :help-ytj-contact-change-link]) (tr [:organization-page :help-ytj-contact-change-link-desc])]]]]
 
      ;; When business-id has multiple companies create list of delete-operator dialogs. Otherwise add only one
-     (if (nil? (:ytj-company-names state))
+     (if (empty? (:ytj-company-names state))
        [delete-operator e! operator (:transport-operators-with-services state)]
        (for [o (get-in state [:transport-operator :transport-operators-to-save])]
          ^{:key (str "operator-delete-control-" (::t-operator/name o) "-" (::t-operator/id o) )}


### PR DESCRIPTION
# Changed
* Transition from operator page to own services when operator is deleted. Previously we moved user away from operator page always when operator was deleted. Now we change page only if non-ytj company is deleted.
   
