### PR TITLE
transit-visualization: same place for change icons always

### DIFF
--- a/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
@@ -69,13 +69,14 @@
     [:div {:style {:flex "1"}}
      [stop-time-changes-icon trip-stop-time-changes-lower trip-stop-time-changes-upper with-labels?]]
 
-    ;; Add route ending icon if route ending change is detected
-    (when (str/includes? (str change-type) "removed")
-      [:div {:style {:flex "0.5"} :title "Reitti on mahdollisesti päättymässä. Ota yhteyttä liikennöitsijään saadaksesi tarkempia tietoja."}
-       [icon-l/icon-labeled
-        [ic/content-remove-circle-outline {:color style/remove-color}] nil]])
-
-    (when (str/includes? (str change-type) "no-traffic")
+    (if (str/includes? (str change-type) "no-traffic")
       [:div {:style {:flex "0.5"} :title (tr [:transit-changes :no-traffic])}
        [icon-l/icon-labeled
-        [ic/av-not-interested {:color style/remove-color}] nil]])]))
+        [ic/av-not-interested {:color style/remove-color}] nil]]
+      [:div {:style {:flex "0.5"}}])
+
+    (if (str/includes? (str change-type) "removed")
+      [:div {:style {:flex "0.5"} :title "Reitti on mahdollisesti päättymässä. Ota yhteyttä liikennöitsijään saadaksesi tarkempia tietoja."}
+       [icon-l/icon-labeled
+        [ic/content-remove-circle-outline {:color style/remove-color}] nil]]
+      [:div {:style {:flex "0.5"}}])]))


### PR DESCRIPTION
# Changed
* Alignment does not match for rows with different number of icons.
This sets same places regardless if other icons are displayed.
Also switched "no-traffic" and "removed" icons to same order as in table legend.