### PR TITLE
167066486 authority users controls

### DIFF
--- a/ote/src/clj/ote/services/operators.sql
+++ b/ote/src/clj/ote/services/operators.sql
@@ -60,7 +60,6 @@ FROM "transport-service" ts
 
 -- name: fetch-operator-users
 SELECT u.id, u.name, u.fullname, u.email
-  FROM "transport-operator" t
-  JOIN member m ON m.group_id = t."ckan-group-id"
-  JOIN "user" u ON m.table_id = u.id
- WHERE t."ckan-group-id" = :ckan-group-id;
+  FROM member m
+      JOIN "user" u ON m.table_id = u.id
+WHERE m.group_id = :ckan-group-id;

--- a/ote/src/clj/ote/services/register.clj
+++ b/ote/src/clj/ote/services/register.clj
@@ -28,7 +28,7 @@
     (with-transaction db
       (let [username-taken? (username-exists? db {:username username})
             email-taken? (email-exists? db {:email email})
-            operator-info (when token
+            group-info (when token
                             (first (fetch-operator-info db {:token token})))]
         (if (or username-taken? email-taken?)
           ;; Username or email taken, return errors to form
@@ -48,11 +48,11 @@
                               ::user/sysadmin false
                               ::user/apikey (str (UUID/randomUUID))
                               ::user/activity_streams_email_notifications false})]
-              (when (and token operator-info)
-                (transport/create-member! db (::user/id new-user) (:ckan-group-id operator-info))
+              (when (and token group-info)
+                (transport/create-member! db (::user/id new-user) (:ckan-group-id group-info))
                 (specql/delete! db ::user/user-token
                   {::user/token token})
-                (log/info "New user (" email ") registered with token from " (:name operator-info))))
+                (log/info "New user (" email ") registered with token from " (:name group-info))))
             {:success? true}))))))
 
 (defn register [db auth-tkt-config form-data]

--- a/ote/src/clj/ote/services/register.clj
+++ b/ote/src/clj/ote/services/register.clj
@@ -48,7 +48,7 @@
                               ::user/sysadmin false
                               ::user/apikey (str (UUID/randomUUID))
                               ::user/activity_streams_email_notifications false})]
-              (when (and token group-info)
+              (when (and token group-info)                  ;; If the user doesn't have a token or group-info they can register, but aren't added to any group
                 (transport/create-member! db (::user/id new-user) (:ckan-group-id group-info))
                 (specql/delete! db ::user/user-token
                   {::user/token token})

--- a/ote/src/clj/ote/services/register.sql
+++ b/ote/src/clj/ote/services/register.sql
@@ -7,7 +7,8 @@ SELECT EXISTS(SELECT id FROM "user" WHERE LOWER(name) = LOWER(:username));
 SELECT EXISTS(SELECT id FROM "user" WHERE LOWER(email) = LOWER(:email));
 
 -- name: fetch-operator-info
-SELECT tro."business-id", tro.name, tro."ckan-group-id", ut.token, ut.expiration
+SELECT g.id as "ckan-group-id", g.title as name, ut.token, ut.expiration, tro."business-id"
 FROM "user-token" ut
-LEFT JOIN "transport-operator" tro ON tro."ckan-group-id" = ut."ckan-group-id"
-WHERE token = :token AND ut.expiration >= (NOW())::date AND NOT tro."deleted?"
+LEFT JOIN "group" g ON g.id = ut."ckan-group-id"
+LEFT JOIN "transport-operator" tro on g.id = tro."ckan-group-id"
+WHERE token = :token AND ut.expiration >= (NOW())::date AND tro."deleted?" IS NOT TRUE

--- a/ote/src/clj/ote/util/email_template.clj
+++ b/ote/src/clj/ote/util/email_template.clj
@@ -246,24 +246,24 @@
      [:br]
      [:h1 {:class "headerText1"
            :style "font-family:Roboto,helvetica neue,arial,sans-serif; font-size:1.5rem; font-weight:700;"}
-      (str "Sinut on kutsuttu " (::t-operator/name operator) "-nimisen palveluntuottajan jäseneksi.")]
+      (str "Sinut on kutsuttu " (::t-operator/title operator) "-nimisen palveluntuottajan jäseneksi.")]
 
      (html-divider-border "100%")
      [:p
       [:strong {:style "font-family:Roboto,helvetica neue,arial,sans-serif;font-size:0.75rem;"}
        (get-in requester [:user :name])] " on kutsunut sinut NAP-palveluun "
-      [:strong (::t-operator/name operator)]
-      (str " -nimisen palveluntuottajan jäseneksi. Voit nyt muokata " (::t-operator/name operator) " -nimisen palvelutuottajan ja sen alla julkaistujen palveluiden tietoja.")]
+      [:strong (::t-operator/title operator)]
+      (str " -nimisen palveluntuottajan jäseneksi. Voit nyt muokata " (::t-operator/title operator) " -nimisen palvelutuottajan ja sen alla julkaistujen palveluiden tietoja.")]
      [:br]
      [:p "Mikäli olet saanut kutsun vahingossa, tai et halua olla palveluntuottajan jäsen, "
-      [:a {:href (str (environment/base-url) "#/transport-operator/" (::t-operator/ckan-group-id operator) "/users")} "voit poistaa itsesi jäsenlistalta."]]
+      [:a {:href (str (environment/base-url) "#/transport-operator/" (::t-operator/group-id operator) "/users")} "voit poistaa itsesi jäsenlistalta."]]
      [:br]
      (blue-button (str (environment/base-url) "#/own-services") "Avaa NAP-palvelun Omat palvelutiedot -näkymä")
 
      (html-divider-border "100%")]))
 
 (defn new-user-invite [requester operator title token]
-  (let [op-name (::t-operator/name operator)]
+  (let [op-name (::t-operator/title operator)]
     (html-template {:show-email-settings? false} title
       [:div {:style "max-width: 800px"}
        [:br]


### PR DESCRIPTION
# Fixed
* Controlling user rights to operators is now based on just the group-id instead of using transport operator to fetch this ID. This is because authority users don't have a proper transport operator, which broke the existing implementation for their user group. 
