### PR TITLE
163361831 compare days 500 error

### DIFF
--- a/database/src/main/resources/db/migration/R__GTFS_query.sql
+++ b/database/src/main/resources/db/migration/R__GTFS_query.sql
@@ -292,8 +292,7 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION gtfs_route_differences(
-     "route-short-name" TEXT, "route-long-name" TEXT, "trip-headsign" TEXT, "route-hash-id" TEXT,
+CREATE OR REPLACE FUNCTION gtfs_route_differences("route-hash-id" TEXT,
      d1_trips "gtfs-package-trip-info"[], d2_trips "gtfs-package-trip-info"[])
 RETURNS "gtfs-route-change-info"
 AS $$
@@ -392,9 +391,9 @@ BEGIN
 
   --RAISE NOTICE 'yli jäi d1: % ja d2: % vuoroa', array_length(d1_trip_ids, 1), array_length(d2_trip_ids, 2);
 
-  route_changes."route-short-name" := "route-short-name";
-  route_changes."route-long-name" := "route-long-name";
-  route_changes."trip-headsign" := "trip-headsign";
+  route_changes."route-short-name" := null; --"route-short-name";
+  route_changes."route-long-name" := null; --"route-long-name";
+  route_changes."trip-headsign" := null; --"trip-headsign";
   route_changes."route-hash-id" := "route-hash-id";
   route_changes."added-trips" := COALESCE(array_length(d2_trip_ids,1), 0);
   route_changes."removed-trips" := COALESCE(array_length(d1_trip_ids,1), 0);

--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -130,7 +130,4 @@
                          {:service-id (Long/parseLong service-id)
                           :date1 (time/parse-date-iso-8601 date1)
                           :date2 (time/parse-date-iso-8601 date2)
-                          :route-short-name short-name
-                          :route-long-name long-name
-                          :trip-headsign headsign
                           :route-hash-id route-hash-id}))))

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -162,20 +162,15 @@ SELECT ts.name AS "transport-service-name",
 -- name: fetch-route-differences
 -- single?: true
 -- Fetch the differences in the given route for the given dates
-SELECT gtfs_route_differences(
-          :route-short-name, :route-long-name, :trip-headsign, :route-hash-id,
+SELECT gtfs_route_differences(:route-hash-id,
           (SELECT tripdata
                      FROM gtfs_route_trips_for_date(
                             gtfs_service_packages_for_date(:service-id::INTEGER, :date1::DATE), :date1::DATE) trips
-            WHERE COALESCE(trips."route-short-name", '') = COALESCE(:route-short-name, '')
-              AND COALESCE(trips."route-long-name", '') = COALESCE(:route-long-name, '')
-              AND COALESCE(trips."trip-headsign", '') = COALESCE(:trip-headsign, '')),
+            WHERE trips."route-hash-id" = :route-hash-id),
           (SELECT tripdata
                      FROM gtfs_route_trips_for_date(
                             gtfs_service_packages_for_date(:service-id::INTEGER, :date2::DATE), :date2::DATE) trips
-            WHERE COALESCE(trips."route-short-name", '') = COALESCE(trips."route-short-name", '')
-              AND COALESCE(trips."route-long-name", '') = COALESCE(:route-long-name, '')
-              AND COALESCE(trips."trip-headsign", '') = COALESCE(:trip-headsign, '')))::TEXT;
+            WHERE trips."route-hash-id" = :route-hash-id))::TEXT;
 
 
 -- name: fetch-gtfs-packages-for-service

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -384,16 +384,10 @@
                          {:date2 date
                           :last-selected-date 2}))]
     (comm/get! (str "transit-visualization/" service-id "/route-differences")
-               {:params (merge
-                         {:date1 (time/format-date-iso-8601 (:date1 compare))
-                          :date2 (time/format-date-iso-8601 (:date2 compare))
-                          :route-hash-id (ensure-route-hash-id route)}
-                         (when-let [short (:gtfs/route-short-name route)]
-                           {:short-name short})
-                         (when-let [long (:gtfs/route-long-name route)]
-                           {:long-name long})
-                         (when-let [headsign (:gtfs/trip-headsign route)]
-                           {:headsign headsign}))
+               {:params {:date1 (time/format-date-iso-8601 (:date1 compare))
+                         :date2 (time/format-date-iso-8601 (:date2 compare))
+                         :route-hash-id (ensure-route-hash-id route)}
+
                 :on-success (tuck/send-async! ->RouteDifferencesResponse)})
     (-> app
         (assoc-in [:transit-visualization :route-differences-loading?] true)

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -414,10 +414,12 @@
 
 (defn route-changes [e! route-changes selected-route route-hash-id-type]
   (let [route-count (count route-changes)
-        table-height (cond
-                       (and (< 0 route-count) (> 10 route-count)) (* 50 route-count) ; 1 - 10
-                       (= 0 route-count) 100
-                       :else 500)]; 10+
+        table-height (str
+                       (cond
+                         (and (< 0 route-count) (> 10 route-count)) (* 50 route-count) ; 1 - 10
+                         (= 0 route-count) 100
+                         :else 500)
+                       "px")]; 10+
   [:div.route-changes
    [route-changes-legend]
    [table/table {:no-rows-message (tr [:transit-visualization-page :loading-routes])
@@ -583,7 +585,7 @@
                                     (comp :gtfs/stop-name first :stoptimes second)
                                     (comp :gtfs/stop-name last :stoptimes second))
                               combined-trips)]
-      [:div.routes-table {:style {:margin-top "1em"}}
+      [:div.trips-table {:style {:margin-top "1em"}}
        [table/table {:name->label str
                      :row-selected? #(= % selected-trip-pair)
                      :on-select #(e! (tv/->SelectTripPair (first %)))}


### PR DESCRIPTION
# Fixed
* Changed gtfs_route_difference stored procedure to work with route-hash-id only.
* This prevents finding multiple route differences and fixes the bug.
* Also added few random numbers to table component to prevent js console warnings. However our table component doesn't take into account :keys that are passed to header row it is always 'h1' and it cannot be fixed using this version of material ui.
   
