### PR TITLE
figwheel-logfile to tmp

### DIFF
--- a/ote/project.clj
+++ b/ote/project.clj
@@ -161,4 +161,5 @@
                  :host "localhost"}
   :main ote.main
   :figwheel {:server-ip "localhost"
-             :nrepl-host "localhost"})
+             :nrepl-host "localhost"
+             :server-logfile "/tmp/logs/figwheel-logfile.log"})


### PR DESCRIPTION
# Changed
* figwheel-logfile to tmp
Prerviously .log file was created under source code folder, which is
unnecessary.
  