### PR TITLE
166491363 transit-visualization, replace trip and stop tables using a spinner after calendar selection

### DIFF
--- a/ote/config.edn
+++ b/ote/config.edn
@@ -15,7 +15,7 @@
         :auth-tkt {:shared-secret "localdev"
                    :max-age-in-seconds 36000
                    :digest-algorithm "MD5"}
-        :session {:key "cookie0123456789"}
+        :session {:key "cookie0123456789"}                  ;; Comment this temporarily when running e2e tests locally
         :ssl-upgrade {:port 3080
                       :ip "localhost"
                       :url "http://localhost:3000/"}

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -35,21 +35,18 @@
 (defn route-filtering-available? [{:keys [changes-route-no-change] :as transit-visualization}]
   (seq changes-route-no-change))
 
-(defn loaded-from-server? [{:keys [route-lines-for-date-loading? route-trips-for-date1-loading?
-                                   route-trips-for-date2-loading? route-calendar-hash-loading?
-                                   route-differences-loading? routes-for-dates-loading?
-                                   service-changes-for-dates-loading?]
-                            :as   transit-visualization}]
-  (and (not route-lines-for-date-loading?)
-       (not route-trips-for-date1-loading?)
-       (not route-trips-for-date2-loading?)
-       (not route-calendar-hash-loading?)
-       (not route-differences-loading?)
-       (not routes-for-dates-loading?)
-       (not service-changes-for-dates-loading?)
-       ;; Hide trip and stop comparison elements until both compared trip datas are available, to avoids runtime errors
-       ;; and to avoid displaying invalid data.
-       (some? (get-in transit-visualization [:compare :date2]))))
+(defn loading-trips? [{:keys [route-lines-for-date-loading? route-trips-for-date1-loading?
+                                route-trips-for-date2-loading? route-calendar-hash-loading?
+                                route-differences-loading? routes-for-dates-loading?
+                                service-changes-for-dates-loading?]
+                         :as   transit-visualization}]
+  (or route-lines-for-date-loading?
+      route-trips-for-date1-loading?
+      route-trips-for-date2-loading?
+      route-calendar-hash-loading?
+      route-differences-loading?
+      routes-for-dates-loading?
+      service-changes-for-dates-loading?))
 
 (defn parse-date [date-str]
   (tf/parse (tf/formatter "dd.MM.yyyy") date-str))
@@ -286,10 +283,10 @@
 
           :default
           app)
-        app (if (loaded-from-server? app)
+        app (if (loading-trips? app)
+              app
               ;; Combine only after all data available to avoid rendering incorrect numbers
-              (combine-trips app)
-              app)]
+              (combine-trips app))]
     ;; Wait until both trips are loaded
     ;; No need to render trips and stops while they are not ready
     (if (and (not (:route-trips-for-date1-loading? app))

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -20,7 +20,8 @@
             [ote.ui.form-fields :as form-fields]
             [ote.views.transit-visualization.calendar :as tv-calendar]
             [ote.views.transit-visualization.change-utilities :as tv-utilities]
-            [ote.views.transit-visualization.change-icons :as tv-change-icons]))
+            [ote.views.transit-visualization.change-icons :as tv-change-icons]
+            [ote.ui.circular_progress :as prog]))
 
 (set! *warn-on-infer* true)
 
@@ -761,10 +762,15 @@
       (when selected-route
         [:div.transit-visualization-route.container
          [:h3 "Valittu reitti: " route-name]
-
          [tv-calendar/route-calendar e! transit-visualization changes-all selected-route]
-         (when (and hash->color date->hash (tv/loaded-from-server? transit-visualization))
-           [:span
-            [selected-route-map-section e! open-sections date->hash hash->color compare]
-            [route-trips e! open-sections compare]
-            [trip-stop-sequence e! open-sections compare]])])]]))
+
+         (if (tv/loading-trips? transit-visualization)
+           (prog/circular-progress (tr [:common-texts :loading]))
+           ;; Selecting a new date1 from calendar clears date2 related keys which are used by selected-route-map-section
+           ;; Also, displaying below data is always in connection with the date1&date2 pair which is outdated after a
+           ;; new selection from calendar.
+           (when (:date2-trips compare)
+             [:span
+              [selected-route-map-section e! open-sections date->hash hash->color compare]
+              [route-trips e! open-sections compare]
+              [trip-stop-sequence e! open-sections compare]]))])]]))


### PR DESCRIPTION
# Changed
* controller: transit-visualization refactor loading state for spinner
* controller: transit-visualization remove dead code LoadOperatorDates
* view: transit-visualization loading spinner for map,trip,stop selections