### PR TITLE
163934214 Clear selected route when opening transit visualization

### DIFF
--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -104,7 +104,8 @@
                       (dissoc :changes-route-no-change)
                       (assoc :service-changes-for-date-loading? true)
                       (assoc :all-route-changes-display? false)
-                      (assoc-in [:open-sections :gtfs-package-info] false)))]
+                      (assoc-in [:open-sections :gtfs-package-info] false)
+                      (dissoc :selected-route)))]
     (update app :transit-visualization init-tv)))
 
 (define-event RoutesForDatesResponse [routes dates]

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -95,19 +95,6 @@
                              sorted-changes)]
     all-sorted-changes))
 
-(defn- init-view-state [app]
-  (let [init-tv (fn [transit-visualization]
-                  (-> transit-visualization
-                      (assoc :all-route-changes-checkbox nil)
-                      (assoc :all-route-changes-display? nil)
-                      (dissoc :changes-route-filtered)
-                      (dissoc :changes-route-no-change)
-                      (assoc :service-changes-for-date-loading? true)
-                      (assoc :all-route-changes-display? false)
-                      (assoc-in [:open-sections :gtfs-package-info] false)
-                      (dissoc :selected-route)))]
-    (update app :transit-visualization init-tv)))
-
 (define-event RoutesForDatesResponse [routes dates]
   {:path [:transit-visualization :compare]}
   (if (= dates (select-keys app [:date1 :date2]))
@@ -187,6 +174,13 @@
                 :changes-route-filtered (sorted-route-changes false (future-changes detection-date (:route-changes response)))
                 :gtfs-package-info (:gtfs-package-info response)
                 :route-hash-id-type (:route-hash-id-type response)))
+
+(defn- init-view-state [app]
+  (let [initial-view-state {:all-route-changes-checkbox nil
+                            :all-route-changes-display? false
+                            :open-sections {:gtfs-package-info false}
+                            :service-changes-for-date-loading? true}]
+    (assoc app :transit-visualization initial-view-state)))
 
 (define-event InitTransitVisualization [service-id detection-date]
   {}


### PR DESCRIPTION

# Fixed
Previously:
1. given user had selected a service in "tunnistetut muutokset"
2. and selected a route
3. when user navigated back to "tunnistetut muutokset"
4. and selected another service
then the route selected in step 2 was still visible in transit visualization view

Now the selected route is cleared from app state when user navigates to transit visualization view.