### PR TITLE
own-service: fixed bug with service errors.

### DIFF
--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -17,8 +17,5 @@ SELECT ts.id,
                  JOIN LATERAL unnest(eid."data-content") dc ON TRUE
         WHERE ts.id = eid."transport-service-id") as "interface-types"
 FROM "transport-service" ts
-         LEFT JOIN "external-interface-description" eid on (ts.id = eid."transport-service-id")
-         LEFT JOIN LATERAL unnest("data-content") types ON true
 WHERE ts."transport-operator-id" in (:operator-ids)
-GROUP BY ts.id
 ORDER BY ts."type" DESC, ts.modified DESC NULLS LAST;

--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -19,6 +19,6 @@ SELECT ts.id,
 FROM "transport-service" ts
          LEFT JOIN "external-interface-description" eid on (ts.id = eid."transport-service-id")
          LEFT JOIN LATERAL unnest("data-content") types ON true
-WHERE ts."transport-operator-id" in (:operator)
+WHERE ts."transport-operator-id" in (:operator-ids)
 GROUP BY ts.id
 ORDER BY ts."type" DESC, ts.modified DESC NULLS LAST;

--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -15,7 +15,7 @@ SELECT ts.id,
        (SELECT array_agg(dc)
           FROM "external-interface-description" eid
                JOIN LATERAL unnest(eid."data-content") dc ON TRUE
-        WHERE ts.id = eid."transport-service-id") as "interface-types"
+         WHERE ts.id = eid."transport-service-id") as "interface-types"
   FROM "transport-service" ts
  WHERE ts."transport-operator-id" in (:operator-ids)
  ORDER BY ts."type" DESC, ts.modified DESC NULLS LAST;

--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -4,15 +4,21 @@ SELECT description FROM "group" WHERE id = :id;
 
 -- name: fetch-transport-services
 SELECT ts.id,
-    ts."transport-operator-id",
-    ts."name",
-    ts."type",
-    ts."sub-type",
-    ts."published",
-    ts."created",
-    ts."modified",
-    ts."transport-type",
-    eid."data-content" as "interface-types"
-FROM "transport-service" ts LEFT OUTER JOIN "external-interface-description" eid on (ts.id = eid."transport-service-id")
-WHERE ts."transport-operator-id" in (:operator-ids)
+       ts."transport-operator-id",
+       ts."name",
+       ts."type",
+       ts."sub-type",
+       ts."published",
+       ts."created",
+       ts."modified",
+       ts."transport-type",
+       (SELECT array_agg(dc)
+        FROM "external-interface-description" eid
+                 JOIN LATERAL unnest(eid."data-content") dc ON TRUE
+        WHERE ts.id = eid."transport-service-id") as "interface-types"
+FROM "transport-service" ts
+         LEFT JOIN "external-interface-description" eid on (ts.id = eid."transport-service-id")
+         LEFT JOIN LATERAL unnest("data-content") types ON true
+WHERE ts."transport-operator-id" in (:operator)
+GROUP BY ts.id
 ORDER BY ts."type" DESC, ts.modified DESC NULLS LAST;

--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -13,9 +13,9 @@ SELECT ts.id,
        ts."modified",
        ts."transport-type",
        (SELECT array_agg(dc)
-        FROM "external-interface-description" eid
-                 JOIN LATERAL unnest(eid."data-content") dc ON TRUE
+          FROM "external-interface-description" eid
+               JOIN LATERAL unnest(eid."data-content") dc ON TRUE
         WHERE ts.id = eid."transport-service-id") as "interface-types"
-FROM "transport-service" ts
-WHERE ts."transport-operator-id" in (:operator-ids)
-ORDER BY ts."type" DESC, ts.modified DESC NULLS LAST;
+  FROM "transport-service" ts
+ WHERE ts."transport-operator-id" in (:operator-ids)
+ ORDER BY ts."type" DESC, ts.modified DESC NULLS LAST;


### PR DESCRIPTION
Duplicated the service if it had many interfaces.

   
# Fixed
* own services page showed error if a service had multiple interfaces and one of the wasn't type `route-and-schedule`

