### PR TITLE
165178236: transit-visualization show all changes via history link

### DIFF
--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -712,7 +712,7 @@
                  " Ladattu NAPiin "
                  (if show-link?
                    (common/linkify
-                     (str "/#/transit-visualization/" service-id "/" (time/format-date-iso-8601 created))
+                     (str "/#/transit-visualization/" service-id "/" (time/format-date-iso-8601 created) "/all")
                      (time/format-timestamp-for-ui created))
                    (time/format-timestamp-for-ui created)) ". "
                  "Sisältää tietoa liikennöinnistä ajanjaksolle  " min-date " - " max-date "."]))]


### PR DESCRIPTION
# Changed
* transit-visualization show all changes via history link
navigation via the history link in infobox shows all changes and not filtered by date. Route navigation doesn't work without the url arg.