### PR TITLE
views,language: transport-operator heading to business name or -auxnames

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -659,7 +659,7 @@ You can also draw the operating area or point to the map with drawing tools. You
  {:address-postal "Postal address"
   :address-postal-street "Street address or P.O. Box"
   :business-id-and-aux-names "Company name and auxiliary names"
-  :business-name "Business name"
+  :business-or-aux-name "Business name or auxiliary name"
   :contact-details-plural "Contact information related to the Business ID"
   :contact-details "Contact details"
   :contact-details-other "Other contact details "

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -665,7 +665,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
  {:address-postal "Postiosoite"
   :address-postal-street "Katuosoite tai PL-osoite"
   :business-id-and-aux-names "Toiminimi ja aputoiminimet"
-  :business-name "Toiminimi"
+  :business-or-aux-name "Toiminimi tai aputoiminimi"
   :contact-details-plural "Toiminimiin liittyvät yhteystiedot"
   :contact-details "Yhteystiedot"
   :contact-details-other "Muut yhteystiedot"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -667,7 +667,7 @@
  {:address-postal "Postadress"
   :address-postal-street "Gatuadress eller postbox"
   :business-id-and-aux-names "Företagsnamn och parallellnamn"
-  :business-name "Företagsnamn"
+  :business-or-aux-name "Företagsnamn eller extra företagsnamn"
   :contact-details-plural "Kontaktuppgifter för företagsnamn"
   :contact-details-other "Andra kontaktuppgifter"
   :contact-details "Kontaktuppgifter"

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -172,7 +172,7 @@
       {:name :heading2
        :label (tr [:organization-page (if ytj-company-names-found?
                                         :business-id-and-aux-names
-                                        :business-name)])
+                                        :business-or-aux-name)])
        :type :text-label
        :h-style :h3
        :full-width? true}


### PR DESCRIPTION
# Changed
* transport-operator: When editing in "single operator mode", the name may be either primary
or auxiliary business name. The title should clarify this.