### PR TITLE
161836698 button styles updated globally

### DIFF
--- a/ote/resources/public/css/styles.css
+++ b/ote/resources/public/css/styles.css
@@ -135,16 +135,6 @@ In order to our OTE menu to render correctly work, we need to reset margin and p
     background-color: rgba(58, 57, 57, 0.1);
 }
 
-
-/* Global link color */
-.wrapper a {
-    color: #2D75B4;
-    text-decoration: none;
-}
-.wrapper a:hover {
-    color: #2D75B4;
-    text-decoration: underline;
-}
 .background-color {
     background: #3db7e4
 }

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -32,14 +32,6 @@
 (def icon-large {:width 32 :height 32
                  :vertical-align "middle"})
 
-(def base-button {:padding-left "1.1em"
-                  :padding-right "1.1em"
-                  :text-transform "uppercase"
-                  :color "#FFFFFF"
-                  :background-color "#1565C0"
-                  :font-size "12px"
-                  :font-weight "bold"})
-
 (def blue-link-with-icon {:color colors/primary
                           :text-decoration "none"
                           :margin-bottom "1px"
@@ -51,9 +43,21 @@
                           ::stylefy/mode {:hover {:border-bottom (str "1px solid " colors/primary)
                                                   :margin-bottom "-1px"}}})
 
+(def base-button (merge
+                   {:padding-left "1.1em"
+                         :padding-right "1.1em"
+                         :text-transform "uppercase"
+                         :color "#FFFFFF"
+                         :background-color "#1565C0"
+                         :font-size "12px"
+                         :font-weight "bold"}
+                   blue-link-with-icon))
+
 (def delete-button (merge base-button {:background-color "rgb(221,0,0)"}))
 
-(def disabled-button (merge base-button {:background-color "#CCCCCC"}))
+
+(def disabled-control {:opacity 0.3
+                       :pointer-events "none"})
 
 (def button-label-style {:font-size "12px"
                          :font-weight "bold"
@@ -181,9 +185,6 @@
                        {:logo {:height "48px"
                                :width "48px"
                                :margin-bottom "8px"}}})
-
-(def disabled-control {:opacity 0.3
-                       :pointer-events "none"})
 
 (def disabled-color {:color "rgba(0, 0, 0, 0.247059)"})
 (def checkbox-label {:float "left"

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -43,15 +43,12 @@
                           ::stylefy/mode {:hover {:border-bottom (str "1px solid " colors/primary)
                                                   :margin-bottom "-1px"}}})
 
-(def base-button (merge
-                   {:padding-left "1.1em"
-                         :padding-right "1.1em"
-                         :text-transform "uppercase"
-                         :color "#FFFFFF"
-                         :background-color "#1565C0"
-                         :font-size "12px"
-                         :font-weight "bold"}
-                   blue-link-with-icon))
+(def base-button
+  {:padding-left "1.1em"
+   :padding-right "1.1em"
+   :text-transform "uppercase"
+   :font-size "12px"
+   :font-weight "bold"})
 
 (def delete-button (merge base-button {:background-color "rgb(221,0,0)"}))
 

--- a/ote/src/cljs/ote/style/buttons.cljs
+++ b/ote/src/cljs/ote/style/buttons.cljs
@@ -3,6 +3,8 @@
     [stylefy.core :as stylefy]
     [ote.theme.colors :as colors]))
 
+(def btn-text-color )
+
 (def outline-btn-hover-focus
   {:text-decoration "none"
    :border-width "2px"
@@ -19,20 +21,22 @@
 (def button-common
   {:padding "20px"
    :height "60px"                                           ;;Hard coded so the height doesn't change with transitions
+   :min-width "4rem"
    :display "inline-block"
+   :justify-content "center"
    :transition "all 200ms ease"
    :text-decoration "none"
    :box-shadow "4px 4px 8px 0 rgba(0, 0, 0, .2)"
    ::stylefy/vendors ["webkit" "moz" "o"]
    ::stylefy/auto-prefix #{:transition}})
 
-(def primary-button
-  (merge button-common
-         {:color "white"
-          :border 0
-          :background-color colors/primary-light
-          ::stylefy/mode {:hover primary-btn-hover-focus
-                          :focus primary-btn-hover-focus}}))
+
+(def disabled-button (merge
+                       button-common
+                       {:color colors/primary-text
+                        :background-color colors/primary-disabled
+                        :pointer-events "none"
+                        :box-shadow "none"}))
 
 (def outline-button
   (merge button-common
@@ -42,6 +46,14 @@
           :border-color colors/primary
           ::stylefy/mode {:hover outline-btn-hover-focus
                           :focus outline-btn-hover-focus}}))
+
+(def primary-button
+  (merge button-common
+         {:color colors/primary-text
+          :border 0
+          :background-color colors/primary-light
+          ::stylefy/mode {:hover primary-btn-hover-focus
+                          :focus primary-btn-hover-focus}}))
 
 (def svg-button
   {:background-color "transparent"

--- a/ote/src/cljs/ote/style/buttons.cljs
+++ b/ote/src/cljs/ote/style/buttons.cljs
@@ -3,7 +3,10 @@
     [stylefy.core :as stylefy]
     [ote.theme.colors :as colors]))
 
-(def btn-text-color )
+(def action-button-icon
+  {:padding "0"
+   :margin "0 1em 0 0"
+   :color colors/white-basic})
 
 (def outline-btn-hover-focus
   {:text-decoration "none"
@@ -18,9 +21,15 @@
    :background-color colors/primary
    :transform "scale(0.98)"})
 
+(def negative-btn-hover-focus
+  {:text-decoration "none"
+   :box-shadow "0 4px 4px rgba(0,0,0,0.2)"
+   :background-color colors/negative-button-hover
+   :transform "scale(0.98)"})
+
 (def button-common
   {:padding "20px"
-   :height "60px"                                           ;;Hard coded so the height doesn't change with transitions
+   :height "60px"                                           ;; Hard coded so the height doesn't change with transitions
    :min-width "4rem"
    :display "inline-block"
    :justify-content "center"
@@ -30,13 +39,20 @@
    ::stylefy/vendors ["webkit" "moz" "o"]
    ::stylefy/auto-prefix #{:transition}})
 
-
 (def disabled-button (merge
                        button-common
                        {:color colors/primary-text
                         :background-color colors/primary-disabled
                         :pointer-events "none"
                         :box-shadow "none"}))
+
+(def negative-button
+  (merge button-common
+         {:color colors/negative-text
+          :border 0
+          :background-color colors/negative-button
+          ::stylefy/mode {:hover negative-btn-hover-focus
+                          :focus negative-btn-hover-focus}}))
 
 (def outline-button
   (merge button-common

--- a/ote/src/cljs/ote/style/buttons.cljs
+++ b/ote/src/cljs/ote/style/buttons.cljs
@@ -32,7 +32,7 @@
    :height "60px"                                           ;; Hard coded so the height doesn't change with transitions
    :min-width "4rem"
    :display "inline-block"
-   :justify-content "center"
+   :text-align "center"
    :transition "all 200ms ease"
    :text-decoration "none"
    :box-shadow "4px 4px 8px 0 rgba(0, 0, 0, .2)"

--- a/ote/src/cljs/ote/style/info_style.cljs
+++ b/ote/src/cljs/ote/style/info_style.cljs
@@ -4,7 +4,7 @@
 
 
 (def info-button
-  {:background-color colors/gray200
+  {:background-color colors/gray230
    :width "100%"
    :padding "1rem"
    :border "none"
@@ -24,7 +24,7 @@
    :margin-right "0.5rem"})
 
 (def info-text
-  {:background-color colors/gray100
+  {:background-color colors/gray240
    :transform-origin "top"
    :display "block"
    :margin 0

--- a/ote/src/cljs/ote/theme/colors.cljs
+++ b/ote/src/cljs/ote/theme/colors.cljs
@@ -3,8 +3,10 @@
 (def blue "#0048c2")
 (def blue-light "#0052dd")
 
-(def gray100 "#F0F0F0")
-(def gray200 "#E6E6E6")
+(def gray100 "#646464")
+(def gray200 "#C8C8C8")
+(def gray230 "#e6e6e6")
+(def gray240 "#f0f0f0")
 (def gray300 "#E0E0E0")
 (def gray400 "#CCC")
 (def gray500 "#969696")
@@ -14,12 +16,13 @@
 (def green-basic "#00AA00")
 (def red-basic "#DD0000")
 (def orange-basic "#FF8800")
+(def white-basic "white")
 
+(def primary-text white-basic)
 (def primary blue)
+(def primary-disabled gray200)
 (def primary-light blue-light)
 (def secondary gray900)
 (def progress primary)
 (def success green-basic)
 (def warning red-basic)
-
-

--- a/ote/src/cljs/ote/theme/colors.cljs
+++ b/ote/src/cljs/ote/theme/colors.cljs
@@ -15,11 +15,15 @@
 
 (def green-basic "#00AA00")
 (def red-basic "#DD0000")
+(def red-dark "#CF0000")
 (def orange-basic "#FF8800")
 (def white-basic "white")
 
-(def primary-text white-basic)
+(def negative-button red-basic)
+(def negative-text white-basic)
+(def negative-button-hover red-dark)
 (def primary blue)
+(def primary-text white-basic)
 (def primary-disabled gray200)
 (def primary-light blue-light)
 (def secondary gray900)

--- a/ote/src/cljs/ote/ui/buttons.cljs
+++ b/ote/src/cljs/ote/ui/buttons.cljs
@@ -2,11 +2,12 @@
   (:require [cljs-react-material-ui.reagent :as ui]
             [ote.localization :refer [tr tr-key]]
             [cljs-react-material-ui.core :refer [color]]
+            [cljs-react-material-ui.icons :as ic]
             [stylefy.core :as stylefy]
             [ote.style.base :as style-base]
             [ote.style.buttons :as style-buttons]
-            [ote.style.buttons :as style-btns]
-            [ote.ui.common :as common]))
+            [ote.ui.common :as common]
+            [ote.theme.colors :as colors]))
 
 (defn- button-container [button]
   [:div (stylefy/use-style style-base/action-button-container)
@@ -16,24 +17,26 @@
   [button-container
    [:button (merge opts
                    (if (:disabled opts)
-                     (stylefy/use-style style-btns/disabled-button)
-                     (stylefy/use-style style-btns/primary-button)))
+                     (stylefy/use-style style-buttons/disabled-button)
+                     (stylefy/use-style style-buttons/primary-button)))
     label]])
 
 (defn cancel [opts label]
   [button-container
    [:button (merge opts
                    (if (:disabled opts)
-                     (stylefy/use-style style-btns/disabled-button)
-                     (stylefy/use-style style-btns/outline-button)))
+                     (stylefy/use-style style-buttons/disabled-button)
+                     (stylefy/use-style style-buttons/outline-button)))
     label]])
 
-(defn delete [opts label] ;; TODO: this could be removed after :open-ytj-integration taken into use
+(defn delete [opts label]
   [button-container
    [:button (merge opts
                    (if (:disabled opts)
-                     (stylefy/use-style style-btns/disabled-button)
-                     (stylefy/use-style style-btns/primary-button))) label]])
+                     (stylefy/use-style style-buttons/disabled-button)
+                     (stylefy/use-style style-buttons/negative-button)))
+    label]])
+
 (defn open-link
   "Create button like linkify link"
   [url label]

--- a/ote/src/cljs/ote/ui/buttons.cljs
+++ b/ote/src/cljs/ote/ui/buttons.cljs
@@ -5,40 +5,35 @@
             [stylefy.core :as stylefy]
             [ote.style.base :as style-base]
             [ote.style.buttons :as style-buttons]
+            [ote.style.buttons :as style-btns]
             [ote.ui.common :as common]))
-
 
 (defn- button-container [button]
   [:div (stylefy/use-style style-base/action-button-container)
    button])
 
 (defn save [opts label]
-  [button-container [ui/raised-button
-                     (merge opts
-                            (if (:disabled opts)
-                              {:button-style style-base/disabled-button :disabled true}
-                              {:button-style style-base/base-button}))
-                     label]])
-
-(defn delete [opts label]
-  [button-container [ui/raised-button
-                     (merge opts
-                            (if (:disabled opts)
-                              {:button-style style-base/disabled-button :disabled true}
-                              {:button-style style-base/delete-button}))
-                     label]])
+  [button-container
+   [:button (merge opts
+                   (if (:disabled opts)
+                     (stylefy/use-style style-btns/disabled-button)
+                     (stylefy/use-style style-btns/primary-button)))
+    label]])
 
 (defn cancel [opts label]
   [button-container
-   [ui/flat-button
-    (merge {:style {:padding-left "1.1em"
-                    :padding-right "1.1em"
-                    :text-transform "uppercase"
-                    :color (color :blue700)
-                    :font-size "12px"
-                    :font-weight "bold"}} opts)
+   [:button (merge opts
+                   (if (:disabled opts)
+                     (stylefy/use-style style-btns/disabled-button)
+                     (stylefy/use-style style-btns/outline-button)))
     label]])
 
+(defn delete [opts label] ;; TODO: this could be removed after :open-ytj-integration taken into use
+  [button-container
+   [:button (merge opts
+                   (if (:disabled opts)
+                     (stylefy/use-style style-btns/disabled-button)
+                     (stylefy/use-style style-btns/primary-button))) label]])
 (defn open-link
   "Create button like linkify link"
   [url label]

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -9,6 +9,7 @@
             [stylefy.core :as stylefy]
             [ote.style.form-fields :as style-form-fields]
             [ote.style.base :as style-base]
+            [ote.style.buttons :as style-buttons]
             [ote.ui.validation :as valid]
             [ote.time :as time]
             [ote.ui.buttons :as buttons]
@@ -832,13 +833,11 @@
      (when add-label
        [:div (stylefy/use-style style-base/button-add-row)
         [buttons/save (merge {:on-click #(update! (conj (or data []) {}))
-                              :label add-label
-                              :label-style style-base/button-label-style
                               :disabled (if add-label-disabled?
                                           (add-label-disabled? (last data))
                                           (values/effectively-empty? (last data)))}
                              (when (not (nil? id))
-                               {:id (str id "-button")}))]])]))
+                               {:id (str id "-button")})) add-label]])]))
 
 (defn- checkbox-container [update! table? label warning error style checked? disabled? on-click]
   [:div (when error (stylefy/use-style style-base/required-element))
@@ -1089,22 +1088,11 @@
           ""))]]))
 
 (defmethod field :external-button [{:keys [label on-click disabled primary secondary style element-id]}]
-  ;; Options
-  ; :label Button label text for displaying
-  ; :on-click On-click callback fn
-  ; :disabled Boolean property for disabling button
-  ; primary
-  ; secondary
-  [:div
-   [ui/raised-button
-    (merge
-      (when element-id {:id element-id})
-      {:label label
-       :primary primary
-       :secondary secondary
-       :on-click #(on-click)
-       :disabled disabled
-       :style style})]])
+  [buttons/save (merge
+                  (when element-id {:id element-id})
+                  {:on-click #(on-click)
+                   :disabled disabled})
+   label])
 
 (defmethod field :text-label [{:keys [label style h-style full-width?]}]
   ;; Options

--- a/ote/src/cljs/ote/views/login.cljs
+++ b/ote/src/cljs/ote/views/login.cljs
@@ -9,6 +9,7 @@
             [ote.localization :refer [tr tr-key]]
             [ote.ui.form :as form]
             [ote.ui.form-fields :as form-fields]
+            [ote.ui.buttons :as buttons]
             [ote.ui.common :refer [linkify] :as common-ui]
             [ote.db.user :as user]
             [clojure.string :as str]))
@@ -24,9 +25,7 @@
                :update! #(e! (lc/->UpdateLoginCredentials %))
                :footer-fn (fn [data]
                             [:span.login-dialog-footer
-                             [ui/raised-button {:primary true
-                                                :on-click #(e! (lc/->Login))
-                                                :label (tr [:login :login-button])}]])}
+                             [buttons/save {:on-click #(e! (lc/->Login))} (tr [:login :login-button])]])}
     [(form/group
       {:expandable? false :columns 3 :layout :raw :card? false}
       {:name :email

--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -54,18 +54,14 @@
       {:open true
        :title (tr [:dialog :delete-transport-service :title])
        :actions [(r/as-element
-                   [ui/flat-button
-                    {:label (tr [:buttons :cancel])
-                     :primary true
-                     :on-click #(e! (ts/->CancelDeleteTransportService id))}])
+                   [buttons/cancel
+                    {:on-click #(e! (ts/->CancelDeleteTransportService id))}
+                    (tr [:buttons :cancel])])
                  (r/as-element
-                   [ui/raised-button
-                    {:label (tr [:buttons :delete])
-                     :icon (ic/action-delete-forever)
-                     :secondary true
-                     :primary true
-                     :on-click #(e! (ts/->ConfirmDeleteTransportService id))}])]}
-
+                   [buttons/delete
+                    {:icon (ic/action-delete-forever)
+                     :on-click #(e! (ts/->ConfirmDeleteTransportService id))}
+                    (tr [:buttons :delete])])]}
       (tr [:dialog :delete-transport-service :confirm] {:name name})])])
 
 (defn transport-services-table-rows [e! services transport-operator-id]

--- a/ote/src/cljs/ote/views/route/route_list.cljs
+++ b/ote/src/cljs/ote/views/route/route_list.cljs
@@ -36,21 +36,17 @@
       {:open    true
        :title   (tr [:route-list-page :delete-dialog-header])
        :actions [(r/as-element
-                   [ui/flat-button
-                    {:label    (tr [:buttons :cancel])
-                     :primary  true
-                     :on-click #(do
+                   [buttons/cancel
+                    {:on-click #(do
                                   (.preventDefault %)
-                                  (e! (route-list/->CancelDeleteRoute id)))}])
+                                  (e! (route-list/->CancelDeleteRoute id)))}
+                    (tr [:buttons :cancel])])
                  (r/as-element
-                   [ui/raised-button
-                    {:label     (tr [:buttons :delete])
-                     :icon      (ic/action-delete-forever)
-                     :secondary true
-                     :primary   true
-                     :on-click  #(do
+                   [buttons/delete
+                    {:on-click  #(do
                                    (.preventDefault %)
-                                   (e! (route-list/->ConfirmDeleteRoute id)))}])]}
+                                   (e! (route-list/->ConfirmDeleteRoute id)))}
+                    (tr [:buttons :delete])])]}
 
       (str (tr [:route-list-page :delete-dialog-remove-route]) (t-service/localized-text-with-fallback @selected-language name))])])
 

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -39,17 +39,13 @@
       {:open true
        :title (tr [:dialog :delete-transport-service :title])
        :actions [(r/as-element
-                   [ui/flat-button
-                    {:label (tr [:buttons :cancel])
-                     :primary true
-                     :on-click #(e! (admin/->CancelDeleteTransportService id))}])
+                   [buttons/cancel
+                    {:on-click #(e! (admin/->CancelDeleteTransportService id))}
+                    (tr [:buttons :cancel])])
                  (r/as-element
-                   [ui/raised-button
-                    {:label (tr [:buttons :delete])
-                     :icon (ic/action-delete-forever)
-                     :secondary true
-                     :primary true
-                     :on-click #(e! (admin/->ConfirmDeleteTransportService id))}])]}
+                   [buttons/delete
+                    {:on-click #(e! (admin/->ConfirmDeleteTransportService id))}
+                    (tr [:buttons :delete])])]}
       (tr [:dialog :delete-transport-service :confirm] {:name name})])])
 
 (defn data-item [icon item]

--- a/ote/src/cljs/ote/views/theme.cljs
+++ b/ote/src/cljs/ote/views/theme.cljs
@@ -7,7 +7,8 @@
             [reagent.core :as r]
             [ote.localization :refer [tr tr-key]]
             [ote.app.controller.front-page :as fp-controller]
-            [datafrisk.core :as df]))
+            [datafrisk.core :as df]
+            [ote.ui.buttons :as buttons]))
 
 (defn- flash-message-error [e! msg]
   [ui/snackbar {:open (boolean msg)
@@ -84,13 +85,9 @@
                 :modal true
                 :open true
                 :actions [(r/as-element
-                           [ui/flat-button {:label (tr :stay)
-                                            :primary true
-                                            :on-click #(e! (fp-controller/->StayOnPage))}])
+                            [buttons/save {:on-click #(e! (fp-controller/->StayOnPage))} (tr :stay)])
                           (r/as-element
-                           [ui/flat-button {:label (tr :leave)
-                                            :secondary true
-                                            :on-click #(e! confirm)}])]}
+                            [buttons/cancel {:on-click #(e! confirm)} (tr :leave)])]}
      msg]))
 
 (defn theme

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -47,13 +47,12 @@
       :open    true
       :title   (tr [:dialog :delete-transport-operator :title])
       :actions [(r/as-element
-                  [buttons/save
+                  [buttons/cancel
                    {:on-click #(e! toggle-dialog)}
                    (tr [:buttons :cancel])])
                 (r/as-element
-                  [buttons/cancel
+                  [buttons/delete
                    {:id "confirm-operator-delete"
-                    :icon      (ic/action-delete-forever)
                     :disabled  (if (empty? operator-services)
                                  false
                                  true)

--- a/ote/src/cljs/ote/views/transport_operator_ytj.cljs
+++ b/ote/src/cljs/ote/views/transport_operator_ytj.cljs
@@ -47,21 +47,18 @@
       :open    true
       :title   (tr [:dialog :delete-transport-operator :title])
       :actions [(r/as-element
-                  [ui/flat-button
-                   {:label    (tr [:buttons :cancel])
-                    :primary  true
-                    :on-click #(e! toggle-dialog)}])
+                  [buttons/save
+                   {:on-click #(e! toggle-dialog)}
+                   (tr [:buttons :cancel])])
                 (r/as-element
-                  [ui/raised-button
+                  [buttons/cancel
                    {:id "confirm-operator-delete"
-                    :label     (tr [:buttons :delete])
                     :icon      (ic/action-delete-forever)
-                    :secondary true
-                    :primary   true
                     :disabled  (if (empty? operator-services)
                                  false
                                  true)
-                    :on-click  #(e! (to/->DeleteTransportOperator (::t-operator/id operator)))}])]}
+                    :on-click  #(e! (to/->DeleteTransportOperator (::t-operator/id operator)))}
+                   (tr [:buttons :delete])])]}
      [:div
       (if (empty? operator-services)
         (tr [:dialog :delete-transport-operator :confirm] {:name (::t-operator/name operator)})
@@ -353,35 +350,35 @@
     (tr [:buttons :next])]])
 
 (defn- operator-form-options [e! state show-actions?]
-  {:name->label     (tr-key [:field-labels])
-   :update!         #(e! (to/->EditTransportOperatorState %))
-   :footer-fn       (fn [data]
-                      [:div {:style style-form/action-control-section-margin}
-                       [:div
-                        (when show-actions?
-                          [buttons/save {:id "btn-operator-save"
-                                         :on-click #(e! (to/->SaveTransportOperator))
-                                         :disabled (form/disable-save? data)}
-                           (tr [:buttons :save])])
+  {:name->label (tr-key [:field-labels])
+   :update! #(e! (to/->EditTransportOperatorState %))
+   :footer-fn (fn [data]
+                [:div {:style style-form/action-control-section-margin}
+                 [:div
+                  (when show-actions?
+                    [buttons/save {:id "btn-operator-save"
+                                   :on-click #(e! (to/->SaveTransportOperator))
+                                   :disabled (form/disable-save? data)}
+                     (tr [:buttons :save])])
 
-                        [buttons/save {:on-click #(e! (to/->CancelTransportOperator))}
-                         (tr [:buttons :cancel])]]
-                       (when (and show-actions? (empty? (:ytj-company-names state)))
-                         (when (not (get-in state [:transport-operator :new?]))
-                           [:div
-                            [:br]
-                            [ui/divider]
-                            [:br]
-                            [:div [:h3 (tr [:dialog :delete-transport-operator :title-base-view])]]
-                            [info/info-toggle (tr [:common-texts :instructions]) (tr [:organization-page :help-operator-how-delete]) true]
-                            [buttons/save {:on-click #(e! (to/->ToggleSingleTransportOperatorDeleteDialog))
-                                           :id "delete-transport-operator-btn"
-                                           :disabled (if (and
-                                                           (empty? (:transport-service-vector state))
-                                                           (::t-operator/id data))
-                                                       false
-                                                       true)}
-                             (tr [:buttons :delete-operator])]]))])})
+                  [buttons/cancel {:on-click #(e! (to/->CancelTransportOperator))}
+                   (tr [:buttons :cancel])]]
+
+                 (when (and show-actions? (empty? (:ytj-company-names state)))
+                   (when (not (get-in state [:transport-operator :new?]))
+                     [:div
+                      [:br]
+                      [ui/divider]
+                      [:br]
+                      [:div [:h3 (tr [:dialog :delete-transport-operator :title-base-view])]]
+                      [info/info-toggle (tr [:common-texts :instructions]) (tr [:organization-page :help-operator-how-delete]) true]
+                      [buttons/save {:on-click #(e! (to/->ToggleSingleTransportOperatorDeleteDialog))
+                                     :disabled (if (and
+                                                     (empty? (:transport-service-vector state))
+                                                     (::t-operator/id data))
+                                                 false
+                                                 true)}
+                       (tr [:buttons :delete-operator])]]))])})
 
 (defn operator-ytj [e! {operator :transport-operator :as state}]
   (let [show-id-entry? (empty? (get-in state [:params :id]))


### PR DESCRIPTION
# Added
* New styles for primary, negative, outline buttons and related elements like text colour
* New negative (=red) button
   
# Fixed
* Some problem fixed.
   
# Changed
* Changed following buttons to use html button element instead of material ui components: save, delete, cancel 
* buttons updated for buttons 
 - embedded in tables a few old ones like file upload remain). Tables e.g. in service and sea route views
 - navigation-prompt
 - service/operator/(sea)route deletion modal
 - user settings
 - user email settigs
 - user login
 - user registration
