### PR TITLE
165178236: transit-visualisation fix "show routes without changes"

### DIFF
--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -385,7 +385,7 @@
         :col-style style-base/table-col-style-wrap
         :format (fn [different-week-date]
                   (if-not different-week-date
-                    [tv-change-icons/labeled-icon [ic/navigation-check] "Ei muutoksia"]
+                    [icon-l/icon-labeled [ic/navigation-check] "Ei muutoksia"]
                     [:span
                      (str (time/days-until different-week-date) " pv")
                      [:span (stylefy/use-style {:margin-left "5px"


### PR DESCRIPTION
# Fixed
* views: transit-visualisation fix show routes without changes
Invalid reagent hiccup form produced a runtime warning and prevented
displaying some rows when table couldn't be rendered.