### PR TITLE
Service search: fix view to use array_cat instead of coalesce

### DIFF
--- a/database/src/main/resources/db/migration/V1_154__fix_transport_service_search_view.sql
+++ b/database/src/main/resources/db/migration/V1_154__fix_transport_service_search_view.sql
@@ -1,0 +1,27 @@
+-- View was using coalesce instead of creating a proper array of all the wanted data.
+CREATE OR REPLACE VIEW transport_service_search_result AS
+SELECT t.*, op.name as "operator-name", op."business-id" as "business-id",
+       -- Changed Start
+       array_cat(
+               array_cat(
+                       (SELECT sc."companies"
+                        FROM "service_company" sc
+                        WHERE sc."transport-service-id" = t.id),
+                       t."companies"),
+               array_agg((aso.name, aso."business-id")::company)) AS "service-companies",
+       -- Changed End
+       (SELECT array_agg(oaf."operation-area")
+        FROM "operation-area-facet" oaf
+        WHERE oaf."transport-service-id" = t.id) AS "operation-area-description",
+       (SELECT array_agg(ROW(ei."external-interface", ei.format,
+           ei."ckan-resource-id",
+           ei.license, ei."data-content",
+           ei."gtfs-import-error",
+           ei."gtfs-db-error")::external_interface_search_result)
+        FROM "external-interface-description" ei
+        WHERE ei."transport-service-id" = t.id)::external_interface_search_result[] AS "external-interface-links"
+FROM "transport-service" t
+         LEFT JOIN (SELECT top.name as name, top."business-id" as "business-id", a."service-id"
+                    FROM "transport-operator" top, "associated-service-operators" a WHERE a."operator-id" = top.id) as aso ON aso."service-id" = t.id
+         JOIN  "transport-operator" op ON op.id = t."transport-operator-id"
+GROUP BY t.id, op.name, op."business-id";


### PR DESCRIPTION
# Changed
* transport_service_search_result view to use create a concatenated list of arrays instead of finding the first non null value to select.
