### PR TITLE
164941250 transit visualization ui tuning

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1023,7 +1023,14 @@ You can also draw the operating area or point to the map with drawing tools. You
   :save-user-success "Account info saved"
   :start-time "Starting time"
   :ending-time "Ending time"
-  :business-id-is-not-unique "The BIS number given is already in NAP. Please, contact NAP helpdesk for further information, joukkoliikenne@traficom.fi or tel. +358 29 534 5454 (Mon - Fri 9 am to 3 pm)."}
+  :business-id-is-not-unique "The BIS number given is already in NAP. Please, contact NAP helpdesk for further information, joukkoliikenne@traficom.fi or tel. +358 29 534 5454 (Mon - Fri 9 am to 3 pm)."
+  :day-of-week-1-short "Mon"
+  :day-of-week-2-short "Tue"
+  :day-of-week-3-short "Wed"
+  :day-of-week-4-short "Thu"
+  :day-of-week-5-short "Fri"
+  :day-of-week-6-short "Sat"
+  :day-of-week-7-short "Sun"}
 
 
  :dialog

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1033,7 +1033,14 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :save-user-success "Käyttäjätiedot tallennettu"
   :start-time "Alkamisaika"
   :ending-time "Päättymisaika"
-  :business-id-is-not-unique "Antamasi Y-tunnus löytyy jo NAP:sta. Ota yhteys NAP-Helpdeskiin asian selvittämiseksi, joukkoliikenne@traficom.fi tai p. 029 534 5454 (arkisin 9 - 15)."}
+  :business-id-is-not-unique "Antamasi Y-tunnus löytyy jo NAP:sta. Ota yhteys NAP-Helpdeskiin asian selvittämiseksi, joukkoliikenne@traficom.fi tai p. 029 534 5454 (arkisin 9 - 15)."
+  :day-of-week-1-short "Ma"
+  :day-of-week-2-short "Ti"
+  :day-of-week-3-short "Ke"
+  :day-of-week-4-short "To"
+  :day-of-week-5-short "Pe"
+  :day-of-week-6-short "La"
+  :day-of-week-7-short "Su"}
 
 
  :dialog

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -925,7 +925,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
  :transit-visualization-page
  {:loading-routes "Laddar rutterna för tjänsten."
   :no-changes-in-routes "Ei reittejä, joissa muutoksia."
-  :checkbox-show-no-change  "Näytä myös reitit, joihin ei ole tulossa muutoksia"
+  :checkbox-show-no-change "Näytä myös reitit, joihin ei ole tulossa muutoksia"
   :route-description "Taulukkoon on listattu palvelun reitit, joissa on havaittu muutoksia.
   Voit valita listalta yhden reitin kerrallaan tarkasteluun. Valitun reitin muutokset näytetään taulukon alapuolella."
   :calendar-description-1 "Muutoksen vertailupäivät on korostettu lilalla ja sinisellä ympyrällä. Päivät ovat valitun muutoksen tapahtumapäivä (sininen)
@@ -1027,7 +1027,14 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :save-user-success "Profil sparad"
   :business-id-is-not-unique "FO-numret finns redan i NAP. Ta kontakt med NAP Help Desk, joukkoliikenne@traficom.fi eller tfn 0295 34 6705 (vardagar kl 9-15)."
   :start-time "Från kl"
-  :ending-time "Till kl"}
+  :ending-time "Till kl"
+  :day-of-week-1-short "Må"
+  :day-of-week-2-short "Ti"
+  :day-of-week-3-short "On"
+  :day-of-week-4-short "To"
+  :day-of-week-5-short "Fr"
+  :day-of-week-6-short "Lö"
+  :day-of-week-7-short "Sö"}
 
 
  :dialog

--- a/ote/src/cljc/ote/time.cljc
+++ b/ote/src/cljc/ote/time.cljc
@@ -163,6 +163,12 @@
   #?(:clj (java.time.LocalDate/of year month date)
      :cljs (goog.date.Date. year (dec month) date)))
 
+;; Change js-date (.js/date) to google datetime
+#?(:cljs
+   (defn js-date-to-goog-date [d]
+     (let [fields (date-fields d)]
+       (goog.date.Date. (:ote.time/year fields) (dec (:ote.time/month fields)) (:ote.time/date fields)))))
+
 (defn year [dt]
   (::year (date-fields dt)))
 

--- a/ote/src/cljc/ote/time.cljc
+++ b/ote/src/cljc/ote/time.cljc
@@ -165,7 +165,7 @@
 
 ;; Change js-date (.js/date) to google datetime
 #?(:cljs
-   (defn js-date-to-goog-date [d]
+   (defn js-date->goog-date [d]
      (let [fields (date-fields d)]
        (goog.date.Date. (:ote.time/year fields) (dec (:ote.time/month fields)) (:ote.time/date fields)))))
 

--- a/ote/src/cljs/ote/ui/service_calendar_compact.cljs
+++ b/ote/src/cljs/ote/ui/service_calendar_compact.cljs
@@ -103,7 +103,7 @@
 (defn- month-name [month]
   (let [lang (.get (goog.net.Cookies. js/document) "finap_lang" "fi")]
     (subs
-     (.toLocaleString (doto (js/Date.) (.setMonth (- month 1))) lang #js {:month "short"})
+     (.toLocaleString (doto (js/Date. (.getFullYear (js/Date.)) (- month 1) 1)) lang #js {:month "short"})
      0 3)))
 
 (defn service-calendar-month [{:keys [selected-date? on-select on-hover hover-style

--- a/ote/src/cljs/ote/ui/table.cljs
+++ b/ote/src/cljs/ote/ui/table.cljs
@@ -19,9 +19,7 @@
                         :color "gray"}}
        opts])))
 
-(defn table [{:keys [height name->label key-fn
-                     label-style
-                     row-style show-row-hover? selected-route
+(defn table [{:keys [height name->label key-fn label-style row-style
                      on-select row-selected? no-rows-message class] :as opts} headers rows]
   (let [random-table-id (str "tid-"(rand-int 999))
         table-row-color "#FFFFFF"

--- a/ote/src/cljs/ote/ui/table.cljs
+++ b/ote/src/cljs/ote/ui/table.cljs
@@ -30,6 +30,7 @@
     [ui/table (merge
                 {:wrapperStyle {:overflow "visible"}
                  :body-style {:padding "3px"}
+                 :header-style {:border (str "solid 3px " colors/gray400)}
                  ;; FIXME: When we have tooltips in header labels, body does not need overflow: visible.
                  ;;        But, if any row includes tooltips, the body must also have visible overflow.
                  ;;        For now, leaving this commented out.
@@ -60,7 +61,7 @@
                                       (merge
                                         (when width
                                           {:width width})
-                                        {:white-space "pre-wrap"
+                                        {:white-space "pre-line"
                                          :overflow "visible"
                                          :color (color :grey900)
                                          :font-size "1em"
@@ -97,7 +98,7 @@
                      (let [value ((or format identity) (if read (read row) (get row name)))]
                        ^{:key (str i "-" random-table-id "-row-col-" name)}
                        [ui/table-row-column {:style (merge
-                                                      {:white-space "pre-wrap"
+                                                      {:white-space "pre-line"
                                                        :overflow "visible"}
                                                       (when width {:width width})
                                                       (when col-style col-style))}

--- a/ote/src/cljs/ote/ui/table.cljs
+++ b/ote/src/cljs/ote/ui/table.cljs
@@ -89,8 +89,7 @@
                                                           {:outline (str "solid 3px " colors/primary-dark)
                                                            ::stylefy/mode {:hover {:background-color (if (even? i) table-row-color table-row-color-alt)}}})
                                                         (when row-style row-style)))
-                              {:selectable (boolean on-select)
-                               :display-border false})
+                              {:selectable (boolean on-select)})
 
                (doall
                  (map-indexed

--- a/ote/src/cljs/ote/views/transit_changes.cljs
+++ b/ote/src/cljs/ote/views/transit_changes.cljs
@@ -61,21 +61,21 @@
 
 (defn change-icons [{:keys [added-routes removed-routes changed-routes no-traffic-routes]}]
   [:div.transit-change-icons (stylefy/use-style style/transit-changes-icon-row-container)
-   [:div (use-style (merge style/transit-changes-legend-icon {:width "25%"}))
+   [:div {:style {:width "25%"}}
     [ic/content-add-circle-outline {:color (if (= 0 added-routes)
                                              style/no-change-color
                                              style/add-color)}]
     (cap-number added-routes)]
-   [:div (use-style (merge style/transit-changes-legend-icon {:width "25%"}))
+   [:div {:style {:width "25%"}}
     [ic/content-remove-circle-outline {:color (if (= 0 removed-routes)
                                                 style/no-change-color
                                                 style/remove-color)}]
     (cap-number removed-routes)]
 
-   [:div (use-style (merge style/transit-changes-legend-icon {:width "25%"}))
+   [:div {:style {:width "25%"}}
     [ui-icons/outline-ballot] (cap-number changed-routes)]
 
-   [:div (use-style (merge style/transit-changes-legend-icon {:width "25%"}))
+   [:div {:style {:width "25%"}}
     [ic/av-not-interested {:color (if (= 0 no-traffic-routes)
                                                 style/no-change-color
                                                 style/remove-color)}]

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -374,6 +374,7 @@
        {:name "Muutoksia (kpl)"
         :width "10%"
         :read identity
+        :col-style style-base/table-col-style-wrap
         :format (fn [row]
                   (if (= :no-change (:change-type row))
                     "0"
@@ -381,6 +382,7 @@
        {:name "Aikaa 1. muutokseen"
         :width "15%"
         :read :different-week-date
+        :col-style style-base/table-col-style-wrap
         :format (fn [different-week-date]
                   (if-not different-week-date
                     [tv-change-icons/labeled-icon [ic/navigation-check] "Ei muutoksia"]
@@ -391,6 +393,7 @@
                       (str  "(" (time/format-timestamp->date-for-ui different-week-date) ")")]]))}
        {:name "Muutosten yhteenveto" :width "32%"
         :read identity
+        :col-style style-base/table-col-style-wrap
         :format (fn [{change-type :change-type different-week-date :different-week-date :as route-changes}]
                   (case change-type
                     :no-traffic
@@ -458,6 +461,7 @@
       [:div.trips-table {:style {:margin-top "1em"}}
        [table/table {:name->label str
                      :row-selected? #(= % selected-trip-pair)
+                     :label-style style-base/table-col-style-wrap
                      :on-select #(e! (tv/->SelectTripPair (first %)))}
 
         [;; name of the first stop of the first trip (FIXME: should be first common?)
@@ -465,30 +469,30 @@
                   "Reittitunnus"
                   "")
           :read #(:headsign (first %))
-          :col-style {:padding-left "10px" :padding-right "5px"}}
+          :col-style style-base/table-col-style-wrap}
          {:name (some-> trips first first :stoptimes first :gtfs/stop-name)
           :read #(-> % first :stoptimes first :gtfs/departure-time)
           :format (partial format-stop-time (style/date1-highlight-style) )
-          :col-style {:padding-left "10px" :padding-right "5px"}}
+          :col-style style-base/table-col-style-wrap}
          ;; name of the last stop of the first trip
          {:name (some-> trips first first :stoptimes last :gtfs/stop-name)
           :read #(-> % first :stoptimes last :gtfs/departure-time)
           :format (partial format-stop-time (style/date1-highlight-style))
-          :col-style {:padding-left "10px" :padding-right "5px"}}
+          :col-style style-base/table-col-style-wrap}
 
          {:name (if (-> trips first second :stoptimes first :gtfs/stop-name)
                     "Reittitunnus"
                     "")
           :read #(:headsign (second %))
-          :col-style {:padding-left "10px" :padding-right "5px"}}
+          :col-style style-base/table-col-style-wrap}
          {:name (-> trips first second :stoptimes first :gtfs/stop-name)
           :read (comp :gtfs/departure-time first :stoptimes second)
           :format (partial format-stop-time (style/date2-highlight-style))
-          :col-style {:padding-left "10px" :padding-right "5px"}}
+          :col-style style-base/table-col-style-wrap}
          {:name (-> trips first second :stoptimes last :gtfs/stop-name)
           :read (comp :gtfs/departure-time last :stoptimes second)
           :format (partial format-stop-time (style/date2-highlight-style))
-          :col-style {:padding-left "10px" :padding-right "5px"}}
+          :col-style style-base/table-col-style-wrap}
 
          {:name "Muutokset" :read identity
           :format (fn [[left right {:keys [stop-time-changes stop-seq-changes]}]]
@@ -508,7 +512,7 @@
                         [tv-change-icons/stop-seq-changes-icon stop-seq-changes]]
                        [:div (stylefy/use-style {:width "50%"})
                         [tv-change-icons/stop-time-changes-icon stop-time-changes]]]))
-          :col-style {:padding-left "10px" :padding-right "5px"}}]
+          :col-style style-base/table-col-style-wrap}]
         trips]])]])
 
 (defn trip-stop-sequence [e! open-sections {:keys [date1 date2 selected-trip-pair
@@ -518,12 +522,24 @@
    "Pysäkit"
    "Pysäkkilistalla näytetään valitun vuoron pysäkkikohtaiset aikataulut."
    (let [second-stops-empty? (empty? (:stoptimes (second selected-trip-pair)))]
-     [:div.trip-stop-sequence
-      [table/table {:name->label str}
-       [{:name "Pysäkki" :read :gtfs/stop-name :format (partial format-stop-name)}
-        {:name "Lähtöaika" :read :gtfs/departure-time-date1 :format (partial format-stop-time (style/date1-highlight-style))}
-        {:name "Lähtöaika" :read :gtfs/departure-time-date2 :format (partial format-stop-time (style/date2-highlight-style))}
-        {:name "Muutokset" :read identity
+     [:div.trip-stop-sequence {:style {:margin-top "1em"}}
+      [table/table {:name->label str
+                    :label-style style-base/table-col-style-wrap}
+       [{:name "Pysäkki"
+         :read :gtfs/stop-name
+         :col-style style-base/table-col-style-wrap
+         :format (partial format-stop-name)}
+        {:name "Lähtöaika"
+         :read :gtfs/departure-time-date1
+         :col-style style-base/table-col-style-wrap
+         :format (partial format-stop-time (style/date1-highlight-style))}
+        {:name "Lähtöaika"
+         :read :gtfs/departure-time-date2
+         :col-style style-base/table-col-style-wrap
+         :format (partial format-stop-time (style/date2-highlight-style))}
+        {:name "Muutokset"
+         :read identity
+         :col-style style-base/table-col-style-wrap
          :format (fn [{:gtfs/keys [departure-time-date1 departure-time-date2]}]
                    (cond
                      (and departure-time-date1 (nil? departure-time-date2))

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -357,7 +357,7 @@
                                  (do
                                    (e! (tv/->SelectRouteForDisplay (first %)))
                                    (.setTimeout js/window (fn [] (scroll/scroll-to-id "route-calendar-anchor")) 150)))
-                   :row-selected? #(= % selected-route)}
+                   :row-selected? #(= (:route-hash-id %) (:route-hash-id selected-route))}
 
       [{:name "Reitti" :width "20%"
         :read (juxt :route-short-name :route-long-name)

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -53,7 +53,8 @@
   [:div (stylefy/use-style (merge (style-base/flex-container "row")
                                   {:justify-content "space-between"
                                    :width "20%"}))
-   [:div [:div {:style (merge {:display "inline-block"
+   [:div
+    [:div {:style (merge {:display "inline-block"
                                :position "relative"
                                :top "5px"
                                :margin-right "0.5em"
@@ -61,7 +62,8 @@
                                :height "20px"}
                               (style/date1-highlight-style))}]
     (time/format-date date1)]
-   [:div [:div {:style (merge {:display "inline-block"
+   [:div
+    [:div {:style (merge {:display "inline-block"
                                :position "relative"
                                :top "5px"
                                :margin-right "0.5em"
@@ -71,7 +73,7 @@
     (time/format-date date2)]])
 
 (defn comparison-date-changes [{diff :differences :as compare}]
-  [:span
+  [:div
    [comparison-dates compare]
 
    (when (seq diff)
@@ -108,6 +110,7 @@
                      :row-selected? #(= (:different-week-date %) (:different-week-date selected-route))}
         [{:name "Aikaa muutokseen"
           :read :different-week-date
+          :col-style style-base/table-col-style-wrap
           :format (fn [different-week-date]
                     [:div
                      [:span (stylefy/use-style { ;; nowrap for the "3 pv" part to prevent breaking "pv" alone to new row.
@@ -118,6 +121,7 @@
                       (str "(" (time/format-timestamp->date-for-ui different-week-date) ")")]])}
          {:name "Muutos tunnistettu"
           :read :transit-change-date
+          :col-style style-base/table-col-style-wrap
           :format (fn [transit-change-date]
                     (time/format-timestamp->date-for-ui transit-change-date))}
          {:name "Muutokset" :width "30%"

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -123,7 +123,7 @@
                      [:span (stylefy/use-style {:color "gray"
                                                 :overflow-wrap "break-word"})
                       (str "("
-                           (day-of-week-number->text (t/day-of-week (time/js-date-to-goog-date different-week-date)))
+                           (day-of-week-number->text (t/day-of-week (time/js-date->goog-date different-week-date)))
                            " "
                            (time/format-timestamp->date-for-ui different-week-date) ")")]])}
          {:name "Muutos tunnistettu"

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -4,6 +4,7 @@
             [cljs-react-material-ui.icons :as ic]
             [stylefy.core :as stylefy]
             [ote.time :as time]
+            [cljs-time.core :as t]
             [cljs-react-material-ui.reagent :as ui]
             [ote.localization :refer [tr]]
             [ote.ui.icons :as ote-icons]
@@ -18,6 +19,9 @@
             [ote.app.controller.transit-visualization :as tv]))
 
 ;; Utility methods
+(defn day-of-week-number->text [dof]
+  (tr [:common-texts (keyword (str "day-of-week-" dof "-short"))]))
+
 (defn select-day [e! day loading?]
   (when-not loading?
     (e! (tv/->SelectDatesForComparison day))))
@@ -113,18 +117,21 @@
           :col-style style-base/table-col-style-wrap
           :format (fn [different-week-date]
                     [:div
-                     [:span (stylefy/use-style { ;; nowrap for the "3 pv" part to prevent breaking "pv" alone to new row.
-                                               :white-space "nowrap"})
+                     [:span (stylefy/use-style {;; nowrap for the "3 pv" part to prevent breaking "pv" alone to new row.
+                                                :white-space "nowrap"})
                       (str (time/days-until different-week-date) " pv ")]
                      [:span (stylefy/use-style {:color "gray"
-                                               :overflow-wrap "break-word"})
-                      (str "(" (time/format-timestamp->date-for-ui different-week-date) ")")]])}
+                                                :overflow-wrap "break-word"})
+                      (str "("
+                           (day-of-week-number->text (t/day-of-week (time/js-date-to-goog-date different-week-date)))
+                           " "
+                           (time/format-timestamp->date-for-ui different-week-date) ")")]])}
          {:name "Muutos tunnistettu"
           :read :transit-change-date
           :col-style style-base/table-col-style-wrap
           :format (fn [transit-change-date]
                     (time/format-timestamp->date-for-ui transit-change-date))}
-         {:name "Muutokset" :width "30%"
+         {:name "Vertailupäivien väliset muutokset" :width "30%"
           :read identity
           :col-style style-base/table-col-style-wrap
           :format (fn [{change-type :change-type :as route}]

--- a/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
@@ -47,7 +47,7 @@
             trip-stop-time-changes-lower trip-stop-time-changes-upper different-week-date] :as diff}
     with-labels?]
    [:div (stylefy/use-style (style-base/flex-container "row"))
-    [:div {:style {:width "15%"}}
+    [:div {:style {:width "20%"}}
      [icon-l/icon-labeled
       [ote-icons/outline-add-box {:color (if (= 0 added-trips)
                                            style/no-change-color
@@ -55,7 +55,7 @@
       [:span (or added-trips (:gtfs/added-trips diff))      ;; :changes and :changes-route* have different namespace
        (when with-labels? " lisättyä vuoroa")]]]
 
-    [:div {:style {:width "15%"}}
+    [:div {:style {:width "20%"}}
      [icon-l/icon-labeled
       [ote-icons/outline-indeterminate-checkbox {:color (if (= 0 removed-trips)
                                                           style/no-change-color


### PR DESCRIPTION
# Fixed
* Transit visualization: Add date of week to calendar change list
* calendar component: Fix month name for February when current day is greater than day count in February (29,30,31)
* All tables: Move header labels and column values to start at the same spot
* All tables: Fix long text values in tables by changing pre-wrap to pre-line
* transit-changes: Move change icons more to left
