### PR TITLE
don't send email when smtp server is undefined

### DIFF
--- a/ote/src/clj/ote/email.clj
+++ b/ote/src/clj/ote/email.clj
@@ -20,8 +20,10 @@
 
 (defn- send-email
   "Send a singular email using Postal."
-  [& args]
-  (apply postal/send-message args))
+  [server msg]
+  (if (-> server :host some?)   
+    (postal/send-message server msg)
+    (log/warn "not sending email because configured smtp host is empty")))
 
 (defrecord Email [email-opts]
   component/Lifecycle


### PR DESCRIPTION
.. because postal will fall back to local /usr/bin/sendmail, and
configuring an empty smtp server means we don't want the app to send
out emails.