### PR TITLE
Only show brokerage dialog when brokerage selection is not already ch…

### DIFF
--- a/ote/src/cljs/ote/app/controller/transport_service.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_service.cljs
@@ -52,7 +52,10 @@
 
 (define-event ShowBrokeringServiceDialog []
   {}
-  (assoc-in app [:transport-service :show-brokering-service-dialog?] true))
+  (let [brokerage-selected? (get-in app [:transport-service ::t-service/passenger-transportation ::t-service/brokerage?])]
+    (if-not brokerage-selected?
+      (assoc-in app [:transport-service :show-brokering-service-dialog?] true)
+      app)))
 
 (define-event SelectBrokeringService [select-type]
   {}


### PR DESCRIPTION
…ecked.

# Fixed
* Brokerage selection dialog is only shown when the selection is not checked already.
