### PR TITLE
Production env variable

### DIFF
--- a/aws/ansible/environments/production/group_vars/ote/vars
+++ b/aws/ansible/environments/production/group_vars/ote/vars
@@ -1,7 +1,7 @@
 db_url: "jdbc:postgresql://{{vault_db_host}}/napote"
 db_username: "{{vault_db_ote_user}}"
 db_password: "{{vault_db_ote_password}}"
-production_environment: "true"
+testing_environment: "false"
 auth_shared_secret: "{{vault_beaker_session_secret}}"
 cookie_domain: "finap.fi"
 base_url: "https://finap.fi"

--- a/aws/ansible/environments/staging/group_vars/ote/vars
+++ b/aws/ansible/environments/staging/group_vars/ote/vars
@@ -1,7 +1,7 @@
 db_url: "jdbc:postgresql://{{vault_db_host}}/napote"
 db_username: "{{vault_db_ote_user}}"
 db_password: "{{vault_db_ote_password}}"
-production_environment: "false"
+testing_environment: "true"
 auth_shared_secret: "{{vault_beaker_session_secret}}"
 cookie_domain: "testi.finap.fi"
 base_url: "https://testi.finap.fi"

--- a/aws/ansible/templates/ote/config.edn.j2
+++ b/aws/ansible/templates/ote/config.edn.j2
@@ -1,5 +1,5 @@
 {:environment {:base-url "{{base_url}}/"}
- :production-env "{{production_environment}}"
+ :testing-env? "{{testing_environment}}"
  :db {:url "{{db_url}}"
       :username "{{db_username}}"
       :password "{{db_password}}"}

--- a/ote/config.edn
+++ b/ote/config.edn
@@ -1,6 +1,6 @@
 {:environment {:base-url "http://localhost:3000/"}
  :dev-mode? true
- :production-env? false
+ :testing-env? true
  :db {:url "jdbc:postgresql://localhost:5432/napote"
       :username "napote"
       :password ""}

--- a/ote/src/clj/ote/services/index.clj
+++ b/ote/src/clj/ote/services/index.clj
@@ -69,16 +69,16 @@
 
 (defn index-page [db user config]
   (let [dev-mode? (:dev-mode? config)
-        production-env? (:production-env? config)
+        testing-env? (:testing-env? config)
         ga-conf (:ga config)
         flags (str/join "," (map name (:enabled-features config)))]
     [:html
      [:head
-      (if production-env?
-        (for [f favicons]
-          [:link f]))
+      (if testing-env?
         (for [f dev-favicons]
           [:link f])
+        (for [f favicons]
+          [:link f]))
       [:meta {:name "theme-color" :content "#ffffff"}]
       [:meta {:name    "viewport"
               :content "width=device-width, initial-scale=1.0"}]

--- a/ote/src/clj/ote/services/transit_changes.sql
+++ b/ote/src/clj/ote/services/transit_changes.sql
@@ -19,7 +19,7 @@ SELECT ts.id AS "transport-service-id",
        "different-week-date", "change-date",
        "date",
        "change-date" - CURRENT_DATE AS "days-until-change",
-       ("change-date" IS NOT NULL) AS "changes?",
+       ("different-week-date" IS NOT NULL) AS "changes?",
        EXISTS(SELECT id
                 FROM "external-interface-description" eid
                WHERE eid."transport-service-id" = ts.id


### PR DESCRIPTION
 # Fixed
* Problem in transit changes showing changes as 0-0-0-0 instead of "Ei muutoksia"
* Default of favicon changed to show the proper favicon instead of development.
   
# Changed
* Querying transit_changes.sql to use different-week-date