### PR TITLE
163208379 operator wizard selections

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -658,6 +658,7 @@ You can also draw the operating area or point to the map with drawing tools. You
  {:address-postal "Postal address"
   :address-postal-street "Street address or P.O. Box"
   :business-id-and-aux-names "Company name and auxiliary names"
+  :business-name "Business name"
   :contact-details-plural "Contact information related to the Business ID"
   :contact-details "Contact details"
   :contact-details-other "Other contact details "

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -664,6 +664,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
  {:address-postal "Postiosoite"
   :address-postal-street "Katuosoite tai PL-osoite"
   :business-id-and-aux-names "Toiminimi ja aputoiminimet"
+  :business-name "Toiminimi"
   :contact-details-plural "Toiminimiin liittyvät yhteystiedot"
   :contact-details "Yhteystiedot"
   :contact-details-other "Muut yhteystiedot"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -666,6 +666,7 @@
  {:address-postal "Post address"
   :address-postal-street "Post address eller PO Box"
   :business-id-and-aux-names "Företagsnamn och hjälpnamn"
+  :business-name "Firma"
   :contact-details-plural "Kontaktuppgifter för företagsnamn"
   :contact-details-other "Andra kontaktuppgifter"
   :contact-details "Kontaktuppgifter"

--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -198,7 +198,7 @@
         use-ytj-email? false
         ytj-contact-web (preferred-ytj-field ["Kotisivun www-osoite" "www-adress" "Website address"] (:contactDetails response))
         use-ytj-web? (not (empty? ytj-contact-web))
-        ytj-company-names (compose-ytj-company-names app response)
+        ytj-company-names (mark-menuitems (compose-ytj-company-names app response))
         ytj-changed-contact-input-fields? (and ytj-business-id-hit?
                                                (or (not= ytj-address-billing (::t-operator/billing-address t-op))
                                                    (not= ytj-address-visiting (::t-operator/visiting-address t-op))
@@ -216,7 +216,6 @@
             ;; Enable saving when YTJ changed a relevant field
             (and (not (:new? t-op))
                  ytj-changed-contact-input-fields?) (assoc-in [:transport-operator ::form/modified] #{::t-operator/name})
-            true (assoc-in [:transport-operator :transport-operators-to-save] []) ;; Init to empty vector to allow populating it in different scenarios
             ;; Set data sources for form fields and if user allowed to edit
             use-ytj-addr-billing? (assoc-in [:transport-operator ::t-operator/billing-address] ytj-address-billing)
             true (assoc-in [:ytj-flags :use-ytj-addr-billing?] use-ytj-addr-billing?)
@@ -235,7 +234,7 @@
                            (sort-by #(get-in % [:transport-operator ::t-operator/name]) (compose-orphan-nap-operators (get-in app [:transport-operator ::t-operator/business-id])
                                                                ytj-company-names
                                                                (:transport-operators-with-services app))))
-            true (assoc :ytj-company-names (mark-menuitems ytj-company-names))
+            true (assoc :ytj-company-names ytj-company-names)
             true (assoc-in [:transport-operator :transport-operators-to-save] (ytj-ops-already-in-nap ytj-company-names)))))
 
 (define-event FetchYtjOperatorResponse [response]

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -182,7 +182,7 @@
                                :width "48px"
                                :margin-bottom "8px"}}})
 
-(def disabled-control {:opacity 0.5
+(def disabled-control {:opacity 0.3
                        :pointer-events "none"})
 
 (def disabled-color {:color "rgba(0, 0, 0, 0.247059)"})

--- a/ote/src/cljs/ote/ui/form.cljs
+++ b/ote/src/cljs/ote/ui/form.cljs
@@ -147,7 +147,8 @@
           :loading?
           :csv-count
           :map-controls
-          :show-delete-dialog?))
+          :show-delete-dialog?
+          :disabled?))
 
 (defrecord ^:private Label [label])
 (defn- label? [x]

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -1101,9 +1101,7 @@
        :secondary secondary
        :on-click #(on-click)
        :disabled disabled
-       :style style
-       })]]
-  )
+       :style style})]])
 
 (defmethod field :text-label [{:keys [label style h-style full-width?]}]
   ;; Options
@@ -1117,7 +1115,6 @@
    (if h-style
      [h-style label]
      [:p label])])
-
 
 (defmethod field :info-toggle [{:keys [label body default-state]}]
   [info/info-toggle label body default-state])

--- a/ote/src/cljs/ote/ui/select_field.cljs
+++ b/ote/src/cljs/ote/ui/select_field.cljs
@@ -37,7 +37,7 @@
          (map-indexed
            (fn [i option]
              (if (= :divider option)
-               ^{:key (str "select-field-divider")}
+               ^{:key (str "select-field-divider-" i)}
                [ui/divider]
                ^{:key (str "select-field-menuitem-" (show-option option))}
                [ui/menu-item


### PR DESCRIPTION
# Changed
* transport-operator wizard section (for selecting ytj name for those nap
operators which do not have a ytj name match), supports now
an empty default value and selecting & reverting selection per orphan.
And updating operators-to-save checkbox list accordingly.