### PR TITLE
161748643 Change "other change, what?" to just "other change"

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -517,7 +517,7 @@ You can also draw the operating area or point to the map with drawing tools. You
    :new "Increasement of transport or a new traffic route/routes"
    :schedule-change "Timetable change"
    :route-change "Route change/changes"
-   :other "Other change, what?"}
+   :other "Other change"}
 
   :ote.db.transit/pre-notice-state
   {:draft "Draft"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -519,7 +519,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
    :new "Liikenteen lisääminen tai uusi reitti"
    :schedule-change "Aikataulumuutos"
    :route-change "Reittimuutos"
-   :other "Muu muutos, mikä?"}
+   :other "Muu muutos"}
 
   :ote.db.transit/pre-notice-state
   {:draft "Luonnos"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -523,7 +523,7 @@
    :new "Trafiken utökas eller ny rutt"
    :schedule-change "Tidtabellsändring"
    :route-change "Ruttändring"
-   :other "Annan ändring, vilken?"}
+   :other "Annan ändring"}
 
   :ote.db.transit/pre-notice-state
   {:draft "Utkast"

--- a/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/pre_notice.cljs
@@ -18,6 +18,7 @@
             [ote.ui.circular_progress :as circular-progress]
             [ote.ui.common :as common]))
 
+
 (def notice-types [:termination :new :schedule-change :route-change :other])
 (def effective-date-descriptions [:year-start :school-start :school-end :season-schedule-change])
 
@@ -154,13 +155,11 @@
        :layout  :row}
 
       {:name                ::transit/pre-notice-type
-       :should-update-check (juxt ::transit/pre-notice-type ::transit/other-type-description)
        :type                :checkbox-group
        :container-class     "col-md-12"
        :header?             false
        :required?           true
        :options             notice-types
-       :option-addition     {:value :other :addition addition}
        :show-option         (tr-key [:enums ::transit/pre-notice-type])}
 
       {:name ::transit/description
@@ -289,7 +288,7 @@
      :table-fields [{:name ::transit/attachment-file-name
                      :type :component
                      :read identity
-                     :component (fn [{data :data} form-data]
+                     :component (fn [{data :data}]
                                   (let [id (:ote.db.transit/id data)
                                         file-name (:ote.db.transit/attachment-file-name data)]
                                     [:div


### PR DESCRIPTION
# Changed
* Pre-notice, pre-notice-list, authority-pre-notice-list, pre-notice-email: Everywhere "other change, what?" is changed to "other change" 
* Removed other-type-change input field from pre-notice page.

   

