### PR TITLE
163781982 one different week should not be considered as a change

### DIFF
--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -129,6 +129,7 @@
 
       ;; If current week does not equal starting week...
       (and (not (week= starting-week-hash curr))
+           (not (week= starting-week-hash next1))
            ;; ...and traffic does not revert back to previous in two weeks
            (not (week= starting-week-hash next2)))
       ;; this is a change

--- a/ote/test/clj/ote/transit_changes/detection_test.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test.clj
@@ -8,7 +8,9 @@
 
 (def route-name ["TST" "Testington - Terstersby" "Testersby"])
 
-(defn weeks [starting-from & route-maps]
+(defn weeks
+  "Give first day of week (monday) as a starting-from."
+  [starting-from & route-maps]
   (vec (map-indexed
         (fn [i routes]
           {:beginning-of-week (.plusDays starting-from (* i 7))
@@ -99,6 +101,25 @@
   (is (nil?
        (get-in (detection/next-different-weeks test-traffic-2-different-weeks)
                [route-name :different-week]))))
+
+(def normal-to-1-different-to-1-normal-and-rest-are-changed
+  (weeks (d 2019 1 28)
+         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ; prev week
+         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ; starting week
+         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ; normal
+         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ; normal
+         {route-name ["!!" "!!" "!!" "!!" "!!" "h6" "h7"]} ; first different week - should be skipper
+         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ; back to normal
+         {route-name ["h1" "h2" "h3" "h4" "!!" "h6" "!!"]} ; new schedule - should be found as different week
+         {route-name ["h1" "h2" "h3" "h4" "!!" "h6" "!!"]} ; new schedule
+         {route-name ["h1" "h2" "h3" "h4" "!!" "h6" "!!"]} ; New schedule
+         {route-name ["h1" "h2" "h3" "h4" "!!" "h6" "!!"]})); New schedule
+
+(deftest one-week-difference-is-skipped
+  (let [result (detection/next-different-weeks normal-to-1-different-to-1-normal-and-rest-are-changed)]
+    (is (= {:beginning-of-week (d 2019 3 11)
+            :end-of-week (d 2019 3 17)}
+           (get-in result [route-name :different-week])))))
 
 
 (def test-traffic-normal-difference


### PR DESCRIPTION
# Fixed
* When route have a different weed followed by normal week followed by different week the first different weeks was considered as a change. Which was wrong. Added a check that two following weeks must be different to count as a change.
   
