### PR TITLE
163289310-route-list-headsign

### DIFF
--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -66,6 +66,14 @@
                         :element-type :gtfs/stoptime-display}
                        string))))
 
+(defn jj [db service-id]
+  (try
+    (first (specql/fetch db :gtfs/detection-service-route-type
+                         #{:gtfs/route-hash-id-type}
+                         {:gtfs/transport-service-id service-id}))
+    (catch Exception e
+      (println "error " e)))
+  )
 
 (define-service-component TransitVisualization {}
 
@@ -81,6 +89,9 @@
                                                    java.sql.Date/valueOf))]
          {:service-info (first (fetch-service-info db {:service-id service-id}))
           :changes changes
+          :route-hash-id-type (first (specql/fetch db :gtfs/detection-service-route-type
+                                                   #{:gtfs/route-hash-id-type}
+                                                   {:gtfs/transport-service-id service-id}))
           :gtfs-package-info (fetch-gtfs-packages-for-service db {:service-id service-id})}))
 
   ^{:unauthenticated true :format :transit}

--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -66,15 +66,6 @@
                         :element-type :gtfs/stoptime-display}
                        string))))
 
-(defn jj [db service-id]
-  (try
-    (first (specql/fetch db :gtfs/detection-service-route-type
-                         #{:gtfs/route-hash-id-type}
-                         {:gtfs/transport-service-id service-id}))
-    (catch Exception e
-      (println "error " e)))
-  )
-
 (define-service-component TransitVisualization {}
 
   ;; Get transit changes, service info and package info for given date and service

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -169,7 +169,8 @@
          :service-info (:service-info response)
          :changes-all (:changes response)
          :changes (update (:changes response) :gtfs/route-changes (comp sorted-route-changes (partial future-changes package-detection-date)))
-         :gtfs-package-info (:gtfs-package-info response)))
+         :gtfs-package-info (:gtfs-package-info response)
+         :route-hash-id-type (:route-hash-id-type response)))
 
 (define-event LoadServiceChangesForDate [service-id date]
   {:path [:transit-visualization]}

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -412,7 +412,7 @@
       [:div.transit-visualization-section-body (stylefy/use-style style/section-body)
        body-content]])])
 
-(defn route-changes [e! route-changes selected-route]
+(defn route-changes [e! route-changes selected-route route-hash-id-type]
   (let [route-count (count route-changes)
         table-height (cond
                        (and (< 0 route-count) (> 10 route-count)) (* 50 route-count) ; 1 - 10
@@ -433,8 +433,12 @@
       :read (juxt :gtfs/route-short-name :gtfs/route-long-name)
       :format (fn [[short long]]
                 (str short " " long))}
-     {:name "Reitti/määränpää" :width "20%"
-      :read :gtfs/trip-headsign}
+     ;; Show Reitti/Määrämpää column only if it does affect on routes.
+     (when (or (nil? route-hash-id-type)
+               (= (:gtfs/route-hash-id-type route-hash-id-type) "short-long-headsign")
+               (= (:gtfs/route-hash-id-type route-hash-id-type) "long-headsign"))
+       {:name "Reitti/määränpää" :width "20%"
+        :read :gtfs/trip-headsign})
 
      {:name "Aikaa 1. muutokseen"
       :width "20%"
@@ -785,7 +789,7 @@
               ^{:key id}
               [pkg p]))])])]))
 
-(defn transit-visualization [e! {:keys [hash->color date->hash service-info changes selected-route compare open-sections]
+(defn transit-visualization [e! {:keys [hash->color date->hash service-info changes selected-route compare open-sections route-hash-id-type]
                                  :as   transit-visualization}]
   [:div
      [:div.transit-visualization
@@ -801,7 +805,7 @@
         ;; Route listing with number of changes
         "Taulukossa on listattu valitussa palvelussa havaittuja muutoksia. Voit valita listalta yhden reitin kerrallaan tarkasteluun. Valitun reitin reitti- ja aikataulutiedot näytetään taulukon alapuolella kalenterissa, kartalla, vuorolistalla ja pysäkkiaikataululistalla."
 
-        [route-changes e! (:gtfs/route-changes changes) selected-route]]]
+        [route-changes e! (:gtfs/route-changes changes) selected-route route-hash-id-type]]]
 
       (when selected-route
         [:div.transit-visualization-route.container


### PR DESCRIPTION
# Changed
* Get route-hash-id-type from database and based on that show headsign in route list or not
 If headsign is shown it must relate to route detection. Otherwise it only confuses users.