### PR TITLE
163788230 transit-visualization filter checkbox fix if data does not change

### DIFF
--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -473,6 +473,8 @@
   ;; Disabling of UI components must happen before table model change because otherwise table rendering
   ;; delays those as well.
   (.setTimeout js/window #(e! (->ToggleShowNoChangeRoutesDelayed)) 0)
-  (-> app
-      (update :show-no-change-routes-checkbox? not)
-      (assoc :route-changes-loading? true)))
+  (cond-> app
+      true (update :show-no-change-routes-checkbox? not)
+      ;; :route-changes-loading? set only when table model changes, otherwise there's no :component-did-mount event to clear the flag
+      (not= (:gtfs/route-changes (:changes-no-change app))
+            (:gtfs/route-changes (:changes-filtered app))) (assoc :route-changes-loading? true)))

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -805,7 +805,7 @@
 
 (defn transit-visualization [e! {:keys [hash->color date->hash service-info changes-no-change changes-filtered selected-route compare open-sections route-hash-id-type show-no-change-routes? show-no-change-routes-checkbox?]
                                  :as transit-visualization}]
-  (let [routes (if show-no-change-routes?
+  (let [routes (if show-no-change-routes? ;; NOTICE! If you change route-changes data resolution logic check also :route-changes-loading? toggling logic ToggleShowNoChangeRoutes
                  (:gtfs/route-changes changes-no-change)
                  (:gtfs/route-changes changes-filtered))
         route-name (if (service-is-using-headsign route-hash-id-type)
@@ -839,7 +839,7 @@
            ;; Different value key for checkbox allows triggering checkbox disabling logic first and table changes only after that.
            show-no-change-routes-checkbox?]]]
 
-        [route-changes e! routes selected-route route-hash-id-type]]]
+        [route-changes e! routes selected-route route-hash-id-type]]] ;; NOTICE! If you change route-changes data resolution logic check also :route-changes-loading? toggling logic ToggleShowNoChangeRoutes
 
       (when selected-route
         [:div.transit-visualization-route.container


### PR DESCRIPTION
# Fixed
* views,controller: transit-visualization filter checkbox fix if data does not change
Otherwise checkbox remains disabled if route-changes model does not change
and component-did-mount event never clears the flag used to disable
control.
  