### PR TITLE
Fix transport_service_search_result Just create isn't enough.

### DIFF
--- a/database/src/main/resources/db/migration/V1_138__fix_service_search_view.sql
+++ b/database/src/main/resources/db/migration/V1_138__fix_service_search_view.sql
@@ -1,5 +1,5 @@
 -- Create new with "associated-service-operators"
-CREATE VIEW transport_service_search_result AS
+CREATE OR REPLACE VIEW transport_service_search_result AS
 SELECT t.*, op.name as "operator-name", op."business-id" as "business-id",
        -- Changed Start
        COALESCE((SELECT sc."companies"


### PR DESCRIPTION
# Fixed
* Migration was missing `OR REPLACE`
Fixes problem introduced in https://github.com/finnishtransportagency/mmtis-national-access-point/pull/895
