### PR TITLE
Video false for cypress settings to stop warnings.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       # Note: When running with chrome, it seems we cannot record a video. Only Electron browser can record a video.
       - run:
           name: Run all tests for a pull request
-          command: $(npm bin)/cypress run --browser chrome --record
+          command: $(npm bin)/cypress run --browser chrome --record false
 
 workflows:
   version: 2

--- a/aws/ansible/jenkins/jobs/cypress.groovy
+++ b/aws/ansible/jenkins/jobs/cypress.groovy
@@ -27,6 +27,6 @@ job('Cypress-e2e-tests') {
         shell('CYPRESS_RECORD_KEY=${vault_cypress_record_key} '+
               'CYPRESS_NAP_LOGIN=${vault_cypress_nap_username} '+
               'CYPRESS_NAP_PASSWORD=${vault_cypress_nap_password} '+
-              '$(npm bin)/cypress run --browser chrome --record')
+              '$(npm bin)/cypress run --browser chrome --record false')
     }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -11,7 +11,7 @@
   "responseTimeout": 30000,
   "trashAssetsBeforeRuns": true,
   "videoCompression": 32,
-  "video": true,
+  "video": false,
   "videoUploadOnPasses": true,
   "viewportHeight": 660,
   "viewportWidth": 1080,


### PR DESCRIPTION
# Fixed
* some warnings in cypress tests. And possibly remove restrictions from the amount of tests that can be ran
