### PR TITLE
Table: fixed table body padding.

### DIFF
--- a/ote/src/cljs/ote/ui/table.cljs
+++ b/ote/src/cljs/ote/ui/table.cljs
@@ -28,13 +28,14 @@
     [ui/table (merge
                 {:wrapperStyle {:overflow "visible"}
                  :header-style {:border (str "solid 3px " colors/gray400)}
+                 :body-style {:padding "3px"}
                  ;; FIXME: When we have tooltips in header labels, body does not need overflow: visible.
                  ;;        But, if any row includes tooltips, the body must also have visible overflow.
                  ;;        For now, leaving this commented out.
                  ;:bodyStyle {:overflow "visible"}
                  }
                 (when no-selection?
-                  :body-style {:padding "3px"})
+                  {:body-style {:padding 0}})
                 (when on-select
                   {:on-row-selection (fn [selected-rows]
                                        (when (seq selected-rows)


### PR DESCRIPTION
# Fixed
* no-selection? keyword check was implemented wrong. So the padding was never given to tables, so the border on selected rows wasn't showing properly.