### PR TITLE
165208562 transit changes hide past changes and transit-visualization ui abbreviation for days

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1006,6 +1006,7 @@ You can also draw the operating area or point to the map with drawing tools. You
                :hours "Hours"
                :days "Days"
                :seconds "Seconds"}
+  :time-days-abbr "d"
   :save-failed "An error has occured while saving. If the problem continues, please contact NAP-Helpdesk p. +35829 534 3434"
   :delete-operator-success "The service provider was deleted successfully."
   :delete-service-success "The service was deleted successfully."

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1016,6 +1016,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
                :hours "Tuntia"
                :days "Päivää"
                :seconds "Sekuntia"}
+  :time-days-abbr "pv"
   :save-failed "Tallennettaessa sattui virhe. Jos ongelma toistuu "
   :delete-operator-success "Palveluntuottaja poistettiin onnistuneesti."
   :delete-service-success "Palvelu poistettiin onnistuneesti."

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1010,6 +1010,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
                :hours "Timmar"
                :days "Dagar"
                :seconds "Sekunder"}
+  :time-days-abbr "d"
   :save-failed "Ett fel inträffade"
   :delete-operator-success "Tjänsteproducenter borttagen."
   :delete-service-success "Tjänsten borttagen."

--- a/ote/src/clj/ote/services/transit_changes.sql
+++ b/ote/src/clj/ote/services/transit_changes.sql
@@ -8,50 +8,73 @@ SELECT "change-date",
 -- name: upcoming-changes
 WITH latest_transit_changes AS (
   SELECT DISTINCT ON ("transport-service-id") *
-    FROM "gtfs-transit-changes"
-   ORDER BY "transport-service-id", date desc
+  FROM "gtfs-transit-changes"
+  ORDER BY "transport-service-id", date desc
 )
 SELECT ts.id AS "transport-service-id",
        ts."commercial-traffic?" AS "commercial?",
        ts.name AS "transport-service-name",
        op.name AS "transport-operator-name",
-       "added-routes", "removed-routes", "changed-routes", "no-traffic-routes",
+
+       -- Resulted record set is grouped by service id, date etc. This part calculates the sum of each distinct value of
+       -- "change-type", which is enum "gtfs-route-change-type". Allows displaying them at front-end summary.
+       COUNT(CASE
+               WHEN drc."change-type" = 'added'::"gtfs-route-change-type" THEN 1
+         END) as "added-routes",
+       COUNT(CASE
+               WHEN "change-type" = 'removed'::"gtfs-route-change-type" THEN 1
+         END)  as "removed-routes",
+       COUNT(CASE
+               WHEN "change-type" = 'no-traffic'::"gtfs-route-change-type" THEN 1
+         END)  as "no-traffic-routes",
+       COUNT(CASE
+               WHEN "change-type" = 'changed'::"gtfs-route-change-type" THEN 1
+         END)  as "changed-routes",
+
        CURRENT_DATE as "current-date",
-       "different-week-date", "change-date",
-       "date",
-       "change-date" - CURRENT_DATE AS "days-until-change",
-       ("different-week-date" IS NOT NULL) AS "changes?",
+       MIN(drc."different-week-date") as "different-week-date",
+       c."change-date",
+       c."date",
+       c."change-date" - CURRENT_DATE AS "days-until-change",
+       (c."different-week-date" IS NOT NULL) AS "changes?",
        EXISTS(SELECT id
-                FROM "external-interface-description" eid
-               WHERE eid."transport-service-id" = ts.id
-                 AND ('GTFS' = ANY(eid.format) OR 'Kalkati.net' = ANY(eid.format))
-                 AND 'route-and-schedule' = ANY(eid."data-content")
-                 AND ("gtfs-db-error" IS NOT NULL OR "gtfs-import-error" IS NOT NULL)) AS "interfaces-has-errors?",
+              FROM "external-interface-description" eid
+              WHERE eid."transport-service-id" = ts.id
+                AND ('GTFS' = ANY(eid.format) OR 'Kalkati.net' = ANY(eid.format))
+                AND 'route-and-schedule' = ANY(eid."data-content")
+                AND ("gtfs-db-error" IS NOT NULL OR "gtfs-import-error" IS NOT NULL)) AS "interfaces-has-errors?",
        NOT EXISTS(SELECT id
-                    FROM "external-interface-description" eid
-                   WHERE eid."transport-service-id" = ts.id
-                     AND ('GTFS' = ANY(eid.format) OR 'Kalkati.net' = ANY(eid.format))
-                     AND 'route-and-schedule' = ANY(eid."data-content")) AS "no-interfaces?",
+                  FROM "external-interface-description" eid
+                  WHERE eid."transport-service-id" = ts.id
+                    AND ('GTFS' = ANY(eid.format) OR 'Kalkati.net' = ANY(eid.format))
+                    AND 'route-and-schedule' = ANY(eid."data-content")) AS "no-interfaces?",
        NOT EXISTS(SELECT id
-                    FROM "external-interface-description" eid
-                   WHERE eid."transport-service-id" = ts.id
-                     AND ('GTFS' = ANY(eid.format) OR 'Kalkati.net' = ANY(eid.format))
-                     AND 'route-and-schedule' = ANY(eid."data-content") AND eid."gtfs-imported" IS NOT NULL) AS "no-interfaces-imported?",
+                  FROM "external-interface-description" eid
+                  WHERE eid."transport-service-id" = ts.id
+                    AND ('GTFS' = ANY(eid.format) OR 'Kalkati.net' = ANY(eid.format))
+                    AND 'route-and-schedule' = ANY(eid."data-content") AND eid."gtfs-imported" IS NOT NULL) AS "no-interfaces-imported?",
        (SELECT string_agg(fr, ',')
-          FROM gtfs_package p
-          JOIN LATERAL unnest(p."finnish-regions") fr ON TRUE
-         WHERE id = ANY(c."package-ids")) AS "finnish-regions",
+        FROM gtfs_package p
+               JOIN LATERAL unnest(p."finnish-regions") fr ON TRUE
+        WHERE id = ANY(c."package-ids")) AS "finnish-regions",
        (SELECT (upper(gtfs_package_date_range(p.id)) - '1 day'::interval)::date
-          FROM gtfs_package p
-         WHERE p."transport-service-id" = ts.id AND p."deleted?" = FALSE
-         ORDER BY p.id DESC limit 1) as "max-date"
-  FROM "transport-service" ts
-  JOIN "transport-operator" op ON ts."transport-operator-id" = op.id
-  LEFT JOIN latest_transit_changes c ON c."transport-service-id" = ts.id
- WHERE 'road' = ANY(ts."transport-type")
-   AND 'schedule' = ts."sub-type"
-   AND ts.published IS NOT NULL
- ORDER BY "different-week-date" ASC, "interfaces-has-errors?" DESC, "no-interfaces?" DESC, "no-interfaces-imported?" ASC;
+        FROM gtfs_package p
+        WHERE p."transport-service-id" = ts.id AND p."deleted?" = FALSE
+        ORDER BY p.id DESC limit 1) as "max-date"
+FROM "transport-service" ts
+       JOIN "transport-operator" op ON ts."transport-operator-id" = op.id
+       LEFT JOIN latest_transit_changes c ON c."transport-service-id" = ts.id,
+     "detected-route-change" drc
+WHERE 'road' = ANY(ts."transport-type")
+  AND drc."transit-change-date" = c.date
+  AND drc."transit-service-id" = c."transport-service-id"
+  AND drc."different-week-date" >= CURRENT_DATE
+  AND 'schedule' = ts."sub-type"
+  AND ts.published IS NOT NULL
+-- Group so that each group represents a distinct change date, allows summing up changes in SELECT section of this query
+GROUP BY ts.id, c."date", op.name, c."change-date", c."package-ids", c."different-week-date"
+ORDER BY "different-week-date" ASC, "interfaces-has-errors?" DESC, "no-interfaces?" DESC, "no-interfaces-imported?" ASC,
+         op.name ASC;
 
 -- name: calculate-routes-route-hashes-using-headsign
 SELECT calculate_route_hash_id_using_headsign(:package-id::INTEGER);

--- a/ote/src/clj/ote/services/transit_changes.sql
+++ b/ote/src/clj/ote/services/transit_changes.sql
@@ -32,10 +32,10 @@ SELECT ts.id AS "transport-service-id",
          END)  as "changed-routes",
 
        CURRENT_DATE as "current-date",
-       MIN(drc."different-week-date") as "different-week-date",
        c."change-date",
        c."date",
-       c."change-date" - CURRENT_DATE AS "days-until-change",
+       MIN(drc."different-week-date") as "different-week-date",
+       MIN(drc."different-week-date") - CURRENT_DATE AS "days-until-change",
        (c."different-week-date" IS NOT NULL) AS "changes?",
        EXISTS(SELECT id
               FROM "external-interface-description" eid

--- a/ote/src/cljs/ote/views/transit_changes.cljs
+++ b/ote/src/cljs/ote/views/transit_changes.cljs
@@ -244,7 +244,7 @@
         :format (fn [{:keys [different-week-date days-until-change]}]
                   (if (and different-week-date (not (nil? different-week-date)))
                     [:span
-                     (str days-until-change " pv")
+                     (str days-until-change " " (tr [:common-texts :time-days-abbr]))
                      [:span (stylefy/use-style {:margin-left "5px"
                                                 :color "gray"})
                       (str "(" (time/format-timestamp->date-for-ui different-week-date) ")")]]

--- a/ote/src/cljs/ote/views/transit_changes.cljs
+++ b/ote/src/cljs/ote/views/transit_changes.cljs
@@ -239,12 +239,12 @@
         :col-style style-base/table-col-style-wrap
         :width "20%"}
        {:name "Aikaa 1. muutokseen" :width "15%"
-        :read :different-week-date
+        :read identity
         :col-style style-base/table-col-style-wrap
-        :format (fn [different-week-date]
+        :format (fn [{:keys [different-week-date days-until-change]}]
                   (if (and different-week-date (not (nil? different-week-date)))
                     [:span
-                     (str (time/days-until different-week-date) " pv")
+                     (str days-until-change " pv")
                      [:span (stylefy/use-style {:margin-left "5px"
                                                 :color "gray"})
                       (str "(" (time/format-timestamp->date-for-ui different-week-date) ")")]]

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -387,7 +387,7 @@
                   (if-not different-week-date
                     [icon-l/icon-labeled [ic/navigation-check] "Ei muutoksia"]
                     [:span
-                     (str (time/days-until different-week-date) " pv")
+                     (str (time/days-until different-week-date) " " (tr [:common-texts :time-days-abbr]))
                      [:span (stylefy/use-style {:margin-left "5px"
                                                 :color "gray"})
                       (str  "(" (time/format-timestamp->date-for-ui different-week-date) ")")]]))}

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -115,15 +115,14 @@
     (.eachLayer m (fn [layer]
                     (if-let [^HTMLImageElement icon (aget layer "_icon")]
                       ;; This is a stop, set the icon visibility
-                      (do
-                        (let [^CSSStyleDeclaration icon-style (aget icon "style")]
-                          (set! (.-visibility icon-style)
-                                (if (and
-                                      (:stops show)
-                                      (not (contains? @removed-route-layers (aget layer "feature" "properties" "trip-name")))
-                                      (show (some-> layer (aget "feature") (aget "properties") (aget "trip-name"))))
-                                  ""
-                                  "hidden")))))
+                      (let [^CSSStyleDeclaration icon-style (aget icon "style")]
+                        (set! (.-visibility icon-style)
+                              (if (and
+                                    (:stops show)
+                                    (not (contains? @removed-route-layers (aget layer "feature" "properties" "trip-name")))
+                                    (show (some-> layer (aget "feature") (aget "properties") (aget "trip-name"))))
+                                ""
+                                "hidden"))))
 
                       (when-let [routename (some-> layer (aget "feature") (aget "properties") (aget "routename"))]
                         (when-not (show routename)
@@ -732,9 +731,8 @@
                   [ic/navigation-expand-less]
                   [ic/navigation-expand-more])
           :on-click (fn [^SyntheticMouseEvent event]
-                      (do
-                        (.preventDefault event)
-                        (e! (tv/->ToggleSection :gtfs-package-info))))
+                      (.preventDefault event)
+                      (e! (tv/->ToggleSection :gtfs-package-info)))
           :style style/infobox-more-link}]
         (when open?
           [:div

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -119,7 +119,7 @@
                     [:div
                      [:span (stylefy/use-style {;; nowrap for the "3 pv" part to prevent breaking "pv" alone to new row.
                                                 :white-space "nowrap"})
-                      (str (time/days-until different-week-date) " pv ")]
+                      (str (time/days-until different-week-date) " " (tr [:common-texts :time-days-abbr]) " ")]
                      [:span (stylefy/use-style {:color "gray"
                                                 :overflow-wrap "break-word"})
                       (str "("


### PR DESCRIPTION
# Changed
* views: transit-visualization use :time-days-abbr instead of hard coding
* views: transit-changes use :time-days-abbr instead of hard coded string
* views: transit-changes use days-until-change from response
* services: transit-changes days-until-change from different-week-date
* services: transit-changes fetch only future upcoming-changes
