### PR TITLE
163902792 transit visualization simplify route filtering checkbox logic

### DIFF
--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -487,6 +487,8 @@
   ;; Disabling of UI components must happen before table model change because otherwise table rendering
   ;; delays those as well.
   (.setTimeout js/window #(e! (->ToggleShowNoChangeRoutesDelayed)) 0)
-  (-> app
-      (update :show-no-change-routes-checkbox? not)
-      (assoc :route-changes-loading? true)))
+  (cond-> app
+      true (update :show-no-change-routes-checkbox? not)
+      ;; :route-changes-loading? set only when table model changes, otherwise there's no :component-did-mount event to clear the flag
+      (not= (:gtfs/route-changes (:changes-no-change app))
+            (:gtfs/route-changes (:changes-filtered app))) (assoc :route-changes-loading? true)))

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -97,7 +97,7 @@
 
 (defn- init-view-state [app]
   (let [init-tv (fn [transit-visualization]
-                  (-> (or transit-visualization {})
+                  (-> transit-visualization
                       (assoc :all-route-changes-checkbox nil)
                       (assoc :all-route-changes-display? nil)
                       (dissoc :changes-route-filtered)

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -846,7 +846,7 @@
 
 (defn transit-visualization [e! {:keys [hash->color date->hash service-info changes-route-no-change changes-route-filtered selected-route compare open-sections route-hash-id-type show-no-change-routes? show-no-change-routes-checkbox?]
                                  :as transit-visualization}]
-  (let [routes (if show-no-change-routes?
+  (let [routes (if show-no-change-routes? ;; NOTICE! If you change route-changes data resolution logic check also :route-changes-loading? toggling logic ToggleShowNoChangeRoutes
                  changes-route-no-change
                  changes-route-filtered)
         route-name (if (service-is-using-headsign route-hash-id-type)
@@ -880,7 +880,7 @@
            ;; Different value key for checkbox allows triggering checkbox disabling logic first and table changes only after that.
            show-no-change-routes-checkbox?]]]
 
-        [route-changes e! routes changes-route-no-change selected-route route-hash-id-type]]]
+        [route-changes e! routes changes-route-no-change selected-route route-hash-id-type]]] ;; NOTICE! If you change route-changes data resolution logic check also :route-changes-loading? toggling logic ToggleShowNoChangeRoutes
 
       (when selected-route
         [:div.transit-visualization-route.container


### PR DESCRIPTION
# Changed
*  controller: transit-visualization simplify route filtering checkbox logic
Also some refactoring of state initialization

Now state toggling does not monitor `componentDidMount` event and is more simple - but also chckbox toggling on UI does not always give instant feedback to user & don't get disabled if there's a long rendering delay.