### PR TITLE
164756947 route summary updates

### DIFF
--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -305,24 +305,20 @@
                             :trip-stop-time-changes-lower :trip-stop-time-changes-upper :change-type :added-trips})
 
 (defn- list-route-changes-with-same-route-hash-id [all-changes single-change]
-  ;; Filter nil values
-  (keep
-    (fn [c]
-      (let [x (select-keys c selected-change-keys)
-            x (if (= :removed (:change-type x))
-                ;; Remove trip and stop changes from route summary if route has change-type :removed
-                (dissoc x :trip-stop-sequence-changes-lower
-                        :trip-stop-time-changes-lower
-                        :trip-stop-sequence-changes-upper
-                        :trip-stop-time-changes-upper
-                        :removed-trips)
-                x)]
-        ;; Return nil because keep won't work with false values.
-        (if (= (:route-hash-id x) (:route-hash-id single-change))
-          x
-          nil)
-        ))
-    all-changes))
+	;; Filter nil values
+	(keep
+		(fn [c]
+			;; Return nil if route-hash-id doesn't match because keep won't work with false values.
+			(when (= (:route-hash-id c) (:route-hash-id single-change))
+				(if (= :removed (:change-type c))
+					;; Remove trip and stop changes from route summary if route has change-type :removed
+					(dissoc c :trip-stop-sequence-changes-lower
+									:trip-stop-time-changes-lower
+									:trip-stop-sequence-changes-upper
+									:trip-stop-time-changes-upper
+									:removed-trips)
+					c)))
+		all-changes))
 
 (defn- route-change-summary
   "Route list has first change row of that route change. To be able to show summary of changes in all route rows we

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -332,7 +332,6 @@
         single-change (select-keys single-change selected-change-keys)
         all-route-changes (list-route-changes-with-same-route-hash-id all-changes single-change)
         merged-changes (apply merge-with + all-route-changes)]
-    ;(.log js/console "all-route-changes " (pr-str all-route-changes))
     merged-changes))
 
 (defn route-changes [e! route-changes no-change-routes selected-route route-hash-id-type changes-all]

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -136,9 +136,9 @@
                        "Uusi reitti"]
 
                       :removed
-                      [icon-l/icon-labeled style/transit-changes-icon
-                       [ote-icons/outline-indeterminate-checkbox {:color style/remove-color}]
-                       "Päättyvä reitti"]
+                      [icon-l/icon-labeled
+                       [ic/content-remove-circle-outline {:color style/remove-color}]
+                       "Mahdollisesti päättyvä reitti"]
 
                       :no-change
                       [icon-l/icon-labeled style/transit-changes-icon

--- a/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
@@ -72,6 +72,6 @@
 
     ;; Add route ending icon if route ending change is detected
     (when (str/includes? (str change-type) "removed")
-      [:div {:style {:width "10%"}}
+      [:div {:style {:width "10%"} :title "Mahdollisesti päättyvä reitti"}
        [icon-l/icon-labeled
         [ic/content-remove-circle-outline {:color style/remove-color}] nil]])]))

--- a/ote/src/cljs/ote/views/transit_visualization/change_utilities.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/change_utilities.cljs
@@ -35,10 +35,10 @@
     [:b "Taulukon ikonien selitteet"]]
    [:div (stylefy/use-style style/transit-changes-icon-legend-row-container)
     (doall
-      (for [[icon color label] [[ic/content-remove-circle-outline {:color style/remove-color} "Mahdollisesti päättyvä reitti"]
-                          [ote-icons/outline-add-box {} "Uusia vuoroja"]
-                          [ote-icons/outline-indeterminate-checkbox {} "Poistuvia vuoroja"]
-                          [ic/action-timeline {} "Pysäkkimuutoksia per vuoro"]
-                          [ic/action-query-builder {} "Aikataulumuutoksia per vuoro"]]]
+      (for [[icon color label] [[ote-icons/outline-add-box {} "Uusia vuoroja"]
+                                [ote-icons/outline-indeterminate-checkbox {} "Poistuvia vuoroja"]
+                                [ic/action-timeline {} "Pysäkkimuutoksia per vuoro"]
+                                [ic/action-query-builder {} "Aikataulumuutoksia per vuoro"]
+                                [ic/content-remove-circle-outline {:color style/remove-color} "Mahdollisesti päättyvä reitti"]]]
         ^{:key (str "transit-visualization-route-changes-legend-" label)}
         [icon-l/icon-labeled style/transit-changes-icon [icon color] label]))]])


### PR DESCRIPTION
# Changed
* Transit visualization page: Move route change table header icon texts to correct order
* Transit visualization page: Do not add trip and stop changes to route change summary if change type is :removed
* Transit visualization page: At the calendar change list end trip changed.
* Transit visualization page: Move calendar change table header icons to correct order.
   
