### PR TITLE
165575508 transit change detection to ignore holidays between no traffic

### DIFF
--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -657,7 +657,7 @@
                     :changes (compare-route-days-all-changes-for-week db service-id route-key detection-result))
                   detection-result))
               routes)
-        res (into [] (expand-day-changes route-day-changes))]
+        res (vec (expand-day-changes route-day-changes))]
     res))
 
 (defn- date-in-the-past? [^LocalDate date]
@@ -687,9 +687,6 @@
     {:gtfs/change-type :no-change
      :gtfs/change-date nil}
     change))
-
-(spec/fdef transform-route-change
-           :args (spec/cat :all-routes vector? :route-change ::service-route-change-map :route-changes-all ::detected-route-changes-for-services-coll))
 
 (defn- route-change-type [max-date-in-past? added? removed-date changed? no-traffic? starting-week-date different-week-date
                           no-traffic-start-date no-traffic-end-date route]
@@ -744,6 +741,8 @@
       :default
       {:gtfs/change-type :no-change})))
 
+(spec/fdef transform-route-change
+           :args (spec/cat :all-routes vector? :route-change ::service-route-change-map :route-changes-all ::detected-route-changes-for-services-coll))
 (defn transform-route-change
   "Transform a detected route change into a database 'gtfs-route-change-info' type."
   [all-routes

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -196,7 +196,7 @@
   (->> (if beginning?
          weekhash
          (reverse weekhash))
-       (take-while nil?)
+       (take-while #(or (nil? %) (keyword? %)))
        count))
 
 (defn add-current-week-hash [to-key if-key state week]

--- a/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
@@ -6,6 +6,8 @@
             [ote.transit-changes.detection-test-utilities :as tu]
             [ote.time :as time]))
 
+(def change-window detection/route-end-detection-threshold)
+
 (def data-no-changes
   (tu/weeks (tu/to-local-date 2019 5 13) (tu/generate-traffic-week 9 ))) ;; Last week starts 2019 07 08
 
@@ -575,8 +577,6 @@
                         :min-date nil,
                         :max-date nil,
                         :route-hash-id tu/route-name-3}]])
-
-(def change-window detection/route-end-detection-threshold)
 
 (def data-ending-route-change
   (tu/weeks (tu/to-local-date 2019 5 13)


### PR DESCRIPTION
# Fixed
* transit-changes: on no-traffic detection ignore holiday keyworded days
* transit-changes: new test for route start
* transit-changes: cleanup old test case code
* transit-changes: detection code formatting 
