### PR TITLE
166180208 registration to use only email and hide username in user settings

### DIFF
--- a/ote/config.edn
+++ b/ote/config.edn
@@ -15,7 +15,7 @@
         :auth-tkt {:shared-secret "localdev"
                    :max-age-in-seconds 36000
                    :digest-algorithm "MD5"}
-        :session {:key "cookie0123456789"}
+        :session {:key "cookie0123456789"}                  ;; Comment this temporarily when running e2e tests locally
         :ssl-upgrade {:port 3080
                       :ip "localhost"
                       :url "http://localhost:3000/"}

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -3,7 +3,6 @@
   (:require [buddy.hashers :as hashers]
             [clojure.string :as str]
             [jeesql.core :refer [defqueries]]
-            [com.stuartsierra.component :as component]
             [ote.components.http :as http]
             [compojure.core :refer [routes POST]]
             [ote.nap.cookie :as cookie]
@@ -13,7 +12,6 @@
             [ote.db.tx :as tx :refer [with-transaction]]
             [specql.core :as specql]
             [ote.db.user :as user]
-            [ote.time :as time]
             [ote.util.feature :as feature]
             [taoensso.timbre :as log]
             [ote.db.modification :as modification]
@@ -24,7 +22,7 @@
             [clj-time.core :as t]
             [clj-time.coerce :as tc]
             [ote.util.throttle :refer [with-throttle-ms]])
-  (:import (java.util UUID Base64 Base64$Decoder)))
+  (:import (java.util UUID Base64)))
 
 (defqueries "ote/services/login.sql")
 

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -137,7 +137,7 @@
         (if email-taken?
           ;; Username or email taken, return errors to form
           {:success? false
-           :email-taken (when email-taken? email)}
+           :email-taken email}
 
           ;; Registration data is valid
           (do (specql/insert! db ::user/user

--- a/ote/src/cljs/ote/app/controller/login.cljs
+++ b/ote/src/cljs/ote/app/controller/login.cljs
@@ -36,12 +36,11 @@
     (if (and (empty? transport-operators)
              (not= :services page))
       ;; If page is :transport-operator and user has no operators, start creating a new one
-      (do
-        (if (= (:page app) :transport-operator)
-          (assoc app
-                 :transport-operator {:new? true}
-                 :services-changed? true)
-          app))
+      (if (= (:page app) :transport-operator)
+        (assoc app
+          :transport-operator {:new? true}
+          :services-changed? true)
+        app)
 
         ;; Get services from response.
         ;; Use selected operator if possible, if not, use the first one from the response.
@@ -71,12 +70,11 @@
                     (not (empty? navigate-to)) (:page navigate-to)
                     (and authority? (= 0 operators-count)) :authority-pre-notices
                     :else :own-services)]
-     (do
-       (routes/navigate! new-page (:params navigate-to))
-       (-> app
-           (dissoc :login)
-           (update-transport-operator-data (:session-data response))
-           (assoc :flash-message flash-message))))))
+     (routes/navigate! new-page (:params navigate-to))
+     (-> app
+         (dissoc :login)
+         (update-transport-operator-data (:session-data response))
+         (assoc :flash-message flash-message)))))
 
 (extend-protocol tuck/Event
 

--- a/ote/src/cljs/ote/views/register.cljs
+++ b/ote/src/cljs/ote/views/register.cljs
@@ -39,21 +39,6 @@
           :hide-error-until-modified? true}
          [(form/group
            {:expandable? false :columns 3 :card? false :layout :raw}
-           {:name :username :type :string :required? true :full-width? true
-            :placeholder (tr [:register :placeholder :username])
-            :validate [(fn [data _]
-                         (if (< (count data) 3)
-                           (tr [:common-texts :required-field])
-                           (when (not (user/username-valid? data))
-                             (tr [:register :errors :username-invalid]))))
-                       (fn [data _]
-                         (when (and username-taken (username-taken data))
-                           (tr [:register :errors :username-taken])))]
-            :on-blur #(edit! :username)
-            :show-errors? (or (and username-taken
-                                   (username-taken (:username form-data)))
-                              (@edited :username))
-            :should-update-check form/always-update}
            {:type :component
             :name :spacer
             :component (fn [_]

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -21,76 +21,63 @@
   "Edit own user info"
   [e! app]
   (r/create-class
-   {:component-will-unmount #(e! (lc/->CancelUserEdit false))
-    :reagent-render
-    (fn
-      [e! {:keys [form-data email-taken username-taken password-incorrect?] :as user}]
+    {:component-will-unmount #(e! (lc/->CancelUserEdit false))
+     :reagent-render
+     (fn
+       [e! {:keys [form-data email-taken password-incorrect?] :as user}]
 
-      [:div.user-edit.col-xs-12.col-sm-8.col-md-8.col-lg-6
-       [list-header/header app (tr [:common-texts :user-menu-profile])]
-       [form/form
-        {:update! #(e! (lc/->UpdateUser %))
-         :name->label (tr-key [:register :fields])
-         :footer-fn (fn [data]
-                      [:div {:style {:margin-top "1em"}}
-                       [buttons/save {:on-click #(e! (lc/->SaveUser
-                                                      (merge-user-data
-                                                       user
-                                                       (form/without-form-metadata data))))
-                                      :disabled (form/disable-save? data)}
-                        (tr [:buttons :save])]
-                       [buttons/cancel {:on-click #(e! (lc/->CancelUserEdit true))}
-                        (tr [:buttons :cancel])]])}
-        [(form/group
-          {:expandable? false :columns 3 :layout :raw :card? false}
+       [:div.user-edit.col-xs-12.col-sm-8.col-md-8.col-lg-6
+        [list-header/header app (tr [:common-texts :user-menu-profile])]
+        [form/form
+         {:update! #(e! (lc/->UpdateUser %))
+          :name->label (tr-key [:register :fields])
+          :footer-fn (fn [data]
+                       [:div {:style {:margin-top "1em"}}
+                        [buttons/save {:on-click #(e! (lc/->SaveUser
+                                                        (merge-user-data
+                                                          user
+                                                          (form/without-form-metadata data))))
+                                       :disabled (form/disable-save? data)}
+                         (tr [:buttons :save])]
+                        [buttons/cancel {:on-click #(e! (lc/->CancelUserEdit true))}
+                         (tr [:buttons :cancel])]])}
+         [(form/group
+            {:expandable? false :columns 3 :layout :raw :card? false}
+            {:name :name :type :string :required? true :full-width? true
+             :placeholder (tr [:register :placeholder :name])
+             :should-update-check form/always-update}
+            {:name :email :type :string :autocomplete "email" :required? true
+             :full-width? true :placeholder (tr [:register :placeholder :email])
+             :validate [(fn [data _]
+                          (when (not (user/email-valid? data))
+                            (tr [:common-texts :required-field])))
+                        (fn [data _]
+                          (when (and email-taken (email-taken data))
+                            (tr [:register :errors :email-taken])))]
+             :should-update-check form/always-update}
 
-          {:name :username :type :string :required? true :full-width? true
-           :placeholder (tr [:register :placeholder :username])
-           :validate [(fn [data _]
-                        (if (< (count data) 3)
-                          (tr [:common-texts :required-field])
-                          (when (not (user/username-valid? data))
-                            (tr [:register :errors :username-invalid]))))
-                      (fn [data _]
-                        (when (and username-taken (username-taken data))
-                          (tr [:register :errors :username-taken])))]
-           :should-update-check form/always-update}
+            (form/subtitle :h3 (tr [:register :change-password]) {:margin-top "3rem"})
+            {:name :password :type :string :password? true
+             :label (tr [:register :fields :new-password])
+             :full-width? true
+             :validate [(fn [data _]
+                          (when (and (not (str/blank? data))
+                                     (not (user/password-valid? data)))
+                            (tr [:register :errors :password-not-valid])))]
+             :should-update-check form/always-update}
+            {:name :confirm :type :string :password? true
+             :full-width? true
+             :validate [(fn [data row]
+                          (when (not= data (:password row))
+                            (tr [:register :errors :passwords-must-match])))]
+             :should-update-check form/always-update}
 
-          {:name :name :type :string :required? true :full-width? true
-           :placeholder (tr [:register :placeholder :name])
-           :should-update-check form/always-update}
-          {:name :email :type :string :autocomplete "email" :required? true
-           :full-width? true :placeholder (tr [:register :placeholder :email])
-           :validate [(fn [data _]
-                        (when (not (user/email-valid? data))
-                          (tr [:common-texts :required-field])))
-                      (fn [data _]
-                        (when (and email-taken (email-taken data))
-                          (tr [:register :errors :email-taken])))]
-           :should-update-check form/always-update}
-
-          (form/subtitle :h3 (tr [:register :change-password]) {:margin-top "3rem"})
-          {:name :password :type :string :password? true
-           :label (tr [:register :fields :new-password])
-           :full-width? true
-           :validate [(fn [data _]
-                        (when (and (not (str/blank? data))
-                                   (not (user/password-valid? data)))
-                          (tr [:register :errors :password-not-valid])))]
-           :should-update-check form/always-update}
-          {:name :confirm :type :string :password? true
-           :full-width? true
-           :validate [(fn [data row]
-                        (when (not= data (:password row))
-                          (tr [:register :errors :passwords-must-match])))]
-           :should-update-check form/always-update}
-
-          ;; Show current password field if it is required for update
-          (form/subtitle :h3 (tr [:register :confirm-changes]) {:margin-top "3rem"})
-          {:name :current-password :type :string :password? true
-           :full-width? true
-           :required? true
-           :validate [(fn [_ _]
-                        (when password-incorrect?
-                          (tr [:login :error :incorrect-password])))]})]
-        (merge-user-data user form-data)]])}))
+            ;; Show current password field if it is required for update
+            (form/subtitle :h3 (tr [:register :confirm-changes]) {:margin-top "3rem"})
+            {:name :current-password :type :string :password? true
+             :full-width? true
+             :required? true
+             :validate [(fn [_ _]
+                          (when password-incorrect?
+                            (tr [:login :error :incorrect-password])))]})]
+         (merge-user-data user form-data)]])}))

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -13,14 +13,6 @@
             [clojure.string :as str]
             [ote.ui.list-header :as list-header]))
 
-(defn require-current-password? [user form-data]
-  (or (and (not (str/blank? (:username form-data)))
-           (not= (:username user) (:username form-data)))
-      (and (not (str/blank? (:email form-data)))
-           (not= (:email user) (:email form-data)))
-      (not (str/blank? (:password form-data)))))
-
-
 (defn merge-user-data [user form-data]
   (merge (select-keys user #{:username :name :email})
          form-data))


### PR DESCRIPTION
This shall be merged only after the new way of adding user to organisation is integrated.

# Changed
* config: Reminder to comment out :session key for local e2e test runs
* views: operator-users remove :username
* services: login, refactoring and explicitly define some http statuses
* services: login, remove unused :requires
* services: user, set functions private
* services: login, on registration use uuid as username
*  view: user settings, hide username field on ui
* view: register remove username field from registration view
* views: user, cleanup code, require-current-password? not used
* controller: login, Cleanup code, remove redundant dos