### PR TITLE
Caret for info

### DIFF
--- a/ote/src/cljs/ote/style/buttons.cljs
+++ b/ote/src/cljs/ote/style/buttons.cljs
@@ -11,7 +11,7 @@
 
 (def outline-btn-hover-focus
   {:text-decoration "none"
-   :border-width "2px"
+   :outline (str "1px solid " colors/primary)
    :box-shadow "1px 1px 2px 0 rgba(0, 0, 0, .2)"
    :transform "scale(0.98)"})
 
@@ -71,6 +71,7 @@
          {:background-color "white"
           :color colors/primary
           :border "1px solid"
+          :cursor "pointer"
           :border-color colors/primary
           ::stylefy/mode {:hover outline-btn-hover-focus
                           :focus outline-btn-hover-focus

--- a/ote/src/cljs/ote/ui/info.cljs
+++ b/ote/src/cljs/ote/ui/info.cljs
@@ -9,19 +9,24 @@
 
 (defn info-toggle
   "Displays a clickable area that opens to show more info. Can be given default parameter for open state.
-  In options can recieve info for :atom, :default-open?, :icon"
+  Can recieve options for :default-open?, :icon"
   ([title inner-component]
    (info-toggle title inner-component {:default-open? true}))
   ([title inner-component options]
-   (let [is-open? (or (:atom options) (r/atom (:default-open? options)))]
+   (let [is-open? (r/atom (:default-open? options))]
      (fn []
        [:div (stylefy/use-style style-info/info-container)
         [:button (merge (stylefy/use-style style-info/info-button)
                         {:on-click #(swap! is-open? not)})
+         [:span {:style {:margin-right "0.5rem"}}
+          (if @is-open?
+            [ic/hardware-keyboard-arrow-up]
+            [ic/hardware-keyboard-arrow-down])]
          [:span (stylefy/use-style style-info/info-icon)
           (if-let [icon (:icon options)]
             icon
-            [ic/action-help])] title]
+            [ic/action-help])]
+         title]
         [:div
          (if @is-open?
            (stylefy/use-style style-info/info-open)

--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -39,9 +39,7 @@
             [ote.style.dialog :as style-dialog]))
 
 (def ic-warning [ic/alert-warning {:style {:color colors/negative-button
-                                           :margin-left "0.5rem"
                                            :margin-bottom "5px"}}])
-
 
 (defn delete-service-action [e! {::t-service/keys [id name]
                                  :keys [show-delete-modal?]
@@ -81,7 +79,7 @@
         {:service-name name
          :error :no-schedule-sea}))))
 
-(defn transport-services-table-rows [e! services transport-operator-id info-open?]
+(defn transport-services-table-rows [e! services transport-operator-id]
   [ui/table-body {:class "table-body"
                   :display-row-checkbox false}
    (doall
@@ -99,13 +97,9 @@
            (if (service-errors row)
              [:span (stylefy/use-style style-base/icon-with-text)
               (tr [:field-labels :transport-service ::t-service/published?-values (some? published)])
-              [:button {:style {:border 0
-                                :background "none"
-                                :cursor "pointer"}
-                        :on-click #(swap! info-open? not)}
-               [ic/alert-warning {:style {:color colors/negative-button
-                                          :margin-left "0.5rem"
-                                          :margin-bottom "5px"}}]]]
+              [ic/alert-warning {:style {:color colors/negative-button
+                                         :margin-left "0.5rem"
+                                         :margin-bottom "5px"}}]]
              (tr [:field-labels :transport-service ::t-service/published?-values (some? published)]))]
           [ui/table-row-column {:class "hidden-xs hidden-sm "} (time/format-timestamp-for-ui modified)]
           [ui/table-row-column {:class "hidden-xs hidden-sm "} (time/format-timestamp-for-ui created)]
@@ -129,7 +123,7 @@
        services))])
 
 (defn- route-error
-  [errors info-open?]
+  [errors]
   (let [error-keys (reduce
                      (fn [set error]
                        (conj set (:error error)))
@@ -169,7 +163,7 @@
          [:strong (tr [:enums ::t-service/transport-type :sea]) " • "]
          [linkify "/#/routes" (tr [:own-services-page :open-sea-rae]) {:target "_blank"}]])]
      {:icon ic-warning
-      :atom info-open?}]))
+      :default-open? true}]))
 
 (defn transport-services-listing [e! transport-operator-id services section-label]
   (when (> (count services) 0)
@@ -177,8 +171,7 @@
                    #(not (nil? %))
                    (map
                      service-errors
-                     services))
-          info-open? (r/atom false)]
+                     services))]
       [:div.row (stylefy/use-style style-base/section-margin)
        [:div {:class "col-xs-12 col-md-12"}
         [:h4 section-label]
@@ -193,10 +186,10 @@
            [ui/table-header-column {:class "hidden-xs hidden-sm table-header"} (tr [:front-page :table-header-service-url])]
            [ui/table-header-column {:class "table-header "} (tr [:front-page :table-header-actions])]]]
 
-         (transport-services-table-rows e! services transport-operator-id info-open?)]
+         (transport-services-table-rows e! services transport-operator-id)]
         [:div {:style {:margin-top "2rem"}}
          (when (not-empty errors)
-           (route-error errors info-open?))]]])))
+           (route-error errors))]]])))
 
 (defn warn-about-test-server []
   (let [page-url (-> (.-location js/window))]

--- a/ote/src/cljs/ote/views/place_search.cljs
+++ b/ote/src/cljs/ote/views/place_search.cljs
@@ -35,7 +35,7 @@
          (let [old (aget chip "handleKeyDown")]
            (aset chip "handleKeyDown"
                  (fn [event]
-                   (when-not (= 8 event.keyCode)
+                   (when-not (= 8 event.keyCode)            ;8 = backspace
                      (old event))))
            (aset chip "__backspace_monkey_patch" true)))))))
 
@@ -65,7 +65,7 @@
                 :value namefin
                 :floating-label-text (tr [:place-search :rename-place])
                 :on-key-press (fn [event]
-                                (when (= 13 event.charCode)
+                                (when (= 13 event.charCode) ;charCode 13 = ENTER
                                   (e! (ps/->EditDrawnGeometryName id))))
                 :on-change #(e! (ps/->SetDrawnGeometryName id %2))}]
               namefin)]])])}))


### PR DESCRIPTION
# Added
* A caret for info-toggle to indicate it's clickable
   
# Fixed
* event handlers in place-search so that they don't break figwheel hot-reloading.
* Button styles, so that the extra border pixel on hover doesn't cause the button to take up more space.
   
# Removed
* Ability to pass atom to info-toggle, because it was just more confusing and the only use case where it was used was no longer necessary.

