### PR TITLE
Transit_visualization: Removed unnecessary check and fixed date1 check

### DIFF
--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -386,15 +386,15 @@
                   (not (nil? (get (:calendar response) (str (time/date-to-str-date (time/now)))))))
                 (time/now)
 
-                ;; No-traffic route, return current day always
-                (= :no-traffic (:change-type route))
+                ;; No-traffic route, return current day when the no-traffic start is in the past
+                (and
+                  (= :no-traffic (:change-type route))
+                  (t/after? (time/now) date1))
                 (time/now)
 
                 :else
                 date1)
-        date2 (if (and
-                    (:different-week-date route)
-                    (not= :no-traffic (:change-type route)))
+        date2 (if (:different-week-date route)
                   (:different-week-date route)
                   (time/days-from (tc/from-date (time/native->date-time date1)) 7))]
     (-> app

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -394,9 +394,9 @@
 
                 :else
                 date1)
-        date2 (if (:different-week-date route)
-                  (:different-week-date route)
-                  (time/days-from (tc/from-date (time/native->date-time date1)) 7))]
+        date2 (if-let [date2 (:different-week-date route)]
+                date2
+                (time/days-from (tc/from-date (time/native->date-time date1)) 7))]
     (-> app
         (assoc-in [:transit-visualization :route-lines-for-date-loading?] true)
         (assoc-in [:transit-visualization :route-trips-for-date1-loading?] true)


### PR DESCRIPTION
When we are currently in a pause in traffic use current date as date1.

# Fixed
* Selected date problem in no-traffic situations.
