### PR TITLE
164075691 routes without changes missing

### DIFF
--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -11,6 +11,7 @@
             [specql.impl.composite :as composite]
             [specql.impl.registry :as specql-registry]
             [ote.util.fn :refer [flip]]
+            [ote.util.clojure :as util-clj]
             [ote.transit-changes.detection :as detection]
             [clojure.set :as set]
             [digest]))
@@ -112,11 +113,13 @@
     (let [service-id (Long/parseLong service-id)]
       {:service-info (first (fetch-service-info db {:service-id service-id}))
        :changes (first (detected-changed-to-service-by-date db
-                                                  {:service-id service-id
-                                                   :date (time/iso-8601-date->sql-date date)}))
-       :route-changes (changed-routes-to-service-by-date db
-                                                         {:service-id service-id
-                                                          :date (time/iso-8601-date->sql-date date)})
+                                                            {:service-id service-id
+                                                             :date (time/iso-8601-date->sql-date date)}))
+       :route-changes (map util-clj/remove-coll-key-ns
+                           (specql/fetch db :gtfs/detected-route-change
+                                         (specql/columns :gtfs/detected-route-change)
+                                         {:gtfs/transit-service-id service-id
+                                          :gtfs/transit-change-date (time/iso-8601-date->sql-date date)}))
        :route-hash-id-type (first (specql/fetch db :gtfs/detection-service-route-type
                                                 #{:gtfs/route-hash-id-type}
                                                 {:gtfs/transport-service-id service-id}))

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -178,12 +178,3 @@ FROM "gtfs-transit-changes" c
 WHERE c."transport-service-id" = :service-id
   AND c.date = :date::DATE;
 
--- name: changed-routes-to-service-by-date
-SELECT r."route-short-name", r."route-long-name", r."trip-headsign",
-       r."change-type", r."added-trips", r."removed-trips",
-       r."trip-stop-sequence-changes-lower", r."trip-stop-sequence-changes-upper",
-       r."trip-stop-time-changes-lower", r."trip-stop-time-changes-upper",
-       r."current-week-date", r."different-week-date", r."change-date", r."route-hash-id"
- FROM "detected-route-change" r
- WHERE r."transit-service-id" = :service-id
-   AND r."transit-change-date" = :date::DATE;

--- a/ote/src/clj/ote/util/clojure.clj
+++ b/ote/src/clj/ote/util/clojure.clj
@@ -1,0 +1,4 @@
+(ns ote.util.clojure)
+
+(defn remove-coll-key-ns [c]
+  (into {} (map (fn [[k v]] [(keyword (name k)) v]) c)))

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -24,9 +24,9 @@
    "#ec8fb5" "#23dbe1" "#a4515b" "#169294" "#fd5925" "#3d4e92" "#f4d403"
    "#66a1e5" "#d07d09" "#9382e9" "#b9cf84" "#544437" "#f2cdb9"])
 
-(defn route-filtering-available? [{:keys [changes-filtered changes-no-change route-changes-loading?] :as transit-visualization}]
+(defn route-filtering-available? [{:keys [changes-route-no-change route-changes-loading?] :as transit-visualization}]
   (and (not route-changes-loading?)
-       (seq (:gtfs/route-changes changes-no-change))))
+       (seq changes-route-no-change)))
 
 (defn loaded-from-server? [{:keys [route-lines-for-date-loading? route-trips-for-date1-loading?
                                    route-trips-for-date2-loading? route-calendar-hash-loading?
@@ -87,7 +87,7 @@
   "Sort route changes according to change date and route-long-name: Earliest first and missing date last."
   [show-no-change changes]
   (let [;; Removed in past routes won't be displayed at the moment. They are ended routes and we do not need to list them.
-        removed-in-past (sort-by (juxt :route-long-name :route-short-name) (filterv #(and (= :removed (:change-type %)) (nil? (:change-date %))) changes))
+        ;removed-in-past (sort-by (juxt :route-long-name :route-short-name) (filterv #(and (= :removed (:change-type %)) (nil? (:change-date %))) changes))
         no-changes (sort-by (juxt :route-long-name :route-short-name) (filterv #(= :no-change (:change-type %)) changes))
         only-changes (filterv :change-date changes)
         sorted-changes (sort-by (juxt :different-week-date :route-long-name :route-short-name) only-changes)


### PR DESCRIPTION
# Changed
* services: remove unused changed-routes-to-service-by-date sql
* views: transit-visualization fix route-change checkbox disabling
* services: transit-visualization fix for route-changes and keyword type, not-changes routes were not shown
* util: file for clojure-language related functions with remove-coll-key-ns