### PR TITLE
164134455 fixed stop fuzzy location problem in transit visualization page.

### DIFF
--- a/database/src/main/resources/db/migration/V1_137__fuzzy_location_to_gtfs_stoptime_display.sql
+++ b/database/src/main/resources/db/migration/V1_137__fuzzy_location_to_gtfs_stoptime_display.sql
@@ -1,0 +1,9 @@
+-- fuzzy-location were not added when new packages were added. So we fix it with this update
+UPDATE "gtfs-stop"
+   SET "stop-fuzzy-lat" = round("stop-lat", 3), "stop-fuzzy-lon" = round("stop-lon", 3)
+ WHERE "gtfs-stop"."stop-fuzzy-lat" IS NULL;
+
+-- Add stop-fuzzy-lat and stop-fuzzy-p-lon to gtfs_stoptime_display type to enable stop postition comparison
+ALTER TYPE gtfs_stoptime_display
+  ADD ATTRIBUTE "stop-fuzzy-lat" numeric,
+  ADD ATTRIBUTE "stop-fuzzy-lon" numeric;

--- a/ote/src/clj/ote/integration/import/gtfs.clj
+++ b/ote/src/clj/ote/integration/import/gtfs.clj
@@ -164,6 +164,10 @@
       ;; Handle stop times
       (import-stop-times db package-id stop-times-file)
 
+      ;; Calculate stop-fuzzy-lat and stop-fuzzy-lon
+      (log/info "Generating fuzzy location for stops in package " package-id)
+      (calculate-fuzzy-location-for-stops! db {:package-id package-id})
+
       ;; Handle detection-routes
       ;; Calculate route-hash-id for the service using previous 100 packages
       (detection/calculate-route-hash-id-for-service db service-id 100 (detection/db-route-detection-type db service-id))

--- a/ote/src/clj/ote/integration/import/stop_times.sql
+++ b/ote/src/clj/ote/integration/import/stop_times.sql
@@ -10,3 +10,9 @@ UPDATE "gtfs-trip"
    SET trips[:index]."stop-times" = :stop-times::"gtfs-stop-time-info"[]
  WHERE "gtfs-trip".id = :trip-row-id
    AND "package-id" = :package-id;
+
+-- name: calculate-fuzzy-location-for-stops!
+UPDATE "gtfs-stop"
+   SET "stop-fuzzy-lat" = round("stop-lat", 3), "stop-fuzzy-lon" = round("stop-lon", 3)
+ WHERE "gtfs-stop"."package-id" = :package-id
+   AND "gtfs-stop"."stop-fuzzy-lat" IS NULL;

--- a/ote/src/clj/ote/services/pre_notices/attachments.clj
+++ b/ote/src/clj/ote/services/pre_notices/attachments.clj
@@ -102,5 +102,5 @@
         (admin/require-admin-user "/transit-changes/upload-gtfs/:service-id/:date" (:user user))
         (do
           (transit-changes/upload-gtfs db (Long/parseLong service-id) date req)
-          (gtfs-tasks/detect-new-changes-task db (time/date-string->date-time date) true [service-id])
+          (gtfs-tasks/detect-new-changes-task db (time/date-string->date-time date) true [(Long/parseLong service-id)])
           (http/transit-response "OK")))))))

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -113,7 +113,7 @@ SELECT trip."package-id", (trip.trip)."trip-id", (trip.trip)."trip-headsign" as 
                      s."stop-name",
                      stoptime."arrival-time",
                      stoptime."departure-time",
-                     s."stop-lat", s."stop-lon")::gtfs_stoptime_display
+                     s."stop-lat", s."stop-lon",s."stop-fuzzy-lat", s."stop-fuzzy-lon")::gtfs_stoptime_display
                  ORDER BY stoptime."stop-sequence") AS "stoptimes"
  FROM gtfs_route_trips_for_date(gtfs_service_packages_for_date(:service-id::INTEGER,:date::date), :date::date) rt
  JOIN LATERAL unnest(rt.tripdata) trip ON TRUE


### PR DESCRIPTION
# Added
* GTFS import: Added fuzzy location calculation for stops when new gtfs is imported
* Update clause to update all null stop-fuzzy-lat and stop-fuzzy-lon values in db.

   
# Fixed
* Admin panel: when new gtfs package was imported and automatic detection started it failed because service-id was string and not integer.
* gtfs-stoptime-display composite type modified by adding fuzzy location for stops
   
# Changed
* Changed existing feature.
   
# Datamodel
* Change to DB migrations.
   
# Environment
* Changes to CI environment
* Builds now 200% faster with change X!
