### PR TITLE
163361841 do nothing on conflict

### DIFF
--- a/database/src/main/resources/db/migration/R__GTFS_query.sql
+++ b/database/src/main/resources/db/migration/R__GTFS_query.sql
@@ -661,7 +661,8 @@ BEGIN
      JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
      JOIN LATERAL unnest(t.trips) trip ON true
     WHERE r."package-id" = package_id
-    GROUP BY r.id, trip."trip-headsign";
+    GROUP BY r.id, trip."trip-headsign"
+       ON CONFLICT DO NOTHING;
 
 END
 $$ LANGUAGE plpgsql;
@@ -679,7 +680,8 @@ BEGIN
     JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
     JOIN LATERAL unnest(t.trips) trip ON true
    WHERE r."package-id" = package_id
-   GROUP BY r.id, trip."trip-headsign";
+   GROUP BY r.id, trip."trip-headsign"
+      ON CONFLICT DO NOTHING;
 
 END
 $$ LANGUAGE plpgsql;
@@ -697,7 +699,8 @@ BEGIN
       JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
       JOIN LATERAL unnest(t.trips) trip ON true
      WHERE r."package-id" = package_id
-     GROUP BY r.id, trip."trip-headsign";
+     GROUP BY r.id, trip."trip-headsign"
+        ON CONFLICT DO NOTHING;
 
 END
 $$ LANGUAGE plpgsql;
@@ -715,7 +718,8 @@ BEGIN
       JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
       JOIN LATERAL unnest(t.trips) trip ON true
      WHERE r."package-id" = package_id
-     GROUP BY r.id, trip."trip-headsign";
+     GROUP BY r.id, trip."trip-headsign"
+        ON CONFLICT DO NOTHING;
 
 END
 $$ LANGUAGE plpgsql;
@@ -733,7 +737,8 @@ BEGIN
       JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
       JOIN LATERAL unnest(t.trips) trip ON true
      WHERE r."package-id" = package_id
-     GROUP BY r.id, trip."trip-headsign";
+     GROUP BY r.id, trip."trip-headsign"
+        ON CONFLICT DO NOTHING;
 
 END
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
# Fixed
* Added on conflict do nothing to detection-route insert. Due to the way how routes are detected (based on trips in some cases) there is a possibility that same route is added twice to detection-route table. We have unique index on package-id and route-hash-id to prevent this from happening. Now added do nothing clause to insert so we skip insert when it fails and it is ok.

