### PR TITLE
break-all to break-word because it looks better.

### DIFF
--- a/ote/src/cljs/ote/style/service_search.cljs
+++ b/ote/src/cljs/ote/style/service_search.cljs
@@ -70,7 +70,7 @@
                                                    :font-size "0.875rem"}
                                         :info-title {:flex 1
                                                      :color colors/gray800
-                                                     :word-break "break-all"}
+                                                     :word-break "break-word"}
                                         :info-content {:flex 2}
                                         :foot {:padding "0 1rem 1rem 1rem"
                                                ::stylefy/media {{:max-width (str width-md "px")}


### PR DESCRIPTION
# Fixed
* break word looks better than break-all

