### PR TITLE
util: define rand-str for generating random text strings

### DIFF
--- a/ote/src/cljc/ote/util/text.cljc
+++ b/ote/src/cljc/ote/util/text.cljc
@@ -8,3 +8,11 @@
   (if (< max-length (count text))
     (shorten-text-to max-length text)
     text))
+
+(defn rand-str
+  "Input: Takes a length for resulting string,
+  Output: returns a randomly generated ascii string or nil if arguent was invalid"
+  [length]
+  (when (pos? length)
+    (let [ascii-codes (concat (range 48 58) (range 66 91) (range 97 123))]
+      (clojure.string/join (repeatedly length #(char (rand-nth ascii-codes)))))))


### PR DESCRIPTION
# Added
* rand-str for generating random text strings
This could be used e.g. for generating unique ^{:key id } id's on view templates for reagent/react.