### PR TITLE
Fixed IE link not working.

### DIFF
--- a/ote/src/cljs/ote/ui/common.cljs
+++ b/ote/src/cljs/ote/ui/common.cljs
@@ -15,7 +15,8 @@
             [goog.crypt.Md5]
             [goog.crypt]
 
-            [ote.util.text :as text]))
+            [ote.util.text :as text]
+            [ote.app.routes :as routes]))
 
 (def mobile?
   (let [ua (str/lower-case js/window.navigator.userAgent)]
@@ -278,6 +279,22 @@
                                          :padding-right "5px"
                                          :color style-base/link-color}]
                 label]])
+
+;; This is implemented because IE craps itself sometimes with the linkify
+(defn back-link-with-event [e! site-keyword label]
+  [:a (merge
+        {:href "#/transit-changes"}
+        {:on-click #(do
+                      (.preventDefault %)
+                      (e! (routes/navigate! site-keyword)))}
+        (stylefy/use-style (merge {:color colors/primary
+                                   :text-decoration "none"
+                                   ::stylefy/mode {:hover {:text-decoration "underline"}}})))
+   [:span [icons/arrow-back {:position "relative"
+                             :top "6px"
+                             :padding-right "5px"
+                             :color style-base/link-color}]
+    label]])
 
 (defn loading-spinner []
   [:div.loading [:img {:src "/base/images/loading-spinner.gif"}]])

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -859,7 +859,7 @@
      [:div.transit-visualization
 
       [page/page-controls
-       [common/back-link "#/transit-changes" "Takaisin markkinaehtoisen liikenteen muutokset -näkymään"]
+       [common/back-link-with-event e! :transit-changes "Takaisin markkinaehtoisen liikenteen muutokset -näkymään"] ; this is done with click event because IE11 doesn't launch popstate event
        "Reittiliikenteen tunnistetut muutokset"
        [:div
         [:h2 (:transport-service-name service-info) " (" (:transport-operator-name service-info) ")"]


### PR DESCRIPTION
Made this to work with event instead of normal link, because IE doesn't properly launch popstate event for some reason.
   
# Fixed
* IE11 fix for back to transit-changes page.
