### PR TITLE
1640467650: fix navigate back event runtime error from call to e!

### DIFF
--- a/ote/src/cljs/ote/ui/common.cljs
+++ b/ote/src/cljs/ote/ui/common.cljs
@@ -281,12 +281,12 @@
                 label]])
 
 ;; This is implemented because IE craps itself sometimes with the linkify
-(defn back-link-with-event [e! site-keyword label]
+(defn back-link-with-event [site-keyword label]
   [:a (merge
         {:href "#/transit-changes"}
         {:on-click #(do
                       (.preventDefault %)
-                      (e! (routes/navigate! site-keyword)))}
+                      (routes/navigate! site-keyword))}
         (stylefy/use-style (merge {:color colors/primary
                                    :text-decoration "none"
                                    ::stylefy/mode {:hover {:text-decoration "underline"}}})))

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -861,7 +861,7 @@
      [:div.transit-visualization
 
       [page/page-controls
-       [common/back-link-with-event e! :transit-changes "Takaisin markkinaehtoisen liikenteen muutokset -näkymään"] ; this is done with click event because IE11 doesn't launch popstate event
+       [common/back-link-with-event :transit-changes "Takaisin markkinaehtoisen liikenteen muutokset -näkymään"] ; this is done with click event because IE11 doesn't launch popstate event
        "Reittiliikenteen tunnistetut muutokset"
        [:div
         [:h2 (:transport-service-name service-info) " (" (:transport-operator-name service-info) ")"]


### PR DESCRIPTION
# Fixed
* fix navigate back event runtime error from call to e!
Workaround for IE backstepping doesn't need a call to e! which expects
an event. routes/navigate! call alone is enough.