### PR TITLE
163936103: transit-changes dont hide calendar during date change

### DIFF
--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -845,9 +845,9 @@
         [:div.transit-visualization-route.container
          [:h3 "Valittu reitti: " route-name]
 
+         [route-calendar e! transit-visualization]
          (when (and hash->color date->hash (tv/loaded-from-server? transit-visualization))
            [:span
-            [route-calendar e! transit-visualization]
             [selected-route-map-section e! open-sections date->hash hash->color compare]
             [route-trips e! open-sections compare]
             [trip-stop-sequence e! open-sections compare]])])]]))


### PR DESCRIPTION
# Changed
* views: transit-changes dont hide calendar during date change
Not hiding calendar prevents view flickering when route details are
reloaded. Route details don't affectc calendar data model.
