### PR TITLE
163649701-skip-contract-traffic

### DIFF
--- a/database/src/main/resources/db/migration/V1_139__mark_interface_as_contract_traffic.sql
+++ b/database/src/main/resources/db/migration/V1_139__mark_interface_as_contract_traffic.sql
@@ -1,0 +1,5 @@
+-- Some of the transport services are contract services and some of them are commercial. Our transit change algorithm is not interested in
+-- contract traffic. So add column that stores information about that
+
+ALTER TABLE "transport-service"
+  ADD COLUMN "commercial-traffic?" boolean DEFAULT TRUE;


### PR DESCRIPTION
# Added
* Add new column to transport service table so we can mark which services are contract traffic so we can skip them from hash calculations and transit changes list