### PR TITLE
164007053 Configured max length of data-content search input box suggestions so…

### DIFF
--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -382,10 +382,11 @@
           :auto-select?       true
           :open-on-focus?     true
           ;; Translate visible suggestion text, but keep the value intact.
-          :suggestions        (mapv (fn [val]
-                                      {:text  (tr [:enums ::t-service/interface-data-content val])
-                                       :value val})
-                                    t-service/interface-data-contents)
+          :suggestions        (sort-by :text (mapv (fn [val]
+                                                     {:text  (tr [:enums ::t-service/interface-data-content val])
+                                                      :value val})
+                                                   t-service/interface-data-contents))
+          :max-results (count t-service/interface-data-contents)
           :suggestions-config {:text :text :value :value}
           :is-empty?          validation/empty-enum-dropdown?})]
       filters]]))

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -160,7 +160,7 @@
                        :max-results (count t-service/interface-data-contents)
                        :write (fn [data vals]
                                 (assoc-in data [::t-service/data-content]
-                                          ;; Values loose their keyword status inside the component, so we'll make
+                                          ;; Values lose their keyword status inside the component, so we'll make
                                           ;; sure that they will be keywords in the state.
                                           (mapv (comp keyword :value) vals)))
                        :read #(as-> % data


### PR DESCRIPTION
# Changed
Transport service catalog : the dropdown in Interface Content input now shows all of the options instead of first 10