### PR TITLE
166113289 bugfix transit visualization calendar wrong header diff stats and similar improvements

### DIFF
--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -46,7 +46,10 @@
        (not route-calendar-hash-loading?)
        (not route-differences-loading?)
        (not routes-for-dates-loading?)
-       (not service-changes-for-dates-loading?)))
+       (not service-changes-for-dates-loading?)
+       ;; Hide trip and stop comparison elements until both compared trip datas are available, to avoids runtime errors
+       ;; and to avoid displaying invalid data.
+       (some? (get-in transit-visualization [:compare :date2]))))
 
 (defn parse-date [date-str]
   (tf/parse (tf/formatter "dd.MM.yyyy") date-str))
@@ -309,20 +312,23 @@
 ;; Routes trip data
 (define-event RouteTripsForDateResponse [trips date]
   {:path [:transit-visualization]}
-  (let [app (combine-trips
-              (cond
-                (= date (get-in app [:compare :date1]))
-                (-> app
-                    (assoc :route-trips-for-date1-loading? false)
-                    (assoc-in [:compare :date1-trips] trips))
+  (let [app (cond
+          (= date (get-in app [:compare :date1]))
+          (-> app
+              (assoc :route-trips-for-date1-loading? false)
+              (assoc-in [:compare :date1-trips] trips))
 
-                (= date (get-in app [:compare :date2] app))
-                (-> app
-                    (assoc :route-trips-for-date2-loading? false)
-                    (assoc-in [:compare :date2-trips] trips))
+          (= date (get-in app [:compare :date2] app))
+          (-> app
+              (assoc :route-trips-for-date2-loading? false)
+              (assoc-in [:compare :date2-trips] trips))
 
-                :default
-                app))]
+          :default
+          app)
+        app (if (loaded-from-server? app)
+              ;; Combine only after all data available to avoid rendering incorrect numbers
+              (combine-trips app)
+              app)]
     ;; Wait until both trips are loaded
     ;; No need to render trips and stops while they are not ready
     (if (and (not (:route-trips-for-date1-loading? app))
@@ -330,7 +336,7 @@
       (select-first-trip app)
       app)))
 
-(defn fetch-trip-data-for-dates [compare service-id route date1 date2]
+(defn fetch-trip-data-for-dates [{:keys [compare] :as t-vis} service-id route date1 date2]
   (doseq [date [date1 date2]
           :let [params (merge {:date (time/format-date-iso-8601 date)
                                :route-hash-id (ensure-route-hash-id route)}
@@ -347,15 +353,20 @@
     (comm/get! (str "transit-visualization/" service-id "/route-trips-for-date")
                {:params params
                 :on-success (tuck/send-async! ->RouteTripsForDateResponse date)}))
-  (assoc compare
-    :show-route-lines {}
-    :date1 date1
-    :date2 date2
-    :date1-route-lines nil
-    :date2-route-lines nil
-    :date1-trips nil
-    :date2-trips nil
-    :show-stops? true))
+  (-> t-vis
+      (assoc :compare
+             (assoc compare
+               :show-route-lines {}
+               :date1 date1
+               :date2 date2
+               :date1-route-lines nil
+               :date2-route-lines nil
+               :date1-trips nil
+               :date2-trips nil
+               :show-stops? true
+               :differences nil)
+             :route-trips-for-date1-loading? true
+             :route-trips-for-date2-loading? true)))
 
 ;; When route type is :no-change we need to find date that has traffic
 (defn- get-next-best-day-for-no-change [start-date current-date direction calendar-days]
@@ -415,18 +426,16 @@
                 date2
                 (time/days-from (tc/from-date (time/native->date-time date1)) 7))]
     (-> app
+        ;; Clear flag here only after data is available for rendering, earlier clearing would render first old data to view
+        (assoc-in [:transit-visualization :route-dates-selected-from-calendar?] false)
         (assoc-in [:transit-visualization :route-lines-for-date-loading?] true)
-        (assoc-in [:transit-visualization :route-trips-for-date1-loading?] true)
-        (assoc-in [:transit-visualization :route-trips-for-date2-loading?] true)
         (assoc-in [:transit-visualization :selected-route] route)
         (update-in [:transit-visualization :compare] dissoc
                    :selected-trip-pair
                    :combined-trips
                    :combined-stop-sequence)
         (update-in [:transit-visualization] dissoc :date->hash :hash->color)
-        (update-in [:transit-visualization :compare] fetch-trip-data-for-dates
-                   service-id route
-                   date1 date2)
+        (update-in [:transit-visualization] fetch-trip-data-for-dates service-id route date1 date2)
         (assoc-in [:transit-visualization :compare :differences]
                   (select-keys route #{:added-trips :removed-trips
                                        :trip-stop-sequence-changes-lower
@@ -447,10 +456,15 @@
       (assoc-in [:transit-visualization :route-differences-loading?] false)
       (assoc-in [:transit-visualization :compare :differences] response)))
 
+(defn- remove-date2-keys [coll]
+  (-> coll
+      (assoc :date2 nil
+             :date2-trips nil
+             :date2-route-lines nil)))
+
 (define-event SelectDatesForComparison [date]
               {}
               (let [service-id (get-in app [:params :service-id])
-                    compare (or (get-in app [:transit-visualization :compare]) {})
                     date1 (get-in app [:transit-visualization :compare :date1])
                     date2 (get-in app [:transit-visualization :compare :date2])
                     route (get-in app [:transit-visualization :selected-route])
@@ -460,10 +474,10 @@
                     earlier-date (if date-after-date1? date1 date)
                     later-date (if date-after-date1? date date1)]
                 (cond
-                  (or (and date1 date2) (t/equal? goog-date1 goog-date))
+                  (or (and date1 date2) (t/equal? goog-date1 goog-date)) ;; Re-selection of day pair after to replace previous day pair selection
                   (-> app
                       (assoc-in [:transit-visualization :compare :date1] date)
-                      (assoc-in [:transit-visualization :compare :date2] nil))
+                      (update-in [:transit-visualization :compare] remove-date2-keys))
 
                   (nil? date2)
                   (do
@@ -479,8 +493,9 @@
                                   earlier-date)
                         (assoc-in [:transit-visualization :compare :date2]
                                   later-date)
-                        (assoc-in [:transit-visualization :compare]
-                                  (fetch-trip-data-for-dates compare service-id
+                        (assoc-in [:transit-visualization]
+                                  (fetch-trip-data-for-dates (:transit-visualization app)
+                                                             service-id
                                                              route
                                                              earlier-date
                                                              later-date)))))))
@@ -490,7 +505,9 @@
   (comm/get! (str "transit-visualization/" (get-in app [:params :service-id]) "/route")
              {:params  {:route-hash-id (ensure-route-hash-id route)}
               :on-success (tuck/send-async! ->RouteCalendarDatesResponse route)})
-  (assoc-in app [:transit-visualization :route-calendar-hash-loading?] true))
+  (-> app
+      (assoc-in [:transit-visualization :route-calendar-hash-loading?] true)
+      (assoc-in [:transit-visualization :compare :differences] nil)))
 
 (define-event ToggleRouteDisplayDate [date]
   {:path [:transit-visualization :compare]}
@@ -503,7 +520,6 @@
 
     :default
     app))
-
 
 (define-event ToggleDifferent []
   {:path [:transit-visualization :compare :different?]}

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -477,7 +477,8 @@
                   (or (and date1 date2) (t/equal? goog-date1 goog-date)) ;; Re-selection of day pair after to replace previous day pair selection
                   (-> app
                       (assoc-in [:transit-visualization :compare :date1] date)
-                      (update-in [:transit-visualization :compare] remove-date2-keys))
+                      (update-in [:transit-visualization :compare] remove-date2-keys)
+                      (assoc-in [:transit-visualization :route-dates-selected-from-calendar?] true))
 
                   (nil? date2)
                   (do

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -87,7 +87,9 @@
      [tv-change-icons/change-icons diff true])])
 
 ;; Ui
-(defn route-calendar [e! {:keys [date->hash hash->color show-previous-year? compare open-sections route-changes] :as transit-visualization} routes selected-route]
+(defn route-calendar [e! {:keys [date->hash hash->color show-previous-year? compare open-sections route-dates-selected-from-calendar?]
+                          :as transit-visualization}
+                      routes selected-route]
   (let [current-year (time/year (time/now))
         changes (filter
                   (fn [x]
@@ -115,7 +117,9 @@
                      :show-row-hover? true
                      :on-select #(when (first %)
                                    (e! (tv/->SelectRouteForDisplay (first %))))
-                     :row-selected? #(= (:different-week-date %) (:different-week-date selected-route))}
+                     :row-selected? #(and
+                                       (= (:different-week-date %) (:different-week-date selected-route))
+                                       (not route-dates-selected-from-calendar?))}
         [{:name ""
           :read identity
           :format (fn [{:keys [recent-change? change-detected]}]

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -66,7 +66,8 @@
                                :width "20px"
                                :height "20px"}
                               (style/date1-highlight-style))}]
-    (time/format-date date1)]
+    (when date1
+      (time/format-date date1))]
    [:div
     [:div {:style (merge {:display "inline-block"
                                :position "relative"
@@ -75,7 +76,8 @@
                                :width "20px"
                                :height "20px"}
                               (style/date2-highlight-style))}]
-    (time/format-date date2)]])
+    (when date2
+      (time/format-date date2))]])
 
 (defn comparison-date-changes [{diff :differences :as compare}]
   [:div

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -16,7 +16,8 @@
             [ote.style.base :as style-base]
             [ote.views.transit-visualization.change-utilities :as tv-section]
             [ote.views.transit-visualization.change-icons :as tv-change-icons]
-            [ote.app.controller.transit-visualization :as tv]))
+            [ote.app.controller.transit-visualization :as tv]
+            [ote.ui.circular_progress :as prog]))
 
 ;; Utility methods
 (defn day-of-week-number->text [dof]
@@ -185,7 +186,12 @@
                                                                hash-color (hash->color hash)]
                                                            (style/date-highlight-style hash-color
                                                                                        style/date-highlight-color-hover))}]
-       (when (and (:date1 compare) (:date2 compare))
-         [:div
-          [:h3 "Valittujen päivämäärien väliset muutokset"]
-          [comparison-date-changes compare]])]]]]))
+
+       [:h3 "Valittujen päivämäärien väliset muutokset"]
+       ;; :differences used to detect when new route selection or new calendar day selection is being loaded
+       (if (empty? (:differences compare))
+         (prog/circular-progress (tr [:common-texts :loading]))
+         ;; :date2 used to hide difference statistics but not the title, when user selects new diff dates from calendar
+         (when (some? (:date2 compare))
+           [:div
+            [comparison-date-changes compare]]))]]]]))

--- a/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
@@ -118,17 +118,21 @@
     [:div {:style {:flex "1"}}
      [icon-l/icon-labeled
       [ote-icons/outline-add-box {:color (if (= 0 added-trips)
-                                           colors/icon-disabled
-                                           colors/add-color)}]
-      [:span (or added-trips (:gtfs/added-trips diff))      ;; :changes and :changes-route* have different namespace
+                                           style/icon-disabled
+                                           style/add-color)}]
+      [:span (or added-trips
+                 (:gtfs/added-trips diff)  ;; :changes and :changes-route* have different namespace
+                 0)
        (when with-labels? " lisättyä vuoroa")]]]
 
     [:div {:style {:flex "1"}}
      [icon-l/icon-labeled
       [ote-icons/outline-indeterminate-checkbox {:color (if (= 0 removed-trips)
-                                                          colors/icon-disabled
-                                                          colors/remove-color)}]
-      [:span (or removed-trips (:gtfs/removed-trips diff) 0)
+                                                          style/icon-disabled
+                                                          style/remove-color)}]
+      [:span (or removed-trips
+                 (:gtfs/removed-trips diff)
+                 0)
        (when with-labels? " poistettua vuoroa")]]]
 
     [:div {:style {:flex "1"}}


### PR DESCRIPTION
# Fixed
* views,controller: transit-visualization hide route change focus frame
* 658ec65d views: transit-visualization calendar sanity check for nil dates
* 060afabc controller: transit-visualization hide and fix diff stats when loading
* e82709dd views: transit-visualization fallback to 0 when no diff stats