### PR TITLE
165815622 transit changes remove old logic funcs and remove unused operator route

### DIFF
--- a/docs/transit-changes/README.md
+++ b/docs/transit-changes/README.md
@@ -186,7 +186,7 @@ If algorithm does not find a different week, it returns just that there is traff
           This helps aligning the trip stop times next to each other so they can be easily compared. In the merging process, time differences of the trip stop time pairs are computed.  
           Any compared trip stop time that is not within 30 minute time window causes the algorithm to mark the
           trip either added or removed.  
-          (Reference: `route-day-changes-new` iterates changed weeks and adds day change comparison)
+          (Reference: `route-day-changes` iterates changed weeks and adds day change comparison)
        - **Stop sequence differences**  
          Stop sequence differences are computed per compared trip pair. The algorithm detects stops that are added or
          removed from a trip by comparing the stop sequences of the trips.

--- a/docs/transit-changes/README.md
+++ b/docs/transit-changes/README.md
@@ -125,7 +125,7 @@ User UI visualization of transit change detection results
    - `service-package-ids-for-date-range` 
 - **6**: Detect changes
    - latest transit package record for each service
-   - `detect-route-changes-for-service-new` parses route day hashes read from db and produces detection result vector per route.
+   - `detect-route-changes-for-service` parses route day hashes read from db and produces detection result vector per route.
    - `update-transit-changes!` does further analysis for results and implements the last steps of the detection logic.
 - **7:**  Store results to db
    - `update-transit-changes!` stores final results to db

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -100,7 +100,7 @@
               (detection/update-transit-changes!
                db today service-id
                (detection/service-package-ids-for-date-range db query-params)
-               (detection/detect-route-changes-for-service-new db query-params)))
+               (detection/detect-route-changes-for-service db query-params)))
             (catch Exception e
               (log/warn e "Change detection failed for service " service-id)))
           (log/info "Detection completed for service: " service-id))))))))

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -362,7 +362,7 @@
   ::detected-route-changes-for-services-coll
   (spec/coll-of ::service-route-change-map :kind vector?))
 
-(defn route-weeks-with-first-difference-new
+(defn route-weeks-with-first-difference
   "Detect the next different week in each route.
   NOTE! starting from the second week in the given route-weeks, the first given week is considered the \"prev\" week.
   Takes a list of weeks that have week hashes for each route.
@@ -442,7 +442,7 @@
   [route-weeks]
   (loop [route-weeks route-weeks
          results []]
-    (let [diff-data (route-weeks-with-first-difference-new route-weeks)
+    (let [diff-data (route-weeks-with-first-difference route-weeks)
           filtered-diff-data (first (filter (fn [value]
                                               (or (:no-traffic-start-date value) (:different-week value)))
                                             diff-data))

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -571,7 +571,7 @@
           []
           detection-results))
 
-(defn route-day-changes-new
+(defn route-day-changes
   "Takes a collection of routes and adds day change comparison details for those weeks which have :different-week"
   [db service-id routes]
   (let [route-day-changes
@@ -977,7 +977,7 @@
                            (detect-changes-for-all-routes)
                            (add-ending-route-change (java.time.LocalDate/now) route-end-detection-threshold all-routes)
                            ; Fetch detailed day details
-                           (route-day-changes-new db service-id))]
+                           (route-day-changes db service-id))]
          (spec/assert ::detected-route-changes-for-services-coll new-data)
          new-data)}
       (catch Exception e

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -946,9 +946,9 @@
 
 (def route-end-detection-threshold 90)
 
-(spec/fdef detect-route-changes-for-service-new
+(spec/fdef detect-route-changes-for-service
            :ret ::detected-route-changes-for-services-coll)
-(defn detect-route-changes-for-service-new [db {:keys [start-date service-id] :as route-query-params}]
+(defn detect-route-changes-for-service [db {:keys [start-date service-id] :as route-query-params}]
   "Input: Takes service-id,
   fetches and analyzes packages for the service and produces a collection of structures, each of which describes
   if a route has traffic or changes/no-traffic/ending-traffic, during a time period defined in the analysis logic.

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -243,7 +243,7 @@
       :default
       (dissoc state :no-traffic-start-date :no-traffic-run))))
 
-(defn add-no-traffic-run-dates-new
+(defn add-no-traffic-run-dates
   "
   state: map where analysis results per route and week are concatenated iteratively
   week: the week being analysed during this call,
@@ -275,9 +275,8 @@
     :default
     state))
 
-(defn- route-next-different-week-new
+(defn- route-next-different-week
   [{diff :different-week no-traffic-end-date :no-traffic-end-date :as state} route weeks curr last-analysis-wk]
-  ;; (println "route-next-different-week called with curr= " curr)
   (if (or diff no-traffic-end-date)
     ;; change already found, don't try again
     state
@@ -289,15 +288,12 @@
                      (assoc :route-key route)
                      ;; Detect no-traffic run
                      (detect-no-traffic-run route-week-hashes)
-                     (add-no-traffic-run-dates-new curr last-analysis-wk)
+                     (add-no-traffic-run-dates curr last-analysis-wk)
 
                      ;; Detect other traffic changes
                      (detect-change-for-route route-week-hashes route)
                      (add-starting-week curr)
                      (add-different-week curr))]
-      #_(if-let [dw (:different-week result)]
-          (println "route-next-different-week found something:" dw)
-          (println "no changes found from:" (:beginning-of-week (first weeks))))
       result)))
 
 (spec/def
@@ -388,7 +384,7 @@
                        ;; value under route key in r-d-s map will be updated by
                        ;; (route-next-different-week *value* route weeks curr)
                        (update route-detection-state route
-                               route-next-different-week-new route weeks curr (first (take-last 3 route-weeks))))
+                               route-next-different-week route weeks curr (first (take-last 3 route-weeks))))
                      route-detection-state
                      route-names))
                  {}                                         ; initial route detection state is empty

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -34,7 +34,6 @@
     ["/edit-service/:id" :edit-service]
     ["/services" :services]
     ["/services/:operator" :services]
-    ["/service-old/:transport-operator-id/:transport-service-id" :service]
     ["/service/:transport-operator-id/:transport-service-id" :service-view]
 
     ["/email-settings" :email-settings]

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -109,8 +109,7 @@
                      :label-style style-base/table-col-style-wrap
                      :show-row-hover? true
                      :on-select #(when (first %)
-                                   (do
-                                     (e! (tv/->SelectRouteForDisplay (first %)))))
+                                   (e! (tv/->SelectRouteForDisplay (first %))))
                      :row-selected? #(= (:different-week-date %) (:different-week-date selected-route))}
         [{:name "Aikaa muutokseen"
           :read :different-week-date

--- a/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
@@ -355,9 +355,9 @@
   (let [diff-maps (-> data-two-week-two-route-change
                       (detection/changes-by-week->changes-by-route)
                       (detection/detect-changes-for-all-routes))
-        fwd-difference-new (detection/route-weeks-with-first-difference data-two-week-two-route-change)]
+        fwd-difference (detection/route-weeks-with-first-difference data-two-week-two-route-change)]
     (testing "first change matches first-week-difference return value"
-      (is (= (-> fwd-difference-new second :different-week) (-> diff-maps first :different-week))))
+      (is (= (-> fwd-difference second :different-week) (-> diff-maps first :different-week))))
 
     (testing "second route's first change date is ok"
       (is (= (tu/to-local-date 2019 2 25)

--- a/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
@@ -312,7 +312,7 @@
                     (tu/generate-traffic-week 4 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] tu/route-name))))
 
 (deftest more-than-one-change-found
-  (spec-test/instrument `detection/route-weeks-with-first-difference-old)
+  (spec-test/instrument `detection/route-weeks-with-first-difference)
 
   ;; first test that the test data and old change detection code agree
   (testing "single-change detection code agrees with test data"
@@ -324,8 +324,7 @@
 
   (let [diff-maps (-> test-more-than-one-change
                       detection/changes-by-week->changes-by-route
-                      detection/detect-changes-for-all-routes)
-        old-diff-maps (detection/route-weeks-with-first-difference-old test-more-than-one-change)]
+                      detection/detect-changes-for-all-routes)]
     (testing "got two changes"
       (is (= 2 (count diff-maps))))
     (testing "first change is detected"
@@ -352,15 +351,12 @@
                   {tu/route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] tu/route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]}
                   {tu/route-name ["h1" "h2" "h3" "h4" "h5" "h6" "h7"] tu/route-name-2 ["h1" "h2" "h3" "h4" "h5" "h6" "h7"]})))
 
-(deftest more-than-one-change-found-w-2-routes
+(deftest test-two-week-two-route-change
   (let [diff-maps (-> data-two-week-two-route-change
                       (detection/changes-by-week->changes-by-route)
                       (detection/detect-changes-for-all-routes))
-
-        fwd-difference-old (detection/route-weeks-with-first-difference-old data-two-week-two-route-change)
         fwd-difference-new (detection/route-weeks-with-first-difference-new data-two-week-two-route-change)]
     (testing "first change matches first-week-difference return value"
-      (is (= (-> fwd-difference-old (get "Raimola") :different-week) (-> diff-maps first :different-week)))
       (is (= (-> fwd-difference-new second :different-week) (-> diff-maps first :different-week))))
 
     (testing "second route's first change date is ok"
@@ -370,7 +366,6 @@
                      :let [d (-> dp :different-week :beginning-of-week)]
                      :when (= "Esala" (:route-key dp))]
                  d)))))))
-
 
 (deftest no-change-found
   (spec-test/instrument `detection/route-weeks-with-first-difference-new)
@@ -460,18 +455,6 @@
     :end-of-week (java.time.LocalDate/parse "2019-07-14"),
     :routes {tu/route-name ["hneljas" "hneljas" "hneljas" "hneljas" nil nil nil]}}])
 
-;; this doesn't compile or work in normal "lein test" run due to the ote.main/ote reference, uncomment for repl use
-#_(deftest test-with-gtfs-package-of-a-service
-    (let [db (:db ote.main/ote)
-          route-query-params {:service-id 5 :start-date (time/parse-date-eu "18.02.2019") :end-date (time/parse-date-eu "06.07.2019")}
-          new-diff (detection/detect-route-changes-for-service-new db route-query-params)
-          old-diff (detection/detect-route-changes-for-service-old db route-query-params)]
-      ;; new-diff structure:
-      ;; :route-changes [ ( [ routeid {dada} ]) etc
-      (println (:start-date route-query-params))
-      (testing "differences between new and old"
-        (is (= old-diff new-diff)))))
-
 (deftest more-than-one-change-found-case-2
   (spec-test/instrument `detection/route-weeks-with-first-difference-new)
 
@@ -485,9 +468,7 @@
 
   (let [diff-maps (-> data-realworld-two-change-case
                       detection/changes-by-week->changes-by-route
-                      detection/detect-changes-for-all-routes)
-        old-diff-map (-> data-realworld-two-change-case
-                         detection/route-weeks-with-first-difference-old)]
+                      detection/detect-changes-for-all-routes)]
     (testing "got two changes"
       (is (= 2 (count diff-maps))))
 

--- a/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
+++ b/ote/test/clj/ote/transit_changes/detection_test_weeks.clj
@@ -176,7 +176,7 @@
             :no-traffic-change 17
             :no-traffic-start-date (tu/to-local-date 2018 11 13)
             :no-traffic-end-date (tu/to-local-date 2018 11 30)}
-           (-> (detection/route-weeks-with-first-difference-new data-no-traffic-run-weekdays)
+           (-> (detection/route-weeks-with-first-difference data-no-traffic-run-weekdays)
                first
                (select-keys tu/select-keys-detect-changes-for-all-routes))))))
 
@@ -212,7 +212,7 @@
 
 (deftest two-week-difference-is-skipped
   (is (nil?
-        (get-in (detection/route-weeks-with-first-difference-new test-traffic-2-different-weeks)
+        (get-in (detection/route-weeks-with-first-difference test-traffic-2-different-weeks)
                 [tu/route-name :different-week]))))
 
 (def data-one-week-difference-is-skipped
@@ -229,7 +229,7 @@
                   {tu/route-name ["h1" "h2" "h3" "h4" "!!" "h6" "!!"]}))) ; New schedule
 
 (deftest test-one-week-difference-is-skipped
-  (let [result (detection/route-weeks-with-first-difference-new data-one-week-difference-is-skipped)]
+  (let [result (detection/route-weeks-with-first-difference data-one-week-difference-is-skipped)]
     (is (= {:beginning-of-week (tu/to-local-date 2019 3 11)
             :end-of-week (tu/to-local-date 2019 3 17)}
            (:different-week (first result))
@@ -252,7 +252,7 @@
           :different-week {:beginning-of-week (tu/to-local-date 2018 10 22)
                            :end-of-week (tu/to-local-date 2018 10 28)}
           :route-key "Raimola"}
-         (first (detection/route-weeks-with-first-difference-new data-traffic-normal-difference)))))
+         (first (detection/route-weeks-with-first-difference data-traffic-normal-difference)))))
 
 (def test-traffic-starting-point-anomalous
   (tu/weeks (tu/to-local-date 2018 10 8)
@@ -263,7 +263,7 @@
 (deftest anomalous-starting-point-is-ignored
   (let [{:keys [starting-week different-week] :as res}
         (-> test-traffic-starting-point-anomalous
-            detection/route-weeks-with-first-difference-new
+            detection/route-weeks-with-first-difference
             first)]
     (is (= (tu/to-local-date 2018 10 22) (:beginning-of-week starting-week))); gets -15, should be -22
     (is (= "Raimola" (:route-key res)))
@@ -282,7 +282,7 @@
 
 (deftest static-holidays-are-skipped
   (let [{:keys [starting-week different-week] :as res}
-        (first (detection/route-weeks-with-first-difference-new test-traffic-static-holidays))]
+        (first (detection/route-weeks-with-first-difference test-traffic-static-holidays))]
 
     (testing "detection skipped christmas week"
       (is (= (tu/to-local-date 2018 12 31) (:beginning-of-week different-week))))
@@ -317,7 +317,7 @@
   ;; first test that the test data and old change detection code agree
   (testing "single-change detection code agrees with test data"
     (is (= (tu/to-local-date 2019 2 18) (-> test-more-than-one-change
-                                            detection/route-weeks-with-first-difference-new
+                                            detection/route-weeks-with-first-difference
                                             first
                                             :different-week
                                             :beginning-of-week))))
@@ -355,7 +355,7 @@
   (let [diff-maps (-> data-two-week-two-route-change
                       (detection/changes-by-week->changes-by-route)
                       (detection/detect-changes-for-all-routes))
-        fwd-difference-new (detection/route-weeks-with-first-difference-new data-two-week-two-route-change)]
+        fwd-difference-new (detection/route-weeks-with-first-difference data-two-week-two-route-change)]
     (testing "first change matches first-week-difference return value"
       (is (= (-> fwd-difference-new second :different-week) (-> diff-maps first :different-week))))
 
@@ -368,7 +368,7 @@
                  d)))))))
 
 (deftest no-change-found
-  (spec-test/instrument `detection/route-weeks-with-first-difference-new)
+  (spec-test/instrument `detection/route-weeks-with-first-difference)
 
   (let [diff-maps (-> data-two-week-change
                       detection/changes-by-week->changes-by-route
@@ -456,12 +456,12 @@
     :routes {tu/route-name ["hneljas" "hneljas" "hneljas" "hneljas" nil nil nil]}}])
 
 (deftest more-than-one-change-found-case-2
-  (spec-test/instrument `detection/route-weeks-with-first-difference-new)
+  (spec-test/instrument `detection/route-weeks-with-first-difference)
 
   ;; first test that the test data and old change detection code agree
   (testing "single-change detection code agrees with test data"
     (is (= (tu/to-local-date 2019 5 27) (-> data-realworld-two-change-case
-                                            detection/route-weeks-with-first-difference-new
+                                            detection/route-weeks-with-first-difference
                                             first
                                             :different-week
                                             :beginning-of-week))))


### PR DESCRIPTION
# Changed
* transit-changes: rename route-day-changes-new remove -new
transit-changes: rename detect-route-changes-for-service-new remove -new 
transit-changes: rename route-weeks-with-first-difference remove -new
transit-changes: rename route-next-different-week-new remove -new
transit-changes: remove legacy detection functions for route wks & days
transit-changes: remove legacy detection functions for route weeks
views: transit-visualization cleanup code
* 4b76177 transport-operator: remove unused REST route