### PR TITLE
166926481: admin, remove edit user button because ckan shall be removed

### DIFF
--- a/ote/src/cljs/ote/views/admin/users.cljs
+++ b/ote/src/cljs/ote/views/admin/users.cljs
@@ -155,5 +155,4 @@
                [ui/table-row-column {:style {:padding 0}}
                 [groups-list groups]]
                [ui/table-row-column
-                [delete-user-action e! user]
-                [edit-user-action e! user]]]))]]])]))
+                [delete-user-action e! user]]]))]]])]))


### PR DESCRIPTION
# Changed
Admin panel's edit user button removed entirely as first workaround for the feature due to ckan removal.
