### PR TITLE
165675611 admin service endpoint refactoring 2

### DIFF
--- a/ote/src/clj/ote/components/http.clj
+++ b/ote/src/clj/ote/components/http.clj
@@ -15,7 +15,8 @@
             [ring.middleware.session.cookie :as session-cookie]
             [ote.localization :as localization]
             [ring.middleware.cookies :as cookies]
-            [cheshire.core :as cheshire]))
+            [cheshire.core :as cheshire]
+            [ote.util.fn :as ote-fn]))
 
 (defn- serve-request [handlers req]
   (some #(% req) handlers))
@@ -178,11 +179,18 @@
       (json-response data)
       (transit-response data))))
 
-
 (defn transit-request
   "Parse HTTP POST body as Transit data."
   [in]
   (transit/transit->clj in))
+
+;; Input: spec=spec which validates params, params=map to validate against spec
+;; Output: http response if params are not valid, nil if params are valid.
+(defn response-bad-args [spec params]
+  (when-let [error-str (ote-fn/form-validation-error-str spec params)]
+    (transit-response
+      (str "Invalid argument(s): " error-str)
+      400)))
 
 (defrecord SslUpgrade [ip port url]
   component/Lifecycle

--- a/ote/src/clj/ote/services/admin.clj
+++ b/ote/src/clj/ote/services/admin.clj
@@ -34,7 +34,9 @@
             [ote.services.external :as external]
             [ote.tasks.pre-notices :as pn]
             [hiccup.core :refer [html]]
-            [ote.email :as email]))
+            [ote.email :as email]
+            [clojure.spec.alpha :as spec]
+            [ote.util.collections :as ote-coll]))
 
 (defqueries "ote/services/admin.sql")
 (defqueries "ote/services/reports.sql")
@@ -62,7 +64,7 @@
 
 (defn- authorization-fail-response [user]
   (when-not (:admin? user)
-    (log/warn "authorization-fail-response: id=" (:id user))
+    (log/info  "authorization-fail-response: id=" (:id user))
     (http/transit-response "Not authorized. Bad role." 403)))
 
 (defn- admin-service [route {user :user
@@ -71,35 +73,39 @@
   (http/transit-response
     (handler db user (http/transit-request form-data))))
 
-(defn- list-users-bad-req-response [search type]
-  ;; list-users-response supports only "any" type at the moment
-  (when (not= "any" type)
-    (log/warn "list-users-bad-req-response: type=" type)
-    (http/transit-response "Type not supported" 400)))
+(spec/def :list-users/type #(= "any" %))
+(spec/def :list-users/search string?)
+(spec/def ::list-users-params-map
+  (spec/keys
+    :opt-un [:list-users/type :list-users/search]))
 
-;; Validate input in list-users-bad-req-response
-(defn- list-users-response [db search]
-  (let [result (->> (nap-users/list-users db {:email (str "%" search "%")
-                                              :name (str "%" search "%")
-                                              :group (str "%" search "%")
-                                              :transit-authority? nil})
-                    (mapv
-                      (fn [{groups :groups :as user}]
-                        (if groups
-                          (assoc user :groups (cheshire/parse-string (.getValue groups) keyword))
-                          user))))]
+;; query users service domain logic
+(defn- list-users-response [db {search :search :as params}]
+  (or
+    (http/response-bad-args ::list-users-params-map params)
 
-    (http/transit-response
-      result
-      (if (pos-int? (count result))
-        200
-        404))))
+    (let [result (->> (nap-users/list-users db {:email (str "%" search "%")
+                                                :name (str "%" search "%")
+                                                :group (str "%" search "%")
+                                                :transit-authority? nil})
+                      (mapv
+                        (fn [{groups :groups :as user}]
+                          (if groups
+                            (assoc user :groups (cheshire/parse-string (.getValue groups) keyword))
+                            user))))]
 
+      (http/transit-response
+        result
+        (if (pos-int? (count result))
+          200
+          404)))))
+
+;; domain logic for delete user service
 (defn- delete-user-response
   "Description: Deletes a user
   Input: db=database instance, id=id of record to delete
   Output: Number or affected records, thus 0 means a failure."
-  [db ^Long id]
+  [db ^String id]
   (let [affected-records (nap-users/delete-user! db {:id (str id)
                                                      :name (java.util.Date.)})]
     (log/info "Delete user id: " (pr-str id), ", records affected=" affected-records)
@@ -109,11 +115,25 @@
         200
         404))))
 
-(defn- user-operator-members [db user query]
-  (let [user-id (:id query)
-        members (vec (nap-users/search-user-operators-and-members db {:user-id user-id}))]
-    (mapv (fn [x]
-            (update x :members #(db-util/PgArray->vec %))) members)))
+(spec/def :user-memberships/userid (spec/and string? some?))
+(spec/def ::user-memberships-params-map
+  (spec/keys
+    :req-un [:user-memberships/userid]))
+
+;; domain logic for query user membership service
+(defn- user-operator-memberships-response [db params]
+  (or
+    (http/response-bad-args ::user-memberships-params-map params)
+
+    (let [members (vec (nap-users/search-user-operators-and-members db {:user-id (:userid params)}))
+          res (when (pos? (count members))
+                (mapv (fn [x]
+                        (update x :members #(db-util/PgArray->vec %))) members))]
+      (http/transit-response
+        res
+        (if (seq res)
+          200
+          404)))))
 
 (defn- published-search-param [query]
   (case (:published-type query)
@@ -469,17 +489,17 @@
 (defn- admin-routes [db http nap-config email-config]
   (routes
 
-    (GET "/admin/user" [search type :as req]
+    (GET "/admin/user" req
       (or (authorization-fail-response (get-in req [:user :user]))
-          (list-users-bad-req-response search type)
-          (list-users-response db search)))
+          (list-users-response db (ote-coll/map->keyed (:params req)))))
 
     (DELETE "/admin/user/:id" [id :as req]
-      (let [id (Long/parseLong id)]                         ;; Parse id for security before passing to db operations
-        (or (authorization-fail-response (get-in req [:user :user]))
-            (delete-user-response db id))))
+      (or (authorization-fail-response (get-in req [:user :user]))
+          (delete-user-response db id)))
 
-    (POST "/admin/user-operator-members" req (admin-service "user-operators" req db #'user-operator-members))
+    (GET "/admin/member" req
+      (or (authorization-fail-response (get-in req [:user :user]))
+          (user-operator-memberships-response db (ote-coll/map->keyed (:params req)))))
 
     (POST "/admin/transport-services" req (admin-service "services" req db #'list-services))
 

--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -11,7 +11,6 @@
             [specql.impl.composite :as composite]
             [specql.impl.registry :as specql-registry]
             [ote.util.fn :refer [flip]]
-            [ote.util.clojure :as util-clj]
             [ote.transit-changes.detection :as detection]
             [clojure.set :as set]
             [digest]))

--- a/ote/src/clj/ote/util/clojure.clj
+++ b/ote/src/clj/ote/util/clojure.clj
@@ -1,4 +1,0 @@
-(ns ote.util.clojure)
-
-(defn remove-coll-key-ns [c]
-  (into {} (map (fn [[k v]] [(keyword (name k)) v]) c)))

--- a/ote/src/cljc/ote/util/collections.cljc
+++ b/ote/src/cljc/ote/util/collections.cljc
@@ -35,3 +35,14 @@
       c
       (recur (+ c (if (pred (first coll)) 1 0))
              (rest coll)))))
+
+(defn remove-coll-key-ns [c]
+  (into {} (map (fn [[k v]] [(keyword (name k)) v]) c)))
+
+;; Input: coll=map
+;; Output: coll, where keys are converted to keywords
+(defn map->keyed [coll]
+  (into {} (map
+             (fn [[key val]]
+               [(keyword key) val])
+             coll)))

--- a/ote/src/cljc/ote/util/fn.cljc
+++ b/ote/src/cljc/ote/util/fn.cljc
@@ -1,8 +1,15 @@
 (ns ote.util.fn
-  "Utilities for working with functions")
+  "Utilities for working with functions"
+  (:require
+    [clojure.spec.alpha :as spec]))
 
 (defn flip
   "Flip argument order of given 2 argument function."
   [fun]
   (fn [a b]
     (fun b a)))
+
+;; Output: nil if form `f` validates against `s`, spec explain error string if not.
+(defn form-validation-error-str [s f]
+  (when-not (spec/valid? s f)
+    (spec/explain-str s f)))

--- a/ote/src/cljs/ote/app/controller/admin.cljs
+++ b/ote/src/cljs/ote/app/controller/admin.cljs
@@ -158,7 +158,8 @@
     (if (= id (:ensured-id (get-user-by-id app id)))
       (comm/delete! (str "admin/user/" id)
                     nil
-                    {:on-success (tuck/send-async! ->ConfirmDeleteUserResponse)})
+                    {:on-success (tuck/send-async! ->ConfirmDeleteUserResponse)
+                     :on-failure (tuck/send-async! ->ConfirmDeleteUserResponseFailure)})
       (.log js/console "Could not delete user! Check given id:" id))
     app)
 

--- a/ote/src/cljs/ote/app/controller/admin.cljs
+++ b/ote/src/cljs/ote/app/controller/admin.cljs
@@ -147,9 +147,11 @@
 
   SearchUsers
   (process-event [_ app]
-    (comm/get! (str "admin/user?type=any&search=" (get-in app [:admin :user-listing :user-filter]))
-                {:on-success (tuck/send-async! ->SearchUsersResponse)
-                 :on-failure (tuck/send-async! ->SearchUsersResponse)})
+    (let [filter (get-in app [:admin :user-listing :user-filter])]
+      (comm/get! (str "admin/user"
+                      (when filter (str "?type=any&search=" filter)))
+                 {:on-success (tuck/send-async! ->SearchUsersResponse)
+                  :on-failure (tuck/send-async! ->SearchUsersResponse)}))
     (assoc-in app [:admin :user-listing :loading?] true))
 
   ConfirmDeleteUser
@@ -157,8 +159,7 @@
     (if (= id (:ensured-id (get-user-by-id app id)))
       (comm/delete! (str "admin/user/" id)
                     nil
-                    {:on-success (tuck/send-async! ->ConfirmDeleteUserResponse)
-                     :on-failure (tuck/send-async! ->ConfirmDeleteUserResponseFailure)})
+                    {:on-success (tuck/send-async! ->ConfirmDeleteUserResponse)})
       (.log js/console "Could not delete user! Check given id:" id))
     app)
 
@@ -183,8 +184,8 @@
 
   OpenDeleteUserModal
   (process-event [{id :id} app]
-    (comm/post! "admin/user-operator-members" {:id id}
-                {:on-success (tuck/send-async! ->OpenDeleteUserModalResponse id)})
+    (comm/get! (str "admin/member?userid=" id)
+               {:on-success (tuck/send-async! ->OpenDeleteUserModalResponse id)})
     app)
 
   OpenDeleteUserModalResponse

--- a/ote/src/cljs/ote/app/controller/admin.cljs
+++ b/ote/src/cljs/ote/app/controller/admin.cljs
@@ -102,12 +102,11 @@
 
 (defn- update-user-by-id [app id update-fn & args]
   (update-in app [:admin :user-listing :results]
-             (fn [operators]
+             (fn [users]
                (map #(if (= (:id %) id)
                        (apply update-fn % args)
                        %)
-                    operators))))
-
+                    users))))
 
 (defn- get-search-result-operator-by-id [app id]
   (some

--- a/ote/src/cljs/ote/views/admin/users.cljs
+++ b/ote/src/cljs/ote/views/admin/users.cljs
@@ -62,7 +62,7 @@
                                       (e! (admin-controller/->ConfirmDeleteUser id)))}]))]}
         [:div
          (if (some false? admin-list)
-           [:p "Ei voida poistaa käyttäjää."]
+           [:p "Ei voi poistaa käyttäjää."]
            [:div
             [:p "Oletko varma, että haluat poistaa käyttäjän?"]
             [:p (str "Käyttäjän id: " id)]


### PR DESCRIPTION
# Added
Utility funcs used in REST endpoint implementation:
* http: generic func for returning http error if map spec validation fails
* util: spec validation function with error string output on fail

# Changed
admin REST endpoint refactoring: 
* controller: admin refactoring rename misleading symbol name
* controller: admin user-operator-members api renamed as member, refactoring
* services: admin user-operator-members api renamed as member, refactoring
* views: admin view typo fix

Other minor cleanup
* util: deleted clojure.clj, content moved to ote.util.collections
* services: transit-visualization remove unused ote.util.clojure require
* util: moved remove-coll-key-ns to existing more suitable namespace
