### PR TITLE
Removed key-fn because stop names are not unique, so it can't be,

### DIFF
--- a/ote/config.edn
+++ b/ote/config.edn
@@ -8,7 +8,7 @@
  ;; :db {:url "jdbc:postgresql://localhost:5435/napote"
  ;;      :username "ote"
  ;;      :password #=(slurp "../../mydbpassword.txt")}
- 
+
  :http {:port 3000
         :ip "localhost"
         :max-body 33554432 ;; 32 megabytes

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -670,7 +670,7 @@
    "Pysäkkilistalla näytetään valitun vuoron pysäkkikohtaiset aikataulut."
    (let [second-stops-empty? (empty? (:stoptimes (second selected-trip-pair)))]
      [:div.trip-stop-sequence
-      [table/table {:name->label str :key-fn :gtfs/stop-name}
+      [table/table {:name->label str}
        [{:name "Pysäkki" :read :gtfs/stop-name :format (partial format-stop-name)}
         {:name "Lähtöaika" :read :gtfs/departure-time-date1 :format (partial format-stop-time (style/date1-highlight-style))}
         {:name "Lähtöaika" :read :gtfs/departure-time-date2 :format (partial format-stop-time (style/date2-highlight-style))}


### PR DESCRIPTION
key of the row

# Fixed
* Removed empty space from config.edn
* Removed key-fn for stoplist because the row data doesn't have a property that's unique enough to be key. stop-names are duplicated when circular route.