### PR TITLE
164796337 discard no traffic if starts on last analysis week & report no-traffic for changed weeks

### DIFF
--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -409,7 +409,7 @@
 
 (defn route-weeks-with-first-difference-new
   "Detect the next different week in each route.
-  NOTE! starting from the seond week in the given route-weeks, the first given week is considered the \"prev\" week.
+  NOTE! starting from the second week in the given route-weeks, the first given week is considered the \"prev\" week.
   Takes a list of weeks that have week hashes for each route.
   Returns map from route [short long headsign] to next different week info.
   The route-weeks maps have keys :beginning-of-week, :end-of-week and :routes, under :routes there is a map with route-name -> 7-vector with day hashes of the week"
@@ -476,13 +476,13 @@
 
   Input: [{:beginning-of-week #object[java.time.LocalDate 0x3f51d3c0 \"2019-02-11\"],
           :end-of-week #object[java.time.LocalDate 0x30b5f64f \"2019-02-17\"],
-          :routes {\"Raimola\" [\"h1\" \"h2\" \"h3\" \"h4\" \"h5\" \"h6\" \"h7\"]}}
+          :routes {\"routename\" [\"h1\" \"h2\" \"h3\" \"h4\" \"h5\" \"h6\" \"h7\"]}}
           {...}]
 
   Output: [{:different-week
             {:beginning-of-week [\"2019-02-25\"]
             :end-of-week #object[java.time.LocalDate 0x5a900751 \"2019-03-03\"]}
-           :route-key \"raimola\"
+           :route-key \"routename\"
            :different-week-hash [\"h1\" \"!!\" \"h3\" \"h4\" \"h5\" \"h6\" \"h7\"]\n
            :starting-week {:beginning-of-week #object[java.time.LocalDate   \"2019-02-11\"]
                             :end-of-week #object[java.time.LocalDate \"2019-02-17\"]}
@@ -549,7 +549,6 @@
                            :gtfs/stop-sequence stop-sequence
                            :gtfs/departure-time (time/pginterval->interval departure-time)})
                         trip-stops)})))
-
 
 (defn compare-selected-trips [date1-trips date2-trips starting-week-date different-week-date]
   (let [combined-trips (transit-changes/combine-trips date1-trips date2-trips)

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -678,7 +678,7 @@
     change))
 
 (spec/fdef transform-route-change
-           :args (spec/cat :all-routes vector? :route-change map? :route-changes-all ::detected-route-changes-for-services-coll))
+           :args (spec/cat :all-routes vector? :route-change ::service-route-change-map :route-changes-all ::detected-route-changes-for-services-coll))
 (defn transform-route-change
   "Transform a detected route change into a database 'gtfs-route-change-info' type."
   [all-routes
@@ -695,8 +695,8 @@
         removed? (and last-route-change? (max-date-within-evaluation-window? route))
         no-traffic? (and no-traffic-start-date
                          (or no-traffic-end-date
-                             (and (> no-traffic-run no-traffic-detection-threshold)
-                                  (.isAfter no-traffic-start-date (.toLocalDate (:max-date route))))))
+                             (and (pos? no-traffic-run)
+                                  (.isBefore no-traffic-start-date (.toLocalDate (:max-date route))))))
         max-date-in-past? (.isBefore (.toLocalDate (:max-date route)) (java.time.LocalDate/now))
         {:keys [starting-week-date different-week-date
                 added-trips removed-trips trip-changes]} changes

--- a/ote/test/clj/ote/transit_changes/detection_test.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test.clj
@@ -53,9 +53,7 @@
          {route-name [nil nil nil nil nil nil nil]}
          {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
          {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         ))
-
+         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}))
 
 (deftest test-no-traffic-run-twice-is-detected
   (let [test-result (-> data-no-traffic-run-twice
@@ -468,6 +466,8 @@
 ;; Day hash data for changes for a default week with FIVE kind of day hashes
 (def data-wk-hash-traffic-five-kind             ["A" "B" "B" "B" "F" "G" "H"])
 (def data-wk-hash-traffic-five-kind-change-four ["A" "2" "5" "5" "5" "6" "7"])
+(def data-wk-hash-traffic-seven-kind             ["A" "C" "D" "E" "F" "G" "H"])
+(def data-wk-hash-traffic-five-kind-change-seven ["1" "2" "3" "4" "5" "6" "7"])
 
 (deftest test-changed-days-of-week
   (testing "One kind of traffic, changes: 0"
@@ -489,5 +489,8 @@
     (is (= [] (transit-changes/changed-days-of-week data-wk-hash-traffic-five-kind data-wk-hash-traffic-five-kind))))
 
   (testing "Five kinds of traffic, changes: 5"
-    (is (= [1 2 4 5 6] (transit-changes/changed-days-of-week data-wk-hash-traffic-five-kind data-wk-hash-traffic-five-kind-change-four)))))
+    (is (= [1 2 4 5 6] (transit-changes/changed-days-of-week data-wk-hash-traffic-five-kind data-wk-hash-traffic-five-kind-change-four))))
+
+  (testing "Seven kinds of traffic, changes: 7"
+    (is (= [0 1 2 3 4 5 6] (transit-changes/changed-days-of-week data-wk-hash-traffic-seven-kind data-wk-hash-traffic-five-kind-change-seven)))))
 

--- a/ote/test/clj/ote/transit_changes/detection_test.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test.clj
@@ -66,7 +66,7 @@
          {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 2019 06 17
          {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 2019 06 24
          {route-name ["h1" "h2" "h3" "h4" "h5" "!!" "h7"]}
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}))
+         {route-name ["h1" "h2" "h3" "h4" "h5" "!!" "h7"]}))
 
 (deftest test-change-on-2nd-to-last-wk
   (let [result (-> data-change-on-2nd-to-last-wk

--- a/ote/test/clj/ote/transit_changes/detection_test.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test.clj
@@ -312,62 +312,6 @@
          {route-name   ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
          {route-name   ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}))
 
-(def seppo
-  (weeks (d 2019 2 4)
-         {route-name   ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name   ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ; 11.2. prev week start
-         {route-name   ["h1" "##" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ; 18.2. first change in route1
-         {route-name   ["h1" "##" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name   ["h1" "##" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name   ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name   ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name   ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}))
-
-
-(def data-with-pause
-  (weeks (d 2019 2 4)
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ;; 4.2.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ;; first current week (11.2.)
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 18.2
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 11.3.
-         {route-name [nil nil nil nil nil nil nil]}         ;; 18.3.
-         {route-name [nil nil nil nil nil nil nil]}         ;; 25.3.
-         {route-name [nil nil nil nil nil nil nil]}         ;; 1.4.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 8.4.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 15.4.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]})) ;; 22.4.
-
-
-(def no-traffic
-  (weeks (d 2019 2 4)
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ;; 4.2.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ;; first current week (11.2.)
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}))
-
-(def differences
-  (weeks (d 2019 2 4)
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ;; 4.2.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]} ;; first current week (11.2.)
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 18.2.
-         {route-name [nil nil nil nil nil nil nil]}         ;; 25.2.
-         {route-name [nil nil nil nil nil nil nil]}         ;; 4.3.
-         {route-name [nil nil nil nil nil nil nil]}         ;; 11.3.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 18.3.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 25.3.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 1.4.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 8.4.
-         {route-name ["h1" "h2" "!!" "h4" "h5" "h6" "h7"]}  ;; 15.4.
-         {route-name ["h1" "h2" "!!" "h4" "h5" "h6" "h7"]}  ;;22.4.
-         {route-name ["h1" "h2" "!!" "h4" "h5" "h6" "h7"]}  ;;29.4.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;;6.5.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}  ;; 13.5.
-         {route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}))
-
 (deftest more-than-one-change-found-w-2-routes
   (let [diff-maps (-> data-two-week-two-route-change
                        (detection/changes-by-week->changes-by-route)


### PR DESCRIPTION
# Fixed
* transit-changes: for changed weeks, report all no-traffic without threashold
* transit-changes: ignore no-traffic which starts on last analysis wk end
    because if normal week has traffic on weekdays
    and nil on last day, analysis reports a started no-traffic run even
    if it actually ends on next day.
    This happens because analysis doesn't run on weeks 3. & 4. of the last
    4-week window.
   
# Changed
* transit-changes: detection code cleanup
 transit-changes: tests fix test-change-on-2nd-to-last-wk
 transit-changes: tests added for real life cases, plus restructuring
 transit-changes: tests: reorganize + summer period week and day tests
 transit-changes: detection code formatting for day comparison
 transit-changes: test changed-days-of-week when daily traffic individual
 transit-changes: unit test cleanup unused definitions