### PR TITLE
166922371: views: index, routes, matomo trackPageView only on route navigation

### DIFF
--- a/ote/src/clj/ote/services/index.clj
+++ b/ote/src/clj/ote/services/index.clj
@@ -49,7 +49,7 @@
     (javascript-tag
       (str " var _paq = window._paq || [];"
            " /* tracker methods like \"setCustomDimension\" should be called before \"trackPageView\" */"
-           " _paq.push(['trackPageView']);"
+           " _paq.push(['setCustomUrl', 'finap.fi']);"
            " _paq.push(['enableLinkTracking']);"
            " _paq.push(['enableHeartBeatTimer']);"
            " (function() {"


### PR DESCRIPTION
# Fixed
* views: index, routes, matomo trackPageView only on route navigation
 Allows setting custom url before reporting url to analytics script.
 Otherwise direct link navigation to register or reset-password is
 reported before removing url argument and query strings.
