### PR TITLE
Transport operator checkbox group layout

### DIFF
--- a/ote/src/cljs/ote/style/form_fields.cljs
+++ b/ote/src/cljs/ote/style/form_fields.cljs
@@ -26,7 +26,8 @@
   (merge localized-text-language
          {:background-color "#06c"}))
 
-(def checkbox-group-base {:margin-bottom "2rem"})
+(def checkbox-group-base {:margin-bottom "2rem"
+                          :display "inline-block"})
 (def checkbox-group-label {:margin-bottom "4px" :width "100%"})
 
 (def table-header {:overflow "visible" :border-bottom "0px solid white"})

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -924,7 +924,7 @@
          (fn [i option]
            (let [checked? (boolean (selected option))]
              ^{:key i}
-             [:div {:style {:display "flex" :flex-wrap "nowrap" :justify-content "flex-start" :align-items "center" :padding-top "0.625rem"}}
+             [:div {:style {:display "flex" :flex-wrap "nowrap" :justify-content "space-between" :align-items "center" :padding-top "0.625rem"}}
               [ui/checkbox {:id         (str i "_" (str option))
                             :label      (when-not table? (show-option option))
                             :checked    checked?


### PR DESCRIPTION
# Changed
*  In transport-operator view align delete buttons horizontally to same level