### PR TITLE
165877303 Fix empty area in change email

### DIFF
--- a/ote/src/clj/ote/tasks/pre_notices.sql
+++ b/ote/src/clj/ote/tasks/pre_notices.sql
@@ -42,6 +42,7 @@ SELECT * FROM (
                   AND (p."finnish-regions" IS NULL OR
                        :regions::CHAR(2)[] IS NULL OR
                        :regions::CHAR(2)[] && p."finnish-regions")
+                GROUP BY h.id,p."finnish-regions", op.name, ts.name,ts.id
               ) x
  ORDER BY x."different-week-date" ASC;
 


### PR DESCRIPTION
# Fixed
* Add group by clause for fetch-unsent-changes-by-regions query to enable multiple package-ids to be used when area is fetched
   
