### PR TITLE
Fix cypress e-2-e warnings

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -11,7 +11,7 @@
   "responseTimeout": 30000,
   "trashAssetsBeforeRuns": true,
   "videoCompression": 32,
-  "video": true,
+  "video": false,
   "videoUploadOnPasses": true,
   "viewportHeight": 660,
   "viewportWidth": 1080,


### PR DESCRIPTION
# Fixed
* "video" set to false, to try and fix errors in jenkins e-2-e tests.