### PR TITLE
controller: transit-visualization fix show-no-change-routes toggling

### DIFF
--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -459,5 +459,5 @@
   (update app routename not))
 
 (define-event ToggleShowNoChangeRoutes []
-  {:path [:transit-visualization :show-no-change-routes?]}
+  {:path [:transit-visualization]}
     (update app :show-no-change-routes? not))


### PR DESCRIPTION
# Fixed
* controller: transit-visualization fix show-no-change-routes? toggling
Checkbox was stuck forever because state passed to it was a container
instead of the boolean which is toggled.
