### PR TITLE
164564026 transport operator public and authority contact fields for operator and pre-notice views and db

### DIFF
--- a/database/src/main/resources/db/migration/V1_141__transport_operator_email_and_phone_for_authorities.sql
+++ b/database/src/main/resources/db/migration/V1_141__transport_operator_email_and_phone_for_authorities.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "transport-operator"
+  ADD COLUMN "authority-phone" VARCHAR(16),
+  ADD COLUMN "authority-email" VARCHAR(200);

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -662,7 +662,9 @@ You can also draw the operating area or point to the map with drawing tools. You
   :business-or-aux-name "Business name or auxiliary name"
   :contact-details-plural "Contact information related to the Business ID"
   :contact-details "Contact details"
-  :contact-details-other "Other contact details "
+  ;:contact-details-other "Other contact details "
+  :contact-details-service-developers "Contact details for developers of services"
+  :contact-details-authorities "Contact details for authorities"
   :fetch-from-ytj "Fetch data from YTJ"
   :fetch-from-ytj-success "Details successfully fetched from the BIS register."
   :field-phone-mobile "Mobile phone"
@@ -688,6 +690,9 @@ You can also draw the operating area or point to the map with drawing tools. You
   :help-about-ytj-link "https://www.ytj.fi/en/index/whatisbis.html"
   :help-ytj-contact-change-link-desc "Change details of your business in the Business Information System (BIS)"
   :help-ytj-contact-change-link "https://www.ytj.fi/en/index/notifications/notificationsofchanges.html"
+  :help-contact-details "Please enter contact details, using which a developer of traffic services or other similar partner may contact your company or organization."
+  :help-contact-details-privacy "The details provided will be publicly available in NAP -transport catalogue. Please note this, if the contact details contain personal information."
+  :help-contact-details-auth (:md "Following contact details will be provided only for the use of authorities. **NOTE: Following details will not be published.**")
   :merge-operator-to-ytj "will be renamed as"
   }
 

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -662,7 +662,6 @@ You can also draw the operating area or point to the map with drawing tools. You
   :business-or-aux-name "Business name or auxiliary name"
   :contact-details-plural "Contact information related to the Business ID"
   :contact-details "Contact details"
-  ;:contact-details-other "Other contact details "
   :contact-details-service-developers "Contact details for developers of services"
   :contact-details-authorities "Contact details for authorities"
   :fetch-from-ytj "Fetch data from YTJ"

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -663,7 +663,6 @@ You can also draw the operating area or point to the map with drawing tools. You
   :business-or-aux-name "Business name or auxiliary name"
   :contact-details-plural "Contact information related to the Business ID"
   :contact-details "Contact details"
-  :contact-details-service-developers "Contact details for developers of services"
   :contact-details-authorities "Contact details for authorities"
   :fetch-from-ytj "Fetch data from YTJ"
   :fetch-from-ytj-success "Details successfully fetched from the BIS register."

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -16,7 +16,7 @@
   :ote.db.transport-operator/phone "Phone 1"
   :ote.db.transport-operator/gsm "Phone 2"
   :ote.db.transport-operator/email "Email address"
-  :ote.db.transport-operator/homepage "WWW-address"
+  :ote.db.transport-operator/homepage "Web page address"
   :ote.db.transport-operator/visiting-address "Postal address"
   :ote.db.transport-operator/billing-address "Billing address"
 
@@ -971,7 +971,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :data-not-found "Information is not found."
   :required-field "Required field"
   :required-field-missing "Mandatory data missing"
-  :required-one-of-many "Details for at least one of the fields must be set."
+  :required-one-of-many "Please fill at least one field."
   :invalid-business-id "The business ID has to be in the form of: 7 numbers, hyphen and a check number."
   :invalid-postal-code "Please, check the postalcode (5 numbers)"
   :invalid-file-type "Invalid file type"

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -658,6 +658,7 @@ You can also draw the operating area or point to the map with drawing tools. You
  :organization-page
  {:address-postal "Postal address"
   :address-postal-street "Street address or P.O. Box"
+  :basic-details "Basic details"
   :business-id-and-aux-names "Company name and auxiliary names"
   :business-or-aux-name "Business name or auxiliary name"
   :contact-details-plural "Contact information related to the Business ID"

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -972,6 +972,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :data-not-found "Information is not found."
   :required-field "Required field"
   :required-field-missing "Mandatory data missing"
+  :required-one-of-many "Details for at least one of the fields must be set."
   :invalid-business-id "The business ID has to be in the form of: 7 numbers, hyphen and a check number."
   :invalid-postal-code "Please, check the postalcode (5 numbers)"
   :invalid-file-type "Invalid file type"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -669,7 +669,6 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :business-or-aux-name "Toiminimi tai aputoiminimi"
   :contact-details-plural "Toiminimiin liittyvät yhteystiedot"
   :contact-details "Yhteystiedot"
-  :contact-details-service-developers "Yhteystiedot palveluiden kehittäjille"
   :contact-details-authorities "Yhteystiedot viranomaiselle"
   :fetch-from-ytj "Hae tiedot YTJ:stä"
   :fetch-from-ytj-success "Tiedot haettu onnistuneesti YTJ:stä."

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -17,7 +17,7 @@
   :ote.db.transport-operator/phone "Puhelinnumero 1"
   :ote.db.transport-operator/gsm "Puhelinnumero 2"
   :ote.db.transport-operator/email "Sähköpostiosoite"
-  :ote.db.transport-operator/homepage "WWW-osoite"
+  :ote.db.transport-operator/homepage "Verkkosivun osoite"
   :ote.db.transport-operator/visiting-address "Käyntiosoite"
   :ote.db.transport-operator/billing-address "Laskutusosoite"
 
@@ -58,7 +58,7 @@
    :ote.db.transport-service/contact-address "Osoitetiedot"
    :ote.db.transport-service/contact-phone "Puhelin"
    :ote.db.transport-service/contact-email "Sähköposti"
-   :ote.db.transport-service/homepage "Verkkosivujen osoite"
+   :ote.db.transport-service/homepage "Verkkosivun osoite"
 
    :ote.db.transport-service/operation-area "Toiminta-alue"
    :ote.db.transport-service/location "Sijainti"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -664,6 +664,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
  :organization-page
  {:address-postal "Postiosoite"
   :address-postal-street "Katuosoite tai PL-osoite"
+  :basic-details "Perustiedot"
   :business-id-and-aux-names "Toiminimi ja aputoiminimet"
   :business-or-aux-name "Toiminimi tai aputoiminimi"
   :contact-details-plural "Toiminimiin liittyvät yhteystiedot"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -982,6 +982,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :data-not-found "Tietoja ei löytynyt."
   :required-field "Tieto vaaditaan"
   :required-field-missing "Pakollisia tietoja syöttämättä"
+  :required-one-of-many "Yksi tiedoista vaaditaan."
   :invalid-business-id "Y-tunnuksen tulee olla muotoa: 7 numeroa, väliviiva ja tarkistusnumero."
   :invalid-postal-code "Tarkista postinumero (5 numeroa)"
   :invalid-file-type "Virheellinen tiedostotyyppi"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -668,7 +668,9 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :business-or-aux-name "Toiminimi tai aputoiminimi"
   :contact-details-plural "Toiminimiin liittyvät yhteystiedot"
   :contact-details "Yhteystiedot"
-  :contact-details-other "Muut yhteystiedot"
+  ;:contact-details-other "Muut yhteystiedot"
+  :contact-details-service-developers "Yhteystiedot palveluiden kehittäjille"
+  :contact-details-authorities "Yhteystiedot viranomaiselle"
   :fetch-from-ytj "Hae tiedot YTJ:stä"
   :fetch-from-ytj-success "Tiedot haettu onnistuneesti YTJ:stä."
   :field-phone-mobile "Matkapuhelin"
@@ -694,6 +696,9 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :help-about-ytj-link "https://www.ytj.fi/index/tietoapalvelusta.html"
   :help-ytj-contact-change-link-desc "Tietojen muutosilmoitus Yritys- ja yhteisötietojärjestelmässä (YTJ)"
   :help-ytj-contact-change-link "https://www.ytj.fi/index/ilmoittaminen/muutosilmoitus.html"
+  :help-contact-details "Ilmoita yhteystiedot, joilla liikennepalveluiden kehittäjä tai muu kumppani saa yritykseesi tai organisaatioosi yhteyttä."
+  :help-contact-details-privacy "Huomioithan, että ilmoittamasi yhteystiedot ovat NAP-liikkumispalvelukatalogista vapaasti kaikkien saatavilla. Tämä on hyvä tietää, mikäli ilmoittamasi yhteystiedot ovat myös henkilökohtaisia yhteystietoja."
+  :help-contact-details-auth (:md "Alla olevat tiedot ovat viranomaiskäyttöön. **HUOM: tietoja ei julkaista.**")
   :merge-operator-to-ytj "korvataan nimellä"
   }
 

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -668,7 +668,6 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :business-or-aux-name "Toiminimi tai aputoiminimi"
   :contact-details-plural "Toiminimiin liittyvät yhteystiedot"
   :contact-details "Yhteystiedot"
-  ;:contact-details-other "Muut yhteystiedot"
   :contact-details-service-developers "Yhteystiedot palveluiden kehittäjille"
   :contact-details-authorities "Yhteystiedot viranomaiselle"
   :fetch-from-ytj "Hae tiedot YTJ:stä"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -17,7 +17,7 @@
   :ote.db.transport-operator/phone "Telefon 1"
   :ote.db.transport-operator/gsm "Telefon 2"
   :ote.db.transport-operator/email "E-post"
-  :ote.db.transport-operator/homepage "WWW-adress"
+  :ote.db.transport-operator/homepage "Webadress"
   :ote.db.transport-operator/visiting-address "Besöksadress"
   :ote.db.transport-operator/billing-address "Faktureringsadress"
 
@@ -975,7 +975,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :data-not-found "Inga uppgifter hittades."
   :required-field "Obligatorisk uppgift"
   :required-field-missing "Obligatorisk uppgift"
-  :required-one-of-many "Yksi tiedoista vaaditaan."
+  :required-one-of-many "Fyll minst ett fält."
   :invalid-business-id "FO-nummer måste vara i form av: 7 siffror, bindestreck och ett kontrollnummer." ;; Google translated
   :invalid-postal-code "Kolla postnumret (5 siffror)"
   :invalid-file-type "Ogiltig filtyp"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -669,7 +669,9 @@
   :business-id-and-aux-names "Företagsnamn och parallellnamn"
   :business-or-aux-name "Företagsnamn eller extra företagsnamn"
   :contact-details-plural "Kontaktuppgifter för företagsnamn"
-  :contact-details-other "Andra kontaktuppgifter"
+  ;:contact-details-other "Andra kontaktuppgifter"
+  :contact-details-service-developers "Yhteystiedot palveluiden kehittäjille"
+  :contact-details-authorities "Yhteystiedot viranomaiselle"
   :contact-details "Kontaktuppgifter"
   :fetch-from-ytj "Hämta data från YTJ"
   :fetch-from-ytj-success "Uppgifterna har hämtats från YTJ."
@@ -696,6 +698,9 @@
   :help-about-ytj-link "https://www.ytj.fi/sv/index/mikaonytj.html"
   :help-ytj-contact-change-link-desc "Anmäl ändringar på nätet"
   :help-ytj-contact-change-link "https://www.ytj.fi/sv/index/ilmoittaminen/muutosilmoitus.html"
+  :help-contact-details "Ilmoita yhteystiedot, joilla liikennepalveluiden kehittäjä tai muu kumppani saa yritykseesi tai organisaatioosi yhteyttä."
+  :help-contact-details-privacy "Huomioithan, että ilmoittamasi yhteystiedot ovat NAP-liikkumispalvelukatalogista vapaasti kaikkien saatavilla. Tämä on hyvä tietää, mikäli ilmoittamasi yhteystiedot ovat myös henkilökohtaisia yhteystietoja."
+  :help-contact-details-auth (:md "Alla olevat tiedot ovat viranomaiskäyttöön. **HUOM: tietoja ei julkaista.**")
   :merge-operator-to-ytj "ersätts med namnet"
   }
 

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -669,7 +669,6 @@
   :business-id-and-aux-names "Företagsnamn och parallellnamn"
   :business-or-aux-name "Företagsnamn eller extra företagsnamn"
   :contact-details-plural "Kontaktuppgifter för företagsnamn"
-  ;:contact-details-other "Andra kontaktuppgifter"
   :contact-details-service-developers "Yhteystiedot palveluiden kehittäjille"
   :contact-details-authorities "Yhteystiedot viranomaiselle"
   :contact-details "Kontaktuppgifter"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -976,6 +976,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :data-not-found "Inga uppgifter hittades."
   :required-field "Obligatorisk uppgift"
   :required-field-missing "Obligatorisk uppgift"
+  :required-one-of-many "Yksi tiedoista vaaditaan."
   :invalid-business-id "FO-nummer måste vara i form av: 7 siffror, bindestreck och ett kontrollnummer." ;; Google translated
   :invalid-postal-code "Kolla postnumret (5 siffror)"
   :invalid-file-type "Ogiltig filtyp"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -670,7 +670,6 @@
   :business-id-and-aux-names "Företagsnamn och parallellnamn"
   :business-or-aux-name "Företagsnamn eller extra företagsnamn"
   :contact-details-plural "Kontaktuppgifter för företagsnamn"
-  :contact-details-service-developers "Yhteystiedot palveluiden kehittäjille"
   :contact-details-authorities "Yhteystiedot viranomaiselle"
   :contact-details "Kontaktuppgifter"
   :fetch-from-ytj "Hämta data från YTJ"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -666,6 +666,7 @@
  :organization-page
  {:address-postal "Postadress"
   :address-postal-street "Gatuadress eller postbox"
+  :basic-details "Perustiedot"
   :business-id-and-aux-names "Företagsnamn och parallellnamn"
   :business-or-aux-name "Företagsnamn eller extra företagsnamn"
   :contact-details-plural "Kontaktuppgifter för företagsnamn"

--- a/ote/src/clj/ote/integration/export/geojson.clj
+++ b/ote/src/clj/ote/integration/export/geojson.clj
@@ -37,7 +37,8 @@
 
 (def ^{:doc "Transport operator columns to set as properties in GeoJSON export"}
   transport-operator-properties-columns
-  #{::t-operator/name ::t-operator/business-id ::t-operator/homepage ::t-operator/visiting-address
+  #{::t-operator/name ::t-operator/business-id ::t-operator/homepage
+    ;::t-operator/visiting-address Commented out because addresses are not currently in use
     ::t-operator/phone ::t-operator/gsm ::t-operator/email})
 
 (def ^{:doc "Transport service columns to set as properties in GeoJSON export"}

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -220,8 +220,8 @@
 (defn- select-op-keys-to-update [op]
   (select-keys op
                [::t-operator/name
-                ::t-operator/billing-address
-                ::t-operator/visiting-address
+                ;::t-operator/billing-address  Commented out because addresses are not currently in use
+                ;::t-operator/visiting-address Commented out because addresses are not currently in use
                 ::t-operator/phone
                 ::t-operator/gsm
                 ::t-operator/email

--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -182,9 +182,9 @@
   (let [t-op (:transport-operator app)
         ytj-business-id-hit? (= 200 (:status response))
         ytj-address-billing (address-of-type 1 (:addresses response))
-        use-ytj-addr-billing? ytj-business-id-hit?
+        use-ytj-addr-billing? false ;;ytj-business-id-hit? Commented out because addresses are not currently in use
         ytj-address-visiting (address-of-type 2 (:addresses response))
-        use-ytj-addr-visiting? ytj-business-id-hit?
+        use-ytj-addr-visiting? false ;;ytj-business-id-hit? Commented out because addresses are not currently in use
         ytj-contact-phone (preferred-ytj-field ["Puhelin" "Telefon" "Telephone"] (:contactDetails response))
         use-ytj-phone? (seq ytj-contact-phone)
         ytj-contact-gsm (preferred-ytj-field ["Matkapuhelin" "Mobiltelefon" "Mobile phone"] (:contactDetails response))

--- a/ote/src/cljs/ote/app/controller/transport_operator.cljs
+++ b/ote/src/cljs/ote/app/controller/transport_operator.cljs
@@ -56,9 +56,9 @@
       (first result))))                                     ;; Return first because expected value is string not vector
 
 ;; Keys for saving fields common with all companies sharing the same Y-tunnus/business-id
-(defn- take-common-op-keys [coll] (select-keys coll [::t-operator/business-id
-                                                     ::t-operator/billing-address
-                                                     ::t-operator/visiting-address
+(defn- take-common-op-keys [coll] (select-keys coll [::t-operator/authority-email
+                                                     ::t-operator/authority-phone
+                                                     ::t-operator/business-id
                                                      ::t-operator/phone
                                                      ::t-operator/gsm
                                                      ::t-operator/email
@@ -68,7 +68,9 @@
 (defn- take-new-op-keys [coll] (select-keys coll [::t-operator/name]))
 
 ; Keys unique to an operator when editing existing company. Extra to `take-common-op-keys`
-(defn- take-update-op-keys [coll] (select-keys coll [::t-operator/id ::t-operator/ckan-description ::t-operator/ckan-group-id]))
+(defn- take-update-op-keys [coll] (select-keys coll [::t-operator/id
+                                                     ::t-operator/ckan-description
+                                                     ::t-operator/ckan-group-id]))
 
 ;; Take keys supported by backend transport-operator API
 (defn take-operator-api-keys [op] (merge (take-new-op-keys op) (take-update-op-keys op) (take-common-op-keys op)))

--- a/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
@@ -74,61 +74,37 @@
 
    [:div (stylefy/use-style (sbase/flex-container "column"))
     [form-fields/field
-     {:label (tr [:field-labels :select-transport-operator])
+     {:type :selection
+      :label (tr [:field-labels :select-transport-operator])
       :name :select-transport-operator
-      :type :selection
       :show-option ::t-operator/name
       :update! #(e! (pre-notice/->SelectOperatorForNotice %))
       :options operators
       :auto-width? true}
      operator]
     [form-fields/field
-     {:label (tr [:field-labels ::t-operator/business-id])
+     {:type :string
+      :label (tr [:field-labels ::t-operator/business-id])
       :name ::t-operator/business-id
-      :type :string
       :update! nil
       :disabled? true}
      (::t-operator/business-id operator)]]
 
    [:div (stylefy/use-style (sbase/flex-container "column"))
     [:div (stylefy/use-style sbase/item-list-container)
-     ;[form-fields/field
-     ; {:label     (tr [:field-labels ::db-common/street])
-     ;  :name      ::db-common/street
-     ;  :type      :string
-     ;  :update!   nil
-     ;  :disabled? true}
-     ; (::db-common/street (::t-operator/visiting-address operator))] ;Commented out because addresses are not currently in use
-
-     ;[form-fields/field
-     ; {:label     (tr [:field-labels ::db-common/postal_code])
-     ;  :name      ::db-common/postal_code
-     ;  :type      :string
-     ;  :update!   nil
-     ;  :disabled? true}
-     ; (::db-common/postal_code (::t-operator/visiting-address operator))] ;Commented out because addresses are not currently in use
-
-     ;[form-fields/field
-     ; {:label     (tr [:field-labels ::db-common/post_office])
-     ;  :name      ::db-common/post_office
-     ;  :type      :string
-     ;  :update!   nil
-     ;  :disabled? true}
-     ; (::db-common/post_office (::t-operator/visiting-address operator))] ;Commented out because addresses are not currently in use
-
      [:div (stylefy/use-style sbase/item-list-row-margin)
       [form-fields/field
-       {:label (tr [:field-labels ::t-operator/phone])
+       {:type :string
+        :label (tr [:field-labels ::t-operator/phone])
         :name ::t-operator/phone
-        :type :string
         :update! nil
         :disabled? true}
        (::t-operator/phone operator)]]
 
      [form-fields/field
-      {:label (tr [:field-labels ::t-operator/gsm])
+      {:type :string
+       :label (tr [:field-labels ::t-operator/gsm])
        :name ::t-operator/gsm
-       :type :string
        :update! nil
        :disabled? true}
       (::t-operator/gsm operator)]]
@@ -136,17 +112,17 @@
     [:div (stylefy/use-style sbase/item-list-container)
      [:div (stylefy/use-style sbase/item-list-row-margin)
       [form-fields/field
-       {:label (tr [:field-labels ::t-operator/homepage])
+       {:type :string
+        :label (tr [:field-labels ::t-operator/homepage])
         :name ::t-operator/business-id
-        :type :string
         :update! nil
         :disabled? true}
        (::t-operator/homepage operator)]]
 
      [form-fields/field
-      {:label (tr [:field-labels ::t-operator/email])
+      {:type :string
+       :label (tr [:field-labels ::t-operator/email])
        :name ::t-operator/email
-       :type :string
        :update! nil
        :disabled? true}
       (::t-operator/email operator)]]]])

--- a/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
@@ -6,7 +6,7 @@
             [ote.app.controller.pre-notices :as pre-notice]
             [ote.ui.buttons :as buttons]
             [ote.ui.form-fields :as form-fields]
-    ;; db
+
             [ote.db.transport-operator :as t-operator]
             [ote.db.common :as db-common]
             [ote.db.transit :as transit]
@@ -18,7 +18,8 @@
             [ote.ui.leaflet :as leaflet]
             [ote.ui.mui-chip-input :as chip-input]
             [clojure.string :as str]
-            [ote.style.dialog :as style-dialog]))
+            [ote.style.dialog :as style-dialog]
+            [ote.style.base :as sbase]))
 
 (def notice-types [:termination :new :schedule-change :route-change :other])
 (def effective-date-descriptions [:year-start :school-start :school-end :season-schedule-change])
@@ -69,79 +70,86 @@
      (tr [:dialog :send-pre-notice :confirm])]))
 
 (defn select-operator [e! operator operators]
-  [:div {:style {:margin-bottom "20px"}}
-   [:div.row
+  [:div  {:style {:margin-bottom "20px"}}
+
+   [:div (stylefy/use-style (sbase/flex-container "column"))
     [form-fields/field
-     {:label       (tr [:field-labels :select-transport-operator])
-      :name        :select-transport-operator
-      :type        :selection
+     {:label (tr [:field-labels :select-transport-operator])
+      :name :select-transport-operator
+      :type :selection
       :show-option ::t-operator/name
-      :update!     #(e! (pre-notice/->SelectOperatorForNotice %))
-      :options     operators
+      :update! #(e! (pre-notice/->SelectOperatorForNotice %))
+      :options operators
       :auto-width? true}
-     operator]]
-   [:div.row
-    [:div.col-xs-12.col-sm-12.col-md-8
-     [:div.col-xs-8.col-sm-6.col-md-6
-      [form-fields/field
-       {:label     (tr [:field-labels ::t-operator/business-id])
-        :name      ::t-operator/business-id
-        :type      :string
-        :update!   nil
-        :disabled? true}
-       (::t-operator/business-id operator)]
+     operator]
+    [form-fields/field
+     {:label (tr [:field-labels ::t-operator/business-id])
+      :name ::t-operator/business-id
+      :type :string
+      :update! nil
+      :disabled? true}
+     (::t-operator/business-id operator)]]
 
-      [form-fields/field
-       {:label     (tr [:field-labels ::db-common/street])
-        :name      ::db-common/street
-        :type      :string
-        :update!   nil
-        :disabled? true}
-       (::db-common/street (::t-operator/visiting-address operator))]
+   [:div (stylefy/use-style (sbase/flex-container "column"))
+    [:div (stylefy/use-style sbase/item-list-container)
+     ;[form-fields/field
+     ; {:label     (tr [:field-labels ::db-common/street])
+     ;  :name      ::db-common/street
+     ;  :type      :string
+     ;  :update!   nil
+     ;  :disabled? true}
+     ; (::db-common/street (::t-operator/visiting-address operator))] ;Commented out because addresses are not currently in use
 
+     ;[form-fields/field
+     ; {:label     (tr [:field-labels ::db-common/postal_code])
+     ;  :name      ::db-common/postal_code
+     ;  :type      :string
+     ;  :update!   nil
+     ;  :disabled? true}
+     ; (::db-common/postal_code (::t-operator/visiting-address operator))] ;Commented out because addresses are not currently in use
+
+     ;[form-fields/field
+     ; {:label     (tr [:field-labels ::db-common/post_office])
+     ;  :name      ::db-common/post_office
+     ;  :type      :string
+     ;  :update!   nil
+     ;  :disabled? true}
+     ; (::db-common/post_office (::t-operator/visiting-address operator))] ;Commented out because addresses are not currently in use
+
+     [:div (stylefy/use-style sbase/item-list-row-margin)
       [form-fields/field
-       {:label     (tr [:field-labels ::db-common/postal_code])
-        :name      ::db-common/postal_code
-        :type      :string
-        :update!   nil
+       {:label (tr [:field-labels ::t-operator/phone])
+        :name ::t-operator/phone
+        :type :string
+        :update! nil
         :disabled? true}
-       (::db-common/postal_code (::t-operator/visiting-address operator))]
+       (::t-operator/phone operator)]]
+
+     [form-fields/field
+      {:label (tr [:field-labels ::t-operator/gsm])
+       :name ::t-operator/gsm
+       :type :string
+       :update! nil
+       :disabled? true}
+      (::t-operator/gsm operator)]]
+
+    [:div (stylefy/use-style sbase/item-list-container)
+     [:div (stylefy/use-style sbase/item-list-row-margin)
       [form-fields/field
-       {:label     (tr [:field-labels ::db-common/post_office])
-        :name      ::db-common/post_office
-        :type      :string
-        :update!   nil
+       {:label (tr [:field-labels ::t-operator/homepage])
+        :name ::t-operator/business-id
+        :type :string
+        :update! nil
         :disabled? true}
-       (::db-common/post_office (::t-operator/visiting-address operator))]]
-     [:div.col-xs-8.col-sm-6.col-md-6
-      [form-fields/field
-       {:label     (tr [:field-labels ::t-operator/homepage])
-        :name      ::t-operator/business-id
-        :type      :string
-        :update!   nil
-        :disabled? true}
-       (::t-operator/homepage operator)]
-      [form-fields/field
-       {:label     (tr [:field-labels ::t-operator/phone])
-        :name      ::t-operator/phone
-        :type      :string
-        :update!   nil
-        :disabled? true}
-       (::t-operator/phone operator)]
-      [form-fields/field
-       {:label     (tr [:field-labels ::t-operator/gsm])
-        :name      ::t-operator/gsm
-        :type      :string
-        :update!   nil
-        :disabled? true}
-       (::t-operator/gsm operator)]
-      [form-fields/field
-       {:label     (tr [:field-labels ::t-operator/email])
-        :name      ::t-operator/email
-        :type      :string
-        :update!   nil
-        :disabled? true}
-       (::t-operator/email operator)]]]]])
+       (::t-operator/homepage operator)]]
+
+     [form-fields/field
+      {:label (tr [:field-labels ::t-operator/email])
+       :name ::t-operator/email
+       :type :string
+       :update! nil
+       :disabled? true}
+      (::t-operator/email operator)]]]])
 
 (defn transport-type [e! {pre-notice :pre-notice :as app}]
   (let [addition [form-fields/field

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -2,10 +2,8 @@
   "Form to edit transport operator information."
   (:require [reagent.core :as r]
             [cljs-react-material-ui.reagent :as ui]
-            [cljs-react-material-ui.icons :as ic]
 
             [ote.ui.form :as form]
-            [ote.ui.form-groups :as form-groups]
             [ote.ui.buttons :as buttons]
             [ote.ui.validation :as ui-validation]
             [ote.ui.info :as info]
@@ -13,23 +11,17 @@
             [ote.ui.warning_msg :as msg-warn]
             [ote.ui.success_msg :as msg-succ]
             [ote.ui.circular_progress :as prog]
-            [stylefy.core :as stylefy]
             [ote.style.form :as style-form]
             [ote.style.form-fields :as style-fields]
-            [ote.ui.common :as ui-common]
-            [ote.ui.form-fields :as form-fields]
 
             [ote.app.controller.flags :as flags]
             [ote.app.controller.transport-operator :as to]
-            [ote.app.controller.front-page :as fp]
 
             [ote.db.transport-operator :as t-operator]
-            [ote.db.common :as common]
             [ote.localization :refer [tr tr-key]]
             [ote.style.base :as style-base]
             [ote.ui.common :as uicommon]
-            [ote.style.dialog :as style-dialog])
-  )
+            [ote.style.dialog :as style-dialog]))
 
 ;; Returns boolean about if there are any orphan nap operators which need renaming to ytj-company-names
 (defn- unmerged-ytj-nap-ops? [orphans]
@@ -267,7 +259,7 @@
       {:type :string
        :element-id "input-operator-telephone"
        :name ::t-operator/phone
-       :label (tr [:organization-page :field-phone-telephone] )
+       :label (tr [:organization-page :field-phone-telephone])
        :disabled? (get-in state [:ytj-flags :use-ytj-phone?] false)
        :required? (required-public-contact-missing? operator)
        :show-errors? false
@@ -399,7 +391,8 @@
         show-details? (or (not ytj-supported?)
                           (and (:transport-operator-loaded? state)
                                (some? (:ytj-response state))))
-        show-merge-companies? (and (pos-int? (count (get-in state [:transport-operator :ytj-orphan-nap-operators])))
+        show-merge-companies? (and ytj-supported?
+                                   (pos-int? (count (get-in state [:transport-operator :ytj-orphan-nap-operators])))
                                    (pos-int? (count (:ytj-company-names state))))
         form-groups (cond-> []
                             creating? (conj (business-id-selection e! state ytj-supported?))

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -141,7 +141,11 @@
         disable-ytj-address-billing? (= (get-in state [:ytj-flags :use-ytj-addr-billing?]) true)
         disable-ytj-address-visiting? (= (get-in state [:ytj-flags :use-ytj-addr-visiting?]) true)
         ytj-company-names (:ytj-company-names state)
-        ytj-company-names-found? (pos-int? (count ytj-company-names))]
+        ytj-company-names-found? (pos-int? (count ytj-company-names))
+        required-public-contact-missing? (fn [operator] (and (empty? (::t-operator/phone operator))
+                                                             (empty? (::t-operator/gsm operator))
+                                                             (empty? (::t-operator/email operator))
+                                                             (empty? (::t-operator/homepage operator))))]
     (form/group
       {:label (tr [:common-texts :title-operator-basic-details])
        :columns 1
@@ -226,6 +230,8 @@
                           (tr [:organization-page :help-ytj-contact-change-link-desc])]]
          :default-state true})
 
+      ;; Contact details for service developers
+
       {:type :text-label
        :name :heading-contact-details-other
        :label (tr [:organization-page :contact-details-service-developers])
@@ -240,11 +246,22 @@
               [:p (tr [:common-texts :nap-data-license]) "\"" (tr [:common-texts :nap-data-license-url-label]) "\"."]]
        :default-state true}
 
+      (if (required-public-contact-missing? operator)
+        {:type :result-msg-warning
+         :element-id "label-public-contact-missing"
+         :name :public-contact-missing
+         :content (tr [:common-texts :required-one-of-many])}
+        {:type :text-label
+         :name :warning-public-contact-missing-placeholder
+         :label ""
+         :h-style :h4})
+
       {:type :string
        :element-id "input-operator-telephone"
        :name ::t-operator/phone
        :label (tr [:organization-page :field-phone-telephone] )
        :disabled? (get-in state [:ytj-flags :use-ytj-phone?] false)
+       :required? (required-public-contact-missing? operator)
        :style style-fields/form-field
        :regex ui-validation/phone-number-regex}
 
@@ -253,6 +270,7 @@
        :name ::t-operator/gsm
        :label (tr [:organization-page :field-phone-mobile] )
        :disabled? (get-in state [:ytj-flags :use-ytj-gsm?] false)
+       :required? (required-public-contact-missing? operator)
        :style style-fields/form-field
        :regex ui-validation/phone-number-regex}
 
@@ -260,13 +278,17 @@
        :element-id "input-operator-email"
        :name ::t-operator/email
        :disabled? (get-in state [:ytj-flags :use-ytj-email?] false)
+       :required? (required-public-contact-missing? operator)
        :style style-fields/form-field}
 
       {:type :string
        :element-id "input-operator-web"
        :name ::t-operator/homepage
        :disabled? (get-in state [:ytj-flags :use-ytj-homepage?] false)
+       :required? (required-public-contact-missing? operator)
        :style style-fields/form-field}
+
+      ;; Contact details for authorities
 
       {:type :text-label
        :name :heading-contact-details-authorities

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -80,6 +80,14 @@
              (when ytj-supported?                           ;; Sets input and button on same row
                {:layout :row}))
 
+      (when-not ytj-supported?
+        {:type :string
+         :element-id "input-operator-name"
+         :name ::t-operator/name
+         :label (tr [:organization-page :business-or-aux-name])
+         :required? true
+         :style style-fields/form-field})
+
       {:type :string
        :name ::t-operator/business-id
        :label (tr [:organization-page :business-id-heading])
@@ -157,7 +165,7 @@
         {:type :divider
          :name :heading1-divider})
 
-      (when-not ytj-supported?
+      (when-not (or creating? ytj-supported?)
         {:type :string
          :element-id "input-operator-name"
          :name ::t-operator/name
@@ -211,14 +219,6 @@
 
          :max-length 128})
 
-      {:type       :text-label
-       :name       :msg-business-id-contact-details
-       :label      (if ytj-company-names-found?
-                     (tr [:organization-page :contact-details-plural])
-                     (tr [:organization-page :contact-details]))
-       :max-length 128
-       :h-style    :h3}
-
       (when ytj-response-ok?
         {:type          :info-toggle
          :name          :help-operator-contact-details
@@ -235,7 +235,7 @@
       {:type :text-label
        :name :heading-contact-details-other
        :label (tr [:organization-page :contact-details-service-developers])
-       :h-style :h3}
+       :h-style :h2}
 
       {:type :info-toggle
        :name :help-operator-contact-details-service-developers
@@ -293,7 +293,7 @@
       {:type :text-label
        :name :heading-contact-details-authorities
        :label (tr [:organization-page :contact-details-authorities])
-       :h-style :h3}
+       :h-style :h2}
 
       {:type :info-toggle
        :name :help-operator-contact-details-auth
@@ -379,7 +379,7 @@
                       [:br]
                       [ui/divider]
                       [:br]
-                      [:div [:h3 (tr [:dialog :delete-transport-operator :title-base-view])]]
+                      [:div [:h2 (tr [:dialog :delete-transport-operator :title-base-view])]]
                       [info/info-toggle (tr [:common-texts :instructions]) (tr [:organization-page :help-operator-how-delete]) true]
                       [buttons/save {:on-click #(e! (to/->ToggleSingleTransportOperatorDeleteDialog))
                                      :disabled (if (and
@@ -392,14 +392,13 @@
 (defn operator [e! {operator :transport-operator :as state}]
   (let [creating? (nil? (get-in state [:params :id]))
         ytj-supported? (flags/enabled? :open-ytj-integration)
-        show-ytj-id-entry? (empty? (get-in state [:params :id]))
         show-details? (or (not ytj-supported?)
                           (and (:transport-operator-loaded? state)
                                (some? (:ytj-response state))))
         show-merge-companies? (and (pos-int? (count (get-in state [:transport-operator :ytj-orphan-nap-operators])))
                                    (pos-int? (count (:ytj-company-names state))))
         form-groups (cond-> []
-                            show-ytj-id-entry? (conj (business-id-selection e! state ytj-supported?))
+                            creating? (conj (business-id-selection e! state ytj-supported?))
                             show-details? (conj (operator-form-groups e! state creating? ytj-supported?)))]
     [:div
      [:div
@@ -408,6 +407,7 @@
                  (if (:new? operator)
                    :organization-new-title
                    :organization-form-title)])]]]
+     [:h2 (tr [:organization-page :basic-details])]
      [:div
       [info/info-toggle (tr [:common-texts :instructions] true)
        (if ytj-supported?

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -281,7 +281,7 @@
 
       {:type :string
        :element-id "input-operator-telephone-auth"
-       :name ::t-operator/phone-auth
+       :name ::t-operator/authority-phone
        :required? true
        :label (tr [:organization-page :field-phone-telephone])
        :style style-fields/form-field
@@ -289,7 +289,7 @@
 
       {:type :string
        :element-id "input-operator-email-auth"
-       :name ::t-operator/email-auth
+       :name ::t-operator/authority-email
        :required? true
        :label ::t-operator/email
        :style style-fields/form-field

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -234,7 +234,7 @@
 
       {:type :text-label
        :name :heading-contact-details-other
-       :label (tr [:organization-page :contact-details-service-developers])
+       :label (tr [:organization-page :contact-details])
        :h-style :h2}
 
       {:type :info-toggle
@@ -242,7 +242,7 @@
        :label (tr [:common-texts :instructions])
        :body [:div
               [:p (tr [:organization-page :help-contact-details])]
-              [:p (tr [:organization-page :help-contact-details-privacy])]
+              [:p (tr [:organization-page :contact-details])]
               [:p (tr [:common-texts :nap-data-license]) "\"" (tr [:common-texts :nap-data-license-url-label]) "\"."]]
        :default-state true}
 
@@ -257,11 +257,20 @@
          :h-style :h4})
 
       {:type :string
+       :element-id "input-operator-web"
+       :name ::t-operator/homepage
+       :disabled? (get-in state [:ytj-flags :use-ytj-homepage?] false)
+       :required? (required-public-contact-missing? operator)
+       :show-errors? false
+       :style style-fields/form-field}
+
+      {:type :string
        :element-id "input-operator-telephone"
        :name ::t-operator/phone
        :label (tr [:organization-page :field-phone-telephone] )
        :disabled? (get-in state [:ytj-flags :use-ytj-phone?] false)
        :required? (required-public-contact-missing? operator)
+       :show-errors? false
        :style style-fields/form-field
        :regex ui-validation/phone-number-regex}
 
@@ -271,6 +280,7 @@
        :label (tr [:organization-page :field-phone-mobile] )
        :disabled? (get-in state [:ytj-flags :use-ytj-gsm?] false)
        :required? (required-public-contact-missing? operator)
+       :show-errors? false
        :style style-fields/form-field
        :regex ui-validation/phone-number-regex}
 
@@ -279,13 +289,7 @@
        :name ::t-operator/email
        :disabled? (get-in state [:ytj-flags :use-ytj-email?] false)
        :required? (required-public-contact-missing? operator)
-       :style style-fields/form-field}
-
-      {:type :string
-       :element-id "input-operator-web"
-       :name ::t-operator/homepage
-       :disabled? (get-in state [:ytj-flags :use-ytj-homepage?] false)
-       :required? (required-public-contact-missing? operator)
+       :show-errors? false
        :style style-fields/form-field}
 
       ;; Contact details for authorities
@@ -313,7 +317,7 @@
        :element-id "input-operator-email-auth"
        :name ::t-operator/authority-email
        :required? true
-       :label ::t-operator/email
+       :label (tr [:field-labels :ote.db.transport-operator/email])
        :style style-fields/form-field
        ;:validate [[:email]];;TODO implement email regex
        })))

--- a/ote/src/cljs/ote/views/transport_operator.cljs
+++ b/ote/src/cljs/ote/views/transport_operator.cljs
@@ -81,17 +81,17 @@
                {:layout :row}))
 
 
-      {:element-id "heading-business-id-title"
+      {:type :text-label
+       :element-id "heading-business-id-title"
        :name :heading-business-id-title
        :label (tr [:organization-page :business-id-heading])
-       :type :text-label
        :full-width? true
        :h-style :h3}
 
-      {:name ::t-operator/business-id
+      {:type :string
+       :name ::t-operator/business-id
        :label ""
        :element-id "input-business-id"
-       :type :string
        :validate [[:business-id]]
        :required? true
        :warning (tr [:common-texts :required-field])
@@ -104,9 +104,9 @@
 
       (when ytj-supported?
         ;; Disabled when business-id is taken or if business-id is not valid or if loading is ongoing
-        {:element-id "btn-submit-business-id"
+        {:type :external-button
+         :element-id "btn-submit-business-id"
          :name ::t-operator/btn-submit-business-id
-         :type :external-button
          :label (tr [:organization-page :fetch-from-ytj])
          :primary true
          :secondary true
@@ -118,17 +118,17 @@
                      (ytj-loading? state))})
 
       (when ytj-supported?
-        {:name :loading-spinner-ytj
-         :type :loading-spinner
+        {:type :loading-spinner
+         :name :loading-spinner-ytj
          :display? (ytj-loading? state)})
 
       (when (and ytj-supported? ytj-response?)
         (if ytj-success?
-          {:name :ytj-result-msg
-           :type :result-msg-success
+          {:type :result-msg-success
+           :name :ytj-result-msg
            :content (tr [:organization-page :fetch-from-ytj-success])}
-          {:name :ytj-result-msg
-           :type :result-msg-warning
+          {:type :result-msg-warning
+           :name :ytj-result-msg
            :content (if (= 404 status)
                       (str (tr [:common-texts :data-not-found])
                            " " (tr [:common-texts :optionally-fill-manually]))
@@ -138,9 +138,9 @@
 
       ; label composition for existing business-id
       (when (get-in state [:transport-operator :business-id-exists?])
-        {:element-id "label-business-id-is-not-unique"
+        {:type :result-msg-warning
+         :element-id "label-business-id-is-not-unique"
          :name :business-id-is-not-unique
-         :type :result-msg-warning
          :content (tr [:common-texts :business-id-is-not-unique])}))))
 
 (defn- operator-form-groups [e! {operator :transport-operator :as state} creating? ytj-supported?]
@@ -158,35 +158,35 @@
        :card? false}
 
       (when ytj-supported?
-        {:name :heading1-divider
-         :type :divider})
+        {:type :divider
+         :name :heading1-divider})
       ;; Because user not allowed to edit business id himself,
       ;; business-id field is input in business-id-selection when creating, a read-only label here when only modifying.
       (when-not creating?
-        {:element-id "heading-business-id"
+        {:type :text-label
+         :element-id "heading-business-id"
          :name :heading-business-id
          :label (str (tr [:organization-page :business-id-heading]) " " (::t-operator/business-id operator))
-         :type :text-label
          :h-style :h2})
 
-      {:name :heading2
+      {:type :text-label
+       :name :heading2
        :label (tr [:organization-page (if ytj-company-names-found?
                                         :business-id-and-aux-names
                                         :business-or-aux-name)])
-       :type :text-label
        :h-style :h3
        :full-width? true}
 
       (when ytj-response-ok?
-        {:name          :help-checkbox-group
-         :type          :info-toggle
+        {:type          :info-toggle
+         :name          :help-checkbox-group
          :label         (tr [:common-texts :instructions])
          :body          [:div (tr [:organization-page :help-operator-edit-selection])]
          :default-state true})
 
       (if ytj-response-ok?                                      ;; Input field if not YTJ results, checkbox-group otherwise
-        {:name                :transport-operators-to-save
-         :type                :checkbox-group-with-delete
+        {:type                :checkbox-group-with-delete
+         :name                :transport-operators-to-save
          :show-option         ::t-operator/name
          :option-enabled?     #(nil? (::t-operator/id %))
          :options             ytj-company-names
@@ -196,17 +196,19 @@
                       (do
                         (e! (to/->ToggleListTransportOperatorDeleteDialog data))
                         (delete-operator e! data (:transport-operators-with-services state))))}
-        {:element-id "input-operator-name"
+        {:type       :string
+         :element-id "input-operator-name"
          :name       ::t-operator/name
          :label      ""
-         :type       :string
+
          :required?  true
          :style      style-fields/form-field})
 
       (when (and ytj-response-ok? (not ytj-company-names-found?))
-        {:name :msg-no-aux-names-for-business-id
+        {:type :text-label
+         :name :msg-no-aux-names-for-business-id
          :label (tr [:organization-page :no-aux-names-for-business-id])
-         :type :text-label
+
          :max-length 128})
 
       {:name       :msg-business-id-contact-details
@@ -218,8 +220,8 @@
        :h-style    :h3}
 
       (when ytj-response-ok?
-        {:name          :help-operator-contact-details
-         :type          :info-toggle
+        {:type          :info-toggle
+         :name          :help-operator-contact-details
          :label         (tr [:common-texts :instructions])
          :body          [:div
                          (tr [:organization-page :help-operator-contact-entry])
@@ -228,23 +230,24 @@
                           (tr [:organization-page :help-ytj-contact-change-link-desc])]]
          :default-state true})
 
-      {:name ::ote.db.transport-operator/visiting-address
-       :type :text-label
+      {:type :text-label
+       :name ::ote.db.transport-operator/visiting-address
        :style style-fields/form-field
        :h-style :h4}
 
-      {:element-id "input-operator-addrVisitStreet"
+      {:type :string
+       :element-id "input-operator-addrVisitStreet"
        :name ::common/street
-       :type :string
+
        :disabled? disable-ytj-address-visiting?
        :style style-fields/form-field
        :read (comp ::common/street ::t-operator/visiting-address)
        :write (fn [data street]
                 (assoc-in data [::t-operator/visiting-address ::common/street] street))}
 
-      {:element-id "input-operator-addrVisitPostalCode"
+      {:type :string
+       :element-id "input-operator-addrVisitPostalCode"
        :name ::common/postal_code
-       :type :string
        :disabled? disable-ytj-address-visiting?
        :style style-fields/form-field
        :regex #"\d{0,5}"
@@ -252,34 +255,35 @@
        :write (fn [data postal-code]
                 (assoc-in data [::t-operator/visiting-address ::common/postal_code] postal-code))}
 
-      {:element-id "input-operator-addrVisitCity"
+      {:type :string
+       :element-id "input-operator-addrVisitCity"
        :name :ote.db.common/post_office
-       :type :string
        :disabled? disable-ytj-address-visiting?
        :style style-fields/form-field
        :read (comp :ote.db.common/post_office :ote.db.transport-operator/visiting-address)
        :write (fn [data post-office]
                 (assoc-in data [:ote.db.transport-operator/visiting-address :ote.db.common/post_office] post-office))}
 
-      {:name :heading-address-postal
+      {:type :text-label
+       :name :heading-address-postal
        :label (tr [:organization-page :address-postal])
-       :type :text-label
        :h-style :h4}
 
-      {:element-id "input-operator-addrBillingStreet"
+      {:type        :string
+       :element-id "input-operator-addrBillingStreet"
        :name        ::common/billing-street
        :label       (tr [:organization-page :address-postal-street])
-       :type        :string
+
        :disabled?   disable-ytj-address-billing?
        :style       style-fields/form-field
        :read        (comp ::common/street ::t-operator/billing-address)
        :write       (fn [data street]
                       (assoc-in data [::t-operator/billing-address ::common/street] street))}
 
-      {:element-id "input-operator-addrBillingPostalCode"
+      {:type :string
+       :element-id "input-operator-addrBillingPostalCode"
        :name ::common/billing-postal_code
        :label (tr [:field-labels :ote.db.common/postal_code])
-       :type :string
        :disabled? disable-ytj-address-billing?
        :style style-fields/form-field
        :regex #"\d{0,5}"
@@ -287,45 +291,46 @@
        :write (fn [data postal-code]
                 (assoc-in data [::t-operator/billing-address ::common/postal_code] postal-code))}
 
-      {:element-id "input-operator-addrBillingCity"
+      {:type :string
+       :element-id "input-operator-addrBillingCity"
        :name ::common/billing-post_office
        :label (tr [:field-labels :ote.db.common/post_office])
-       :type :string
        :disabled? disable-ytj-address-billing?
        :style style-fields/form-field
        :read (comp :ote.db.common/post_office :ote.db.transport-operator/billing-address)
        :write (fn [data post-office]
                 (assoc-in data [:ote.db.transport-operator/billing-address :ote.db.common/post_office] post-office))}
 
-      {:name :heading-contact-details-other
+      {:type :text-label
+       :name :heading-contact-details-other
        :label (tr [:organization-page :contact-details-other])
-       :type :text-label
        :h-style :h4}
 
-      {:element-id "input-operator-telephone"
+      {:type :string
+       :element-id "input-operator-telephone"
        :name ::t-operator/phone
        :label (tr [:organization-page :field-phone-telephone] )
-       :type :string
        :disabled? (get-in state [:ytj-flags :use-ytj-phone?] false)
        :style style-fields/form-field
        :regex ui-validation/phone-number-regex}
 
-      {:element-id "input-operator-mobilePhone"
+      {:type :string
+       :element-id "input-operator-mobilePhone"
        :name ::t-operator/gsm
        :label (tr [:organization-page :field-phone-mobile] )
-       :type :string :disabled? (get-in state [:ytj-flags :use-ytj-gsm?] false)
+       :disabled? (get-in state [:ytj-flags :use-ytj-gsm?] false)
        :style style-fields/form-field
        :regex ui-validation/phone-number-regex}
 
-      {:element-id "input-operator-email"
+      {:type :string
+       :element-id "input-operator-email"
        :name ::t-operator/email
-       :type :string
        :disabled? (get-in state [:ytj-flags :use-ytj-email?] false)
        :style style-fields/form-field}
 
-      {:element-id "input-operator-web"
+      {:type :string
+       :element-id "input-operator-web"
        :name ::t-operator/homepage
-       :type :string
        :disabled? (get-in state [:ytj-flags :use-ytj-homepage?] false)
        :style style-fields/form-field})))
 


### PR DESCRIPTION
# Changed
* views: transport-operator one mandatory public contact field
* views,controller: transport-operator set which phone email keys to save
* services: transport save authority-phone and -email, filter allowed keys
* db: transport-operator added columns authority-phone and authority-email
* view,controller: transport-operator view update and hide address fields
* integration: disable geojson operator address export
* services: transport prevent updating operator address fields
* views: pre-notice remove operator address fields and update layout
* views: tranport-operator form field type attribute first in source code