### PR TITLE
166907227 email verification

### DIFF
--- a/database/src/main/resources/db/migration/V1_155__add_email_confirmation_columns.sql
+++ b/database/src/main/resources/db/migration/V1_155__add_email_confirmation_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "user"
+ADD COLUMN "email-confirmed?" BOOLEAN DEFAULT FALSE,
+ADD COLUMN "confirmation-time" TIMESTAMP;

--- a/database/src/main/resources/db/migration/V1_156__email_confirmation_table.sql
+++ b/database/src/main/resources/db/migration/V1_156__email_confirmation_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "email-confirmation-token" (
+    "user-email" text UNIQUE,
+    token text PRIMARY KEY,
+    expiration date NOT NULL
+)

--- a/database/src/main/resources/db/migration/V1_157__existing_users_confirmed.sql
+++ b/database/src/main/resources/db/migration/V1_157__existing_users_confirmed.sql
@@ -1,0 +1,2 @@
+UPDATE "user"
+SET "email-confirmed?" = TRUE;

--- a/database/testdata-ckan.sql
+++ b/database/testdata-ckan.sql
@@ -1,11 +1,10 @@
 -- ### Add admin user ###
-INSERT INTO "user" (id, name, openid, password, fullname, email, apikey, created, reset_key, about, activity_streams_email_notifications, sysadmin, state)
+INSERT INTO "user" (id, name, openid, password, fullname, email, apikey, created, reset_key, about, activity_streams_email_notifications, sysadmin, state, "email-confirmed?")
 VALUES ('401139db-8f3e-4371-8233-5d51d4c4c8b6', 'admin', NULL,
                                                 '$pbkdf2-sha512$25000$dq51TgmB0JpzDiGEkDKGUA$YVW2kq0qZrp7ZMge7P33JCTTaUaz9eH0eKXDNENRpOJ/ndCrpBGR94Qm3XakaGBLCA54qi1Q6wxnDgcfvgOxbA',
                                                 'Admin Adminson', 'admin@napoteadmin123.com',
                                                 'd7c6dccf-6541-4443-a9b4-7ab7c36735bc',
-                                                '2017-10-04T09:45:10.895301' :: TIMESTAMP, NULL, NULL, FALSE, TRUE,
-        'active');
+                                                '2017-10-04T09:45:10.895301' :: TIMESTAMP, NULL, NULL, FALSE, TRUE, 'active', TRUE);
 INSERT INTO "activity" (id, timestamp, user_id, object_id, revision_id, activity_type, data)
 VALUES ('2fc23860-6275-4712-a1a8-37bab21cc2b6', '2017-10-04T09:45:10.899229' :: TIMESTAMP,
         '401139db-8f3e-4371-8233-5d51d4c4c8b6', '401139db-8f3e-4371-8233-5d51d4c4c8b6', NULL, 'new user', NULL);
@@ -77,9 +76,9 @@ WHERE revision.id = '7b7f56df-1c88-48b7-b807-6bcfaedb274a';
 -- ### ... ###
 
 -- Add regular user (normaluser/password)
-INSERT INTO "public"."user"("id","name","apikey","created","about","openid","password","fullname","email","reset_key","sysadmin","activity_streams_email_notifications","state")
+INSERT INTO "public"."user"("id","name","apikey","created","about","openid","password","fullname","email","reset_key","sysadmin","activity_streams_email_notifications","state", "email-confirmed?")
 VALUES
-(E'676a2532-b106-4329-b95e-e30c8c8265d5',E'normaluser',E'8eb7bf65-2a7b-45dd-a576-be10a02c3801',E'2018-01-17 11:46:11.658956',NULL,NULL,E'$pbkdf2-sha512$25000$UApBKOXcW6uVci4FQKiVcg$B4j1WY60oVyXvJHA9YRXIN8wKl8lD.Gzn802IwOLTuCgcIqbaaEQIJcqaIWr2ROf4XBtKdCTSCyroLhIMpFC9g',E'User Userson',E'user.userson@example.com',NULL,FALSE,FALSE,E'active');
+(E'676a2532-b106-4329-b95e-e30c8c8265d5',E'normaluser',E'8eb7bf65-2a7b-45dd-a576-be10a02c3801',E'2018-01-17 11:46:11.658956',NULL,NULL,E'$pbkdf2-sha512$25000$UApBKOXcW6uVci4FQKiVcg$B4j1WY60oVyXvJHA9YRXIN8wKl8lD.Gzn802IwOLTuCgcIqbaaEQIJcqaIWr2ROf4XBtKdCTSCyroLhIMpFC9g',E'User Userson',E'user.userson@example.com',NULL,FALSE,FALSE,E'active',TRUE);
 
 INSERT INTO "public"."revision"("id","timestamp","author","message","state","approved_timestamp")
 VALUES

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1029,6 +1029,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :invalid-file-type "Invalid file type"
   :save-failure "Saving failed."
   :save-success "Successfully saved."
+  :send-new-message "Send a new message"
   :transport-service-saved "Transport service information has been saved!"
   :transport-operator-saved "Transport operator information has been saved!"
   :footer-livi-logo "Finnish Transport and Communications Agency"
@@ -1187,7 +1188,8 @@ You can also draw the operating area or point to the map with drawing tools. You
 
   :error {:login-error "Invalid credentials, please verify them and retry."
           :no-such-user "Unknown user"
-          :incorrect-password "Incorrect password"}
+          :incorrect-password "Incorrect password"
+          :unconfirmed-email "Kirjautuminen epäonnistui, koska sähköpostia ei ole todennettu. Jos et ole saanut todennusviestiä rekisteröinnin yhteydessä, voit lähettää sen uudelleen."}
 
   :check-email-for-link "Your request for changing password has been received. A link for resetting your password has now been sent to your email address."
   :logged-out "You have been logged out."}
@@ -1246,7 +1248,14 @@ You can also draw the operating area or point to the map with drawing tools. You
   :confirm-changes "Confirm changes"
   :change-password "Change password"
   :valid-token ["At registration you will get user rights to the service producer " :operator-name "."]
-  :invalid-token "Your invitation has expired. Complete the registration and contact the invitation sender or the NAP Helpdesk (nap@traficom.fi) to get a new invitation."}
+  :invalid-token "Your invitation has expired. Complete the registration and contact the invitation sender or the NAP Helpdesk (nap@traficom.fi) to get a new invitation."
+  :verification-email-sent-text ["Kiitos rekisteröitymisestäsi NAP-palveluun! Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi. Todennusviesti on lähetetty osoitteseen " :email "."]
+  :confirmation-failed "Sähköpostin vahvistus epäonnistui"
+  :confirmation-success "Sähköposti vahvistettu"
+  :confirm-email "Sähköpostin todennus"
+  :email-to-be-confirmed "Todennettava sähköposti"
+  :resend-confirmation "Lähetä sähköpostin todentamisviesti uudelleen"
+  :resend-success ["Todentamisviesti lähetetty osoitteeseen " :email ". Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi viestin ohjeen mukaan. Jos todentamisviesti ei tule perille, ota yhteyttä NAP-Helpdeskiin: 029 534 5454 (arkisin klo 9-15) tai nap@traficom.fi"]}
 
  :reset-password
  {:label "Reset your password"
@@ -1309,4 +1318,11 @@ You can also draw the operating area or point to the map with drawing tools. You
                    :body6 "If you are unable to change your password successfully, contact NAP Helpdesk."
                    :body7 "Ignore this message, if you have not tried to change your password."
                    :body8 "This message has been sent automatically from the NAP system. Do not reply to this message, replies are not processed."
-                   :link-text "Reset password"}}}
+                   :link-text "Reset password"}
+  :footer {:email-sender "Tämän viestin lähetti NAP."
+           :help-desk "NAP-Helpdesk yhteystiedot:"
+           :help-desk-email "nap@traficom.fi"
+           :help-desk-phone " tai 029 534 5454 (arkisin 09-15)"}
+  :email-verification {:verification-message "Hei. Kiitos rekisteröitymisestäsi NAP-palveluun! Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi. Voit tehdä alla olevasta painikkeesta."
+                       :verify-email "Todenna sähköpostiosoite"
+                       :if-not-registered "Mikäli et ole juuri rekisteröitynyt NAP-palveluun, voit jättää tämän viestin huomioimatta."}}}

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1037,6 +1037,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :invalid-file-type "Virheellinen tiedostotyyppi"
   :save-failure "Tallennus ei onnistunut."
   :save-success "Tallennus onnistui."
+  :send-new-message "Lähetä uusi viesti"
   :transport-service-saved "Liikkumispalvelun tiedot tallennettu!"
   :transport-operator-saved "Palveluntarjoajan tiedot tallennettu!"
   :footer-livi-logo "Traficom"
@@ -1199,7 +1200,8 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
 
   :error {:login-error "Kirjautumistiedoissa virhe. Tarkista tiedot ja kokeile uudestaan."
           :no-such-user "Tuntematon käyttäjä"
-          :incorrect-password "Väärä salasana"}
+          :incorrect-password "Väärä salasana"
+          :unconfirmed-email "Kirjautuminen epäonnistui, koska sähköpostia ei ole todennettu. Jos et ole saanut todennusviestiä rekisteröinnin yhteydessä, voit lähettää sen uudelleen."}
 
   :check-email-for-link "Salasanan vaihtopyyntösi on vastaanotettu. Olemme nyt lähettäneet salasanan vaihtamiseen tarvittavan linkin sähköpostiisi."
   :logged-out "Olet kirjautunut ulos."}
@@ -1258,7 +1260,14 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :confirm-changes "Varmista muutokset"
   :change-password "Vaihda salasana"
   :valid-token ["Saat rekisteröitymisen yhteydessä käyttöoikeudet palveluntuottajaan " :operator-name "."]
-  :invalid-token "Kutsusi on vanhentunut. Jatka rekisteröityminen loppuun, ja ota tämän jälkeen yhteys kutsun lähettäjään tai NAP-Helpdeskiin (nap@traficom.fi) saadaksesi uuden kutsun."}
+  :invalid-token "Kutsusi on vanhentunut. Jatka rekisteröityminen loppuun, ja ota tämän jälkeen yhteys kutsun lähettäjään tai NAP-Helpdeskiin (nap@traficom.fi) saadaksesi uuden kutsun."
+  :verification-email-sent-text ["Kiitos rekisteröitymisestäsi NAP-palveluun! Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi. Todennusviesti on lähetetty osoitteseen " :email "."]
+  :confirmation-failed "Sähköpostin todennus epäonnistui. Sähköpostisi on jo todennettu tai todennusviesti on vanhentunut. Voit lähettää uuden todennusviestin alla olevasta linkistä."
+  :confirmation-success "Sähköposti todennettu."
+  :confirm-email "Sähköpostin todennus"
+  :email-to-be-confirmed "Todennettava sähköposti"
+  :resend-confirmation "Lähetä sähköpostin todentamisviesti uudelleen."
+  :resend-success ["Todentamisviesti lähetetty osoitteeseen " :email ". Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi viestin ohjeen mukaan. Jos todentamisviesti ei tule perille, ota yhteyttä NAP-Helpdeskiin: 029 534 5454 (arkisin klo 9-15) tai nap@traficom.fi"]}
 
  :reset-password
  {:label "Salasanan vaihto"
@@ -1321,4 +1330,11 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
                    :body6 "Mikäli salasanan vaihto ei onnistu, ota yhteys NAP-Helpdeskiin."
                    :body7 "Mikäli et ole yrittänyt vaihtaa salasanaasi, voit jättää tämän viestin huomioimatta."
                    :body8 "Tämä viesti on lähetetty NAP-järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä."
-                   :link-text "Vaihda salasana"}}}
+                   :link-text "Vaihda salasana"}
+  :footer {:email-sender "Tämän viestin lähetti NAP."
+           :help-desk "NAP-Helpdesk yhteystiedot:"
+           :help-desk-email "nap@traficom.fi"
+           :help-desk-phone " tai 029 534 5454 (arkisin 09-15)"}
+  :email-verification {:verification-message "Hei. Kiitos rekisteröitymisestäsi NAP-palveluun! Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi. Voit tehdä alla olevasta painikkeesta."
+                       :verify-email "Todenna sähköpostiosoite"
+                       :if-not-registered "Mikäli et ole juuri rekisteröitynyt NAP-palveluun, voit jättää tämän viestin huomioimatta."}}}

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1033,6 +1033,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :invalid-file-type "Ogiltig filtyp"
   :save-failure "Går ej att spara."
   :save-success "Sparat."
+  :send-new-message "Lähetä uusi viesti"
   :transport-service-saved "Uppgifterna sparade!"
   :transport-operator-saved "Uppgifterna sparade!"
   :footer-livi-logo "Traficom"
@@ -1250,7 +1251,15 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :confirm-changes "Bekräfta ändringar"
   :change-password "Ändra lösenord"
   :valid-token ["I samband med registreringen får du användarrättigheter till tjänsteproducenten " :operator-name "."]
-  :invalid-token "Din inbjudan har förfallit. Avsluta registreringen och kontakta därefter inbjudans avsändare eller NAP Helpdesk (nap@traficom.fi) för att få en ny inbjudan."}
+  :invalid-token "Din inbjudan har förfallit. Avsluta registreringen och kontakta därefter inbjudans avsändare eller NAP Helpdesk (nap@traficom.fi) för att få en ny inbjudan."
+  :invalid-token "Kutsusi on vanhentunut. Jatka rekisteröityminen loppuun, ja ota tämän jälkeen yhteys kutsun lähettäjään tai NAP-Helpdeskiin (nap@traficom.fi) saadaksesi uuden kutsun."
+  :verification-email-sent-text ["Kiitos rekisteröitymisestäsi NAP-palveluun! Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi. Todennusviesti on lähetetty osoitteseen " :email "."]
+  :confirmation-failed "Sähköpostin vahvistus epäonnistui"
+  :confirmation-success "Sähköposti vahvistettu"
+  :confirm-email "Sähköpostin todennus"
+  :email-to-be-confirmed "Todennettava sähköposti"
+  :resend-confirmation "Lähetä sähköpostin todentamisviesti uudelleen"
+  :resend-success ["Todentamisviesti lähetetty osoitteeseen " :email ". Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi viestin ohjeen mukaan. Jos todentamisviesti ei tule perille, ota yhteyttä NAP-Helpdeskiin: 029 534 5454 (arkisin klo 9-15) tai nap@traficom.fi"]}
 
  :reset-password
  {:label "Återställ ditt lösenord"
@@ -1314,5 +1323,11 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
                    :body6 "Om du inte lyckas byta lösenordet, kontakta NAP Helpdesk."
                    :body7 "Om du inte har försökt byta ditt lösenord, kan du ignorera detta meddelande."
                    :body8 "Detta meddelande har skickats automatiskt från NAP-systemet. Svara inte på det här meddelandet, eftersom svaren inte behandlas."
-                   :link-text "Återställ lösenord"}}
- }
+                   :link-text "Återställ lösenord"}
+  :footer {:email-sender "Tämän viestin lähetti NAP."
+           :help-desk "NAP-Helpdesk yhteystiedot:"
+           :help-desk-email "nap@traficom.fi"
+           :help-desk-phone " tai 029 534 5454 (arkisin 09-15)"}
+  :email-verification {:verification-message "Hei. Kiitos rekisteröitymisestäsi NAP-palveluun! Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi. Voit tehdä alla olevasta painikkeesta."
+                       :verify-email "Todenna sähköpostiosoite"
+                       :if-not-registered "Mikäli et ole juuri rekisteröitynyt NAP-palveluun, voit jättää tämän viestin huomioimatta."}}}

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1192,7 +1192,8 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
 
   :error {:login-error "Kirjautumistiedoissa virhe. Tarkista tiedot ja kokeile uudestaan."
           :no-such-user "Okänd konto"
-          :incorrect-password "Fel lösenord"}
+          :incorrect-password "Fel lösenord"
+          :unconfirmed-email "Kirjautuminen epäonnistui, koska sähköpostia ei ole todennettu. Jos et ole saanut todennusviestiä rekisteröinnin yhteydessä, voit lähettää sen uudelleen."}
 
   :check-email-for-link "Din begäran om ändring av lösenord har mottagits. Vi har nu skickat en länk för att ändra ditt lösenord till ditt mail."
   :logged-out "Du har blivit utloggad"}
@@ -1252,7 +1253,6 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :change-password "Ändra lösenord"
   :valid-token ["I samband med registreringen får du användarrättigheter till tjänsteproducenten " :operator-name "."]
   :invalid-token "Din inbjudan har förfallit. Avsluta registreringen och kontakta därefter inbjudans avsändare eller NAP Helpdesk (nap@traficom.fi) för att få en ny inbjudan."
-  :invalid-token "Kutsusi on vanhentunut. Jatka rekisteröityminen loppuun, ja ota tämän jälkeen yhteys kutsun lähettäjään tai NAP-Helpdeskiin (nap@traficom.fi) saadaksesi uuden kutsun."
   :verification-email-sent-text ["Kiitos rekisteröitymisestäsi NAP-palveluun! Voidaksesi käyttää palvelua, tulee sinun vielä todentaa sähköpostiosoitteesi. Todennusviesti on lähetetty osoitteseen " :email "."]
   :confirmation-failed "Sähköpostin vahvistus epäonnistui"
   :confirmation-success "Sähköposti vahvistettu"

--- a/ote/src/clj/ote/main.clj
+++ b/ote/src/clj/ote/main.clj
@@ -58,7 +58,7 @@
    :robots (component/using (robots/->RobotsTxt (get-in config [:http :allow-robots?])) [:http])
 
    ;; Services for the frontend
-   :register (component/using (register-services/->Register config) [:http :db])
+   :register (component/using (register-services/->Register config) [:http :db :email])
    :transport (component/using (transport-service/->Transport config) [:http :db :email])
    :external (component/using (external/->External (:nap config)) [:http :db])
    :routes (component/using (routes/->Routes (:nap config)) [:http :db])

--- a/ote/src/clj/ote/services/index.clj
+++ b/ote/src/clj/ote/services/index.clj
@@ -112,7 +112,8 @@
                         {:integrity integrity}))])
       [:style {:id "_stylefy-constant-styles_"} ""]
       [:style {:id "_stylefy-styles_"}]
-      (matomo-analytics-scripts matomo-config)
+      (when (not (true? dev-mode?))
+        (matomo-analytics-scripts matomo-config))
       (translations localization/*language*)
       (user-info db user)]
 

--- a/ote/src/clj/ote/services/login.sql
+++ b/ote/src/clj/ote/services/login.sql
@@ -1,5 +1,5 @@
 -- name: fetch-login-info
-SELECT name, email, password, fullname, id
+SELECT name, email, password, fullname, id, "email-confirmed?"
   FROM "user"
  WHERE (lower(name) = lower(:email) OR lower(email) = lower(:email)) and state = 'active';
 

--- a/ote/src/clj/ote/services/register.clj
+++ b/ote/src/clj/ote/services/register.clj
@@ -58,10 +58,10 @@
                             ::user/apikey (str (UUID/randomUUID))
                             ::user/activity_streams_email_notifications false})]
             (when (and token group-info)                ;; If the user doesn't have a token or group-info they can register, but aren't added to any group
-              (transport/create-member! db (::user/id new-user) (:ckan-group-id operator-info))
+              (transport/create-member! db (::user/id new-user) (:ckan-group-id group-info))
               (specql/delete! db ::user/user-token
                 {::user/token token})
-              (log/info "New user (" email ") registered with token from " (:name operator-info))))
+              (log/info "New user (" email ") registered with token from " (:name group-info))))
           {:success? true})))))
 
 (defn- send-email-verification

--- a/ote/src/clj/ote/services/register.clj
+++ b/ote/src/clj/ote/services/register.clj
@@ -2,15 +2,24 @@
   (:require [compojure.core :refer [routes GET POST DELETE]]
             [com.stuartsierra.component :as component]
             [ote.db.user :as user]
+            [ote.localization :as localization]
             [ote.components.http :as http]
             [specql.core :as specql]
+            [specql.op :as op]
             [ote.services.login :as login]
             [ote.db.tx :as tx :refer [with-transaction]]
             [jeesql.core :refer [defqueries]]
             [ote.util.feature :as feature]
             [clojure.string :as str]
             [ote.services.transport :as transport]
-            [taoensso.timbre :as log])
+            [taoensso.timbre :as log]
+            [ote.email :as email]
+            [hiccup.core :as hiccup]
+            [ote.util.email-template :as email-template]
+            [ote.time :as time]
+            [clj-time.core :as t]
+            [clj-time.coerce :as tc]
+            [ote.util.throttle :as throttle])
   (:import (java.util UUID)))
 
 (defqueries "ote/services/register.sql")
@@ -25,50 +34,118 @@
   (if-not (valid-registration? form-data)
     ;; Check errors that should have been checked on the form
     {:success? false}
-    (with-transaction db
-      (let [username-taken? (username-exists? db {:username username})
-            email-taken? (email-exists? db {:email email})
-            group-info (when token
-                            (first (fetch-operator-info db {:token token})))]
-        (if (or username-taken? email-taken?)
-          ;; Username or email taken, return errors to form
-          {:success? false
-           :username-taken (when username-taken? username)
-           :email-taken (when email-taken? email)}
-          ;; Registration data is valid and username/email is not taken
-          (do
-            (let [new-user (specql/insert! db ::user/user
-                             {::user/id (str (UUID/randomUUID))
-                              ::user/name username
-                              ::user/fullname name
-                              ::user/email email
-                              ::user/password (login/buddy->passlib (login/encrypt password))
-                              ::user/created (java.util.Date.)
-                              ::user/state "active"
-                              ::user/sysadmin false
-                              ::user/apikey (str (UUID/randomUUID))
-                              ::user/activity_streams_email_notifications false})]
-              (when (and token group-info)                  ;; If the user doesn't have a token or group-info they can register, but aren't added to any group
-                (transport/create-member! db (::user/id new-user) (:ckan-group-id group-info))
-                (specql/delete! db ::user/user-token
-                  {::user/token token})
-                (log/info "New user (" email ") registered with token from " (:name group-info))))
-            {:success? true}))))))
+    (let [username-taken? (username-exists? db {:username username})
+          email-taken? (email-exists? db {:email email})
+          group-info (when token
+                          (first (fetch-operator-info db {:token token})))]
+      (if (or username-taken? email-taken?)
+        ;; Username or email taken, return errors to form
+        {:success? false
+         :username-taken (when username-taken? username)
+         :email-taken (when email-taken? email)}
+        ;; Registration data is valid and username/email is not taken
+        (do
+          (let [new-user (specql/insert! db ::user/user
+                           {::user/id (str (UUID/randomUUID))
+                            ::user/name username
+                            ::user/fullname name
+                            ::user/email email
+                            ::user/password (login/buddy->passlib (login/encrypt password))
+                            ::user/created (java.util.Date.)
+                            ::user/state "active"
+                            ::user/sysadmin false
+                            ::user/email-confirmed? false
+                            ::user/apikey (str (UUID/randomUUID))
+                            ::user/activity_streams_email_notifications false})]
+            (when (and token group-info)                ;; If the user doesn't have a token or group-info they can register, but aren't added to any group
+              (transport/create-member! db (::user/id new-user) (:ckan-group-id operator-info))
+              (specql/delete! db ::user/user-token
+                {::user/token token})
+              (log/info "New user (" email ") registered with token from " (:name operator-info))))
+          {:success? true})))))
 
-(defn register [db auth-tkt-config form-data]
-  (feature/when-enabled :ote-register
-    (let [result (register-user! db auth-tkt-config form-data)]
-      (if (:success? result)
-        ;; User created, log in immediately with the user info
-        (login/login db auth-tkt-config form-data)
+(defn- send-email-verification
+  [email-config user-email language email-confirmation-uuid]
+  (let [title "testi"]
+    (try
+      (localization/with-language
+        language
+        (email/send!
+          email-config
+          {:to user-email
+           :subject title
+           :body [{:type "text/html;charset=utf-8"
+                   :content (str email-template/html-header
+                              (hiccup/html (email-template/email-confirmation title email-confirmation-uuid)))}]}))
+      (catch Exception e
+        (log/warn (str "Error while sending verification to:  " user-email " ") e)))))
 
-        ;; Registration failed, return errors
-        (http/transit-response result)))))
+(defn create-confirmation-token!
+  [db user-email token]
+  (let [expiration-date (time/sql-date (.plusDays (java.time.LocalDate/now) 7))]
+    (specql/insert! db ::user/email-confirmation-token
+      {::user/user-email user-email ::user/token token ::user/expiration expiration-date})))
 
+(defn register [db email auth-tkt-config form-data]
+  (with-transaction db
+    (feature/when-enabled :ote-register
+      (let [result (register-user! db auth-tkt-config form-data)
+            email-confirmation-token (str (UUID/randomUUID))
+            user-email (:email form-data)
+            language (:language form-data)]
+        (if (:success? result)
+          ;; User created, log in immediately with the user info
+          (do (create-confirmation-token! db (:email form-data) email-confirmation-token)
+              (send-email-verification email user-email language email-confirmation-token)
+              (http/transit-response result 200))
+          ;; registeration failed send errors
+          (http/transit-response {:message :registeration-failure} 400))))))
+
+(defn delete-users-old-token!
+  [db user-email]
+  (specql/delete! db ::user/email-confirmation-token
+    {::user/user-email user-email}))
+
+(defn manage-new-confirmation
+  "We always want to send the same response so someone can't get all the user emails by spamming this endpoint"
+  [db email-config form-data]
+  (throttle/with-throttle-ms 1000
+    (let [user-email (:email form-data)
+          language (:language form-data)
+          user-confirmed? (::user/email-confirmed?
+                            (first (specql/fetch db ::user/user
+                                     #{::user/email-confirmed?}
+                                     {::user/email user-email})))
+          confirmation-token (str (UUID/randomUUID))]
+      (if user-confirmed?
+        (http/transit-response :success true)
+        (do
+          (delete-users-old-token! db user-email)
+          (create-confirmation-token! db user-email confirmation-token)
+          (send-email-verification email-config user-email language confirmation-token)
+          (http/transit-response :success true))))))
+
+(defn mange-confirm-email-address
+  [db form-data]
+  (let [token (:token form-data)
+        confirmation (first
+                       (specql/fetch db ::user/email-confirmation-token
+                         (specql/columns ::user/email-confirmation-token)
+                         {::user/token token
+                          ::user/expiration (op/>= (tc/to-sql-date (t/now)))}))]
+    (if (not-empty confirmation)
+      (do (specql/update! db ::user/user
+            {::user/email-confirmed? true
+             ::user/confirmation-time (tc/to-sql-date (t/now))}
+            {::user/email (::user/user-email confirmation)})
+          (specql/delete! db ::user/email-confirmation-token
+            {::user/token token})
+          (http/transit-response {:message :email-validation-success} 200))
+      (http/transit-response {:message :email-validation-failure} 401))))
 
 (defn- register-routes
   "Unauthenticated routes"
-  [db config]
+  [db email config]
   (let [auth-tkt-config (get-in config [:http :auth-tkt])]
     (routes
       (POST "/token/validate" {form-data :body
@@ -79,20 +156,30 @@
             (http/transit-response operator)
             (http/transit-response "Invalid token" 400))))
 
+      (POST "/confirm-email" {form-data :body
+                              user :user}
+        (let [form-data (http/transit-request form-data)]
+          (#'mange-confirm-email-address db form-data)))
+
+      (POST "/send-email-confirmation" {form-data :body
+                                        user :user}
+        (let [form-data (http/transit-request form-data)]
+          (#'manage-new-confirmation db email form-data)))
+
       (POST "/register" {form-data :body
                          user :user}
         (if user
           ;; Trying to register while logged in
           (http/transit-response {:success? false})
-          (#'register db auth-tkt-config
+          (#'register db email auth-tkt-config
             (http/transit-request form-data)))))))
 
 (defrecord Register [config]
   component/Lifecycle
-  (start [{:keys [db http] :as this}]
+  (start [{:keys [db email http] :as this}]
     (assoc
       this ::stop
-           [(http/publish! http {:authenticated? false} (register-routes db config))]))
+           [(http/publish! http {:authenticated? false} (register-routes db email config))]))
   (stop [{stop ::stop :as this}]
     (doseq [s stop]
       (s))

--- a/ote/src/clj/ote/util/email_template.clj
+++ b/ote/src/clj/ote/util/email_template.clj
@@ -3,8 +3,6 @@
             [hiccup.util :refer [escape-html]]
             [ote.db.transit :as transit]
             [ote.db.transport-operator :as t-operator]
-            [ote.db.tx :as tx]
-            [ote.db.lock :as lock]
             [ote.localization :refer [tr] :as localization]
             [ote.time :as time]
             [ote.util.db :as db-util]
@@ -172,18 +170,18 @@
       [:br]
       [:br]
       [:p {:style "font-family:Roboto,helvetica neue,arial,sans-serif;font-size:0.75rem;"}
-       "Tämän viestin lähetti NAP."]
+       (tr [:email-templates :footer :email-sender])]
       [:br]
       [:span [:strong {:style "font-family:Roboto,helvetica neue,arial,sans-serif;font-size:0.75rem;"}
-              "NAP-Helpdesk yhteystiedot:"]]
+              (tr [:email-templates :footer :help-desk])]]
       [:p
        [:a {:style "font-family:Roboto,helvetica neue,arial,sans-serif;font-size:0.75rem;"
-            :href "mailto:nap@traficom.fi"} "nap@traficom.fi"]
+            :href "mailto:nap@traficom.fi"} (tr [:email-templates :footer :help-desk-email])]
        [:span {:style "font-family:Roboto,helvetica neue,arial,sans-serif;font-size:0.75rem;"}
-        " tai 029 534 5454 (arkisin 09-15)"]]
+        (tr [:email-templates :footer :help-desk-phone])]]
       [:br]
       (when show-email-settings?
-        [:p {:style "font-family:Roboto,helvetica neue,arial,sans-serif;font-size:0.75rem;padding-bottom: 16px;"}
+        [:p {:style "font-family:Roboto,helvetica neue,arial,sans-serif;font-size:0.75rem;"}
          "Haluatko muuttaa sähköpostiasetuksiasi?"
          [:br]
          [:a
@@ -283,6 +281,17 @@
        (blue-button (str (environment/base-url) "#/register/" token) "Rekisteröidy NAP-palveluun")
 
        (html-divider-border "100%")])))
+
+(defn email-confirmation
+  [title token]
+  (html-template title {:show-email-settings? false}
+    [:div {:style "max-width: 800px"}
+     [:p (tr [:email-templates :email-verification :verification-message])]
+     [:br]
+     [:p (tr [:email-templates :email-verification :if-not-registered])]
+     [:br]
+     (blue-button (str (environment/base-url) "#/confirm-email/" token) (tr [:email-templates :email-verification :verify-email]))
+     (html-divider-border "100%")]))
 
 (defn reset-password [title token user]
   (html-template {:show-email-settings? false} title

--- a/ote/src/cljc/ote/db/user.cljc
+++ b/ote/src/cljc/ote/db/user.cljc
@@ -25,6 +25,8 @@
 
   ["user-token" ::user-token]
 
+  ["email-confirmation-token" ::email-confirmation-token]
+
   ["member" ::member])
 
 (defn username-valid? [username]

--- a/ote/src/cljs/ote/app/controller/confirm_email.cljs
+++ b/ote/src/cljs/ote/app/controller/confirm_email.cljs
@@ -1,0 +1,28 @@
+(ns ote.app.controller.confirm-email
+  (:require [ote.app.routes :as routes]
+            [ote.communication :as comm]
+            [tuck.core :as tuck :refer-macros [define-event]]))
+
+(define-event ConfirmSuccess []
+  {}
+  (-> app
+    (assoc-in [:confirm-email :loaded?] true)
+    (assoc-in [:confirm-email :success?] true)))
+
+(define-event ConfirmFailure []
+  {}
+  (-> app
+    (assoc-in [:confirm-email :loaded?] true)
+    (assoc-in [:confirm-email :success?] false)))
+
+(define-event InitConfirmEmailView []
+  {}
+  (comm/post!
+    "confirm-email"
+    {:token (get-in app [:params :token])}
+    {:on-success (tuck/send-async! ->ConfirmSuccess)
+     :on-failure (tuck/send-async! ->ConfirmFailure)})
+  (assoc-in app [:confirm-email :loaded?] false))
+
+(defmethod routes/on-navigate-event :confirm-email [_]
+  (->InitConfirmEmailView))

--- a/ote/src/cljs/ote/app/controller/resend_confirmation.cljs
+++ b/ote/src/cljs/ote/app/controller/resend_confirmation.cljs
@@ -1,0 +1,23 @@
+(ns ote.app.controller.resend-confirmation
+  (:require [ote.communication :as comm]
+            [tuck.core :as tuck :refer-macros [define-event]]
+            [ote.app.controller.common :refer [->ServerError]]))
+
+(define-event EmailFieldOnChange [input]
+  {}
+  (update-in app [:send-confirmation] assoc :confirmation-email input))
+
+(define-event SendConfirmationSuccess []
+  {}
+  (-> app
+    (assoc-in [:send-confirmation :success?] true)))
+
+(define-event SendConfirmation [email language]
+  {}
+  (comm/post!
+    "send-email-confirmation"
+    {:email email
+     :language language}
+    {:on-success (tuck/send-async! ->SendConfirmationSuccess)
+     :on-failure (tuck/send-async! ->ServerError)})
+  app)

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -147,7 +147,7 @@
                      app (merge app navigation-data)
                      win-location (subs (.. js/window -location -hash) 1)
                      ;; Remove potentially sensitive arguments from analytics script reporting
-                     win-location (if-let [opt-out-page (#{:register :reset-password} (:page navigation-data))]
+                     win-location (if-let [opt-out-page (#{:register :reset-password :confirm-email} (:page navigation-data))]
                                     (str "/" (name opt-out-page))
                                     win-location)]
 

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -38,6 +38,8 @@
     ["/service/:transport-operator-id/:transport-service-id" :service-view]
 
     ["/email-settings" :email-settings]
+    ["/confirm-email/resend-token" :resend-confirmation]
+    ["/confirm-email/:token" :confirm-email]
 
     ;; Route based traffic
     ["/routes" :routes]

--- a/ote/src/cljs/ote/style/notification.cljs
+++ b/ote/src/cljs/ote/style/notification.cljs
@@ -15,7 +15,7 @@
      :padding "1rem"
      :border-radius "4px"}
     (= type :error)
-    {:border (str "1px solid " colors/green-light "7d")
-     :background-color (str colors/green-light "1f")
+    {:border (str "1px solid " colors/red-darker "7d")
+     :background-color (str colors/red-darker "1f")
      :padding "1rem"
      :border-radius "4px"}))

--- a/ote/src/cljs/ote/style/register.cljs
+++ b/ote/src/cljs/ote/style/register.cljs
@@ -1,0 +1,40 @@
+(ns ote.style.register
+  (:require
+    [stylefy.core :as stylefy]))
+
+
+(stylefy/keyframes "fade-out"
+  [:from
+   {:opacity 1}]
+  ["99%"
+   {:opacity 0}]
+  [:to
+   {:opacity 0
+    :max-height 0
+    :visibility "hidden"}])
+
+(stylefy/keyframes "fade-in"
+  [:from
+   {:opacity 0
+    :max-height "200px"}]                                   ;;Doesn't matter what this number is as long as it's bigger than the height of the element
+  [:to
+   {:opacity 1
+    :max-height "200px"}])
+
+
+(def success-fade-in {:opacity 0
+                      :max-height "0px"
+                      :overflow "hidden"
+                      :animation-name "fade-in"
+                      :animation-duration "0.3s"
+                      :animation-fill-mode "forwards"
+                      :animation-delay "0.3s"
+                      ::stylefy/vendors ["webkit" "moz" "o"]
+                      ::stylefy/auto-prefix #{:animation-delay :animation-fill-mode :animation-name :animation-duration}})
+
+(def form-fadeout {:animation-name "fade-out"
+                   :animation-duration "0.3s"
+                   :max-height "1000px"                     ;;Doesn't matter what this number is as long as it's bigger than the height of the form
+                   :overflow "hidden"
+                   :animation-fill-mode "forwards"
+                   ::stylefy/auto-prefix #{:animation-delay :animation-fill-mode :animation-name :animation-duration}})

--- a/ote/src/cljs/ote/ui/form.cljs
+++ b/ote/src/cljs/ote/ui/form.cljs
@@ -173,7 +173,7 @@
         (recur acc
                (concat (remove nil? (:schemas s)) schemas))
 
-        :default
+        :else
         (recur (conj acc s)
                schemas)))))
 

--- a/ote/src/cljs/ote/ui/notification.cljs
+++ b/ote/src/cljs/ote/ui/notification.cljs
@@ -2,8 +2,10 @@
   (:require [ote.style.notification :as notification-style]
             [stylefy.core :as stylefy]))
 
-
 (defn notification
-  [{:keys [type text]}]
-  [:div (stylefy/use-style (notification-style/success-notification type))
-   [:div text]])
+  ([{:keys [type text]}]
+   [:div (stylefy/use-style (notification-style/success-notification type))
+    [:span text]])
+  ([{:keys [type]} body]
+   [:div (stylefy/use-style (notification-style/success-notification type))
+    body]))

--- a/ote/src/cljs/ote/views/confirm_email.cljs
+++ b/ote/src/cljs/ote/views/confirm_email.cljs
@@ -1,0 +1,31 @@
+(ns ote.views.confirm-email
+  "Email confirmation page"
+  (:require [ote.app.controller.confirm-email :as ce]
+            [ote.localization :refer [tr tr-key]]
+            [ote.ui.notification :as notification]
+            [ote.ui.circular_progress :as prog]
+            [ote.ui.common :as common-ui]))
+
+(defn confirm-success
+  []
+  [:div
+   [notification/notification {:text (tr [:register :confirmation-success])
+                               :type :success}]
+   [:div {:style {:margin-top "1rem"}}
+    [common-ui/linkify "/#/login" (tr [:login :login-button])]]])
+
+(defn confirm-email
+  [e! app]
+  (let [loaded? (get-in app [:confirm-email :loaded?])
+        success? (get-in app [:confirm-email :success?])]
+    [:div
+     [:h1 (tr [:register :confirm-email])]
+     (if loaded?
+       (if success?
+         [confirm-success]
+         [notification/notification {:type :warning}
+          [:div
+           [:p {:style {:margin 0}}
+            (tr [:register :confirmation-failed])]
+           [common-ui/linkify "#/confirm-email/resend-token" (tr [:common-texts :send-new-message])]]])
+       [prog/circular-progress])]))

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -24,6 +24,8 @@
             [ote.views.own-services :as os]
             [ote.views.operator-users :as ou]
             [ote.views.service-viewer :as sv]
+            [ote.views.confirm-email :as ce]
+            [ote.views.resend-confirmation :as rc]
             [ote.views.login :as login]
             [ote.views.user :as user]
             [ote.views.admin :as admin]
@@ -137,6 +139,8 @@
                     :admin-exception-days [admin-detected-changes/configure-detected-changes e! (assoc-in app [:admin :transit-changes :tab] "admin-exception-days")]
 
                     :email-settings [email-settings/email-notification-settings e! app]
+                    :confirm-email [ce/confirm-email e! app]
+                    :resend-confirmation [rc/email-confirmation-form e! app]
 
                     :routes [route-list/routes e! app]
                     :new-route [route/new-route e! app]

--- a/ote/src/cljs/ote/views/register.cljs
+++ b/ote/src/cljs/ote/views/register.cljs
@@ -6,11 +6,12 @@
             [ote.localization :refer [tr tr-key]]
             [ote.ui.buttons :as buttons]
             [ote.ui.common :as common]
+            [ote.style.register :as register-style]
+            [stylefy.core :as stylefy]
             [ote.db.user :as user]
             [ote.ui.notification :as notification]))
 
-
-(defn token-check
+(defn invitation-token-check
   [token-info]
   (if (or
         (nil? token-info)
@@ -30,100 +31,105 @@
 ;; component if it is needed in other components, but it needs too many changes
 ;; to be worth it for this form alone.
 
-(defn register [e! {:keys [token] :as params} {:keys [form-data email-taken username-taken token-info] :as register} user]
+(defn register [e! {:keys [token] :as params} {:keys [form-data email-taken username-taken token-info success?] :as register} user]
   (let [edited (r/atom #{})                                 ; keep track of blurred fields
         edit! #(swap! edited conj %)]
-    (fn [e! {:keys [token] :as params} {:keys [form-data email-taken username-taken token-info] :as register} user]
-      [:div
-       [:div.col-xs-12.col-md-6
-        [:h1 (tr [:register :label])]
-        (when (some? token)
-          [token-check token-info])
-        [form/form
-         {:update! #(e! (lc/->UpdateRegistrationForm %))
-          :name->label (tr-key [:register :fields])
-          :footer-fn (fn [data]
-                       [:span
-                        (when (some? user)
-                          [common/help (tr [:register :errors :logged-in] user)])
-                        [buttons/save {:on-click #(e! (lc/->Register (form/without-form-metadata data)))
-                                       :disabled (or (some? user)
-                                                   (form/disable-save? data))}
-                         (tr [:register :label])]])
-          :hide-error-until-modified? true}
-         [(form/group
-            {:expandable? false :columns 3 :card? false :layout :raw}
-            {:element-id "register-username"
-             :name :username
-             :type :string
-             :required? true
-             :full-width? true
-             :placeholder (tr [:register :placeholder :username])
-             :validate [(fn [data _]
-                          (if (< (count data) 3)
-                            (tr [:common-texts :required-field])
-                            (when (not (user/username-valid? data))
-                              (tr [:register :errors :username-invalid]))))
-                        (fn [data _]
-                          (when (and username-taken (username-taken data))
-                            (tr [:register :errors :username-taken])))]
-             :on-blur #(edit! :username)
-             :show-errors? (or (and username-taken
-                                 (username-taken (:username form-data)))
-                             (@edited :username))
-             :should-update-check form/always-update}
-            {:type :component
-             :name :spacer
-             :component (fn [_]
-                          [:div {:style {:margin-top "20px"}}])}
-            {:element-id "register-name"
-             :name :name
-             :type :string
-             :required? true
-             :full-width? true
-             :placeholder (tr [:register :placeholder :name])
-             :on-blur #(edit! :name)
-             :show-errors? (@edited :name)
-             :should-update-check form/always-update}
-            {:element-id "register-email"
-             :name :email
-             :type :string
-             :autocomplete "email"
-             :required? true
-             :full-width? true :placeholder (tr [:register :placeholder :email])
-             :validate [(fn [data _]
-                          (when (not (user/email-valid? data))
-                            (tr [:common-texts :required-field])))
-                        (fn [data _]
-                          (when (and email-taken (email-taken data))
-                            (tr [:register :errors :email-taken])))]
-             :on-blur #(edit! :email)
-             :show-errors? (or (and email-taken
-                                 (email-taken (:email form-data)))
-                             (@edited :email))
-             :should-update-check form/always-update}
-            {:element-id "register-password"
-             :name :password
-             :type :string
-             :password? true
-             :required? true
-             :full-width? true
-             :validate [(fn [data _]
-                          (when (not (user/password-valid? data))
-                            (tr [:register :errors :password-not-valid])))]
-             :on-blur #(edit! :password)
-             :show-errors? (@edited :password)
-             :should-update-check form/always-update}
-            {:element-id "register-confirm"
-             :name :confirm
-             :type :string
-             :password? true
-             :required? true
-             :full-width? true
-             :validate [(fn [data row]
-                          (when (not= data (:password row))
-                            (tr [:register :errors :passwords-must-match])))]
-             :on-blur #(edit! :confirm)
-             :show-errors? (@edited :confirm)
-             :should-update-check form/always-update})]
-         form-data]]])))
+    (fn [e! {:keys [token] :as params} {:keys [form-data email-taken username-taken token-info success?] :as register} user]
+      (let [email (:email form-data)]
+        [:div
+         [:div.col-xs-12.col-md-6
+          [:h1 (tr [:register :label])]
+          (when (and (some? token) (not success?))
+            [invitation-token-check token-info])
+          (when success? [:div (stylefy/use-style register-style/success-fade-in)
+                          [notification/notification {:type :success
+                                                      :text (tr [:register :verification-email-sent-text] {:email email})}]])
+          [:div (when success? (stylefy/use-style register-style/form-fadeout))
+           [form/form
+            {:update! #(e! (lc/->UpdateRegistrationForm %))
+             :name->label (tr-key [:register :fields])
+             :footer-fn (fn [data]
+                          [:span
+                           (when (some? user)
+                             [common/help (tr [:register :errors :logged-in] user)])
+                           [buttons/save {:on-click #(e! (lc/->Register (form/without-form-metadata data)))
+                                          :disabled (or (some? user)
+                                                      (form/disable-save? data))}
+                            (tr [:register :label])]])
+             :hide-error-until-modified? true}
+            [(form/group
+               {:expandable? false :columns 3 :card? false :layout :raw}
+               {:element-id "register-username"
+                :name :username
+                :type :string
+                :required? true
+                :full-width? true
+                :placeholder (tr [:register :placeholder :username])
+                :validate [(fn [data _]
+                             (if (< (count data) 3)
+                               (tr [:common-texts :required-field])
+                               (when (not (user/username-valid? data))
+                                 (tr [:register :errors :username-invalid]))))
+                           (fn [data _]
+                             (when (and username-taken (username-taken data))
+                               (tr [:register :errors :username-taken])))]
+                :on-blur #(edit! :username)
+                :show-errors? (or (and username-taken
+                                    (username-taken (:username form-data)))
+                                (@edited :username))
+                :should-update-check form/always-update}
+               {:type :component
+                :name :spacer
+                :component (fn [_]
+                             [:div {:style {:margin-top "20px"}}])}
+               {:element-id "register-name"
+                :name :name
+                :type :string
+                :required? true
+                :full-width? true
+                :placeholder (tr [:register :placeholder :name])
+                :on-blur #(edit! :name)
+                :show-errors? (@edited :name)
+                :should-update-check form/always-update}
+               {:element-id "register-email"
+                :name :email
+                :type :string
+                :autocomplete "email"
+                :required? true
+                :full-width? true :placeholder (tr [:register :placeholder :email])
+                :validate [(fn [data _]
+                             (when (not (user/email-valid? data))
+                               (tr [:common-texts :required-field])))
+                           (fn [data _]
+                             (when (and email-taken (email-taken data))
+                               (tr [:register :errors :email-taken])))]
+                :on-blur #(edit! :email)
+                :show-errors? (or (and email-taken
+                                    (email-taken (:email form-data)))
+                                (@edited :email))
+                :should-update-check form/always-update}
+               {:element-id "register-password"
+                :name :password
+                :type :string
+                :password? true
+                :required? true
+                :full-width? true
+                :validate [(fn [data _]
+                             (when (not (user/password-valid? data))
+                               (tr [:register :errors :password-not-valid])))]
+                :on-blur #(edit! :password)
+                :show-errors? (@edited :password)
+                :should-update-check form/always-update}
+               {:element-id "register-confirm"
+                :name :confirm
+                :type :string
+                :password? true
+                :required? true
+                :full-width? true
+                :validate [(fn [data row]
+                             (when (not= data (:password row))
+                               (tr [:register :errors :passwords-must-match])))]
+                :on-blur #(edit! :confirm)
+                :show-errors? (@edited :confirm)
+                :should-update-check form/always-update})]
+            form-data]]]]))))

--- a/ote/src/cljs/ote/views/resend_confirmation.cljs
+++ b/ote/src/cljs/ote/views/resend_confirmation.cljs
@@ -1,0 +1,40 @@
+(ns ote.views.resend-confirmation
+  (:require [ote.app.utils :as utils]
+            [ote.ui.form-fields :as form-fields]
+            [ote.localization :as localization :refer [tr]]
+            [ote.app.controller.resend-confirmation :as rc-controller]
+            [ote.ui.buttons :as buttons]
+            [ote.ui.notification :as notification]))
+
+(defn email-confirmation-form
+  [e! {:keys [send-confirmation] :as state}]
+  (let [input-value (:confirmation-email send-confirmation)
+        submit-success? (:success? send-confirmation)]
+    [:div
+     [:h1 (tr [:register :resend-confirmation])]
+     (when submit-success?
+       [notification/notification {:text (tr [:register :resend-success] {:email input-value})
+                                   :type :success}])
+     [:form {:on-submit (fn [e]
+                          (.preventDefault e)
+                          (when (and
+                                  (some? input-value)
+                                  (re-matches utils/email-regex input-value)
+                                  (not submit-success?))
+                            (e! (rc-controller/->SendConfirmation input-value @localization/selected-language))))}
+      [form-fields/field {:element-id "user-email"
+                          :type :string
+                          :full-width? true
+                          :name :add-member
+                          :update! #(e! (rc-controller/->EmailFieldOnChange %))
+                          :label (tr [:register :email-to-be-confirmed])
+                          :placeholder (tr [:transport-users-page :email-placeholder])}
+       input-value]
+      [:div {:style {:display "flex"
+                     :align-items "center"}}
+       [buttons/save
+        {:disabled (not (and
+                          (some? input-value)
+                          (re-matches utils/email-regex input-value)
+                          (not submit-success?)))}
+        (tr [:common-texts :send-new-message])]]]]))

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -1,11 +1,7 @@
 (ns ote.views.user
   "User's own info view"
   (:require [reagent.core :as r]
-            [cljs-react-material-ui.reagent :as ui]
-            [ote.ui.icons :as icons]
-            [stylefy.core :as stylefy]
             [ote.ui.form :as form]
-            [ote.ui.form-fields :as form-fields]
             [ote.db.user :as user]
             [ote.localization :refer [tr tr-key]]
             [ote.ui.buttons :as buttons]
@@ -67,7 +63,7 @@
           {:name :name :type :string :required? true :full-width? true
            :placeholder (tr [:register :placeholder :name])
            :should-update-check form/always-update}
-          {:name :email :type :string :autocomplete "email" :required? true
+          {:name :email :type :string :autocomplete "email" :required? true :disabled? true
            :full-width? true :placeholder (tr [:register :placeholder :email])
            :validate [(fn [data _]
                         (when (not (user/email-valid? data))


### PR DESCRIPTION
# Added
* Email confirmation
   
# Fixed
* Login form returning status code 200 on every response. 

# Changed
* Users can no longer change their emails, because this would bring a lot of unwanted complexity to confirming email addresses. This feature could be done in a different ticket.
   
# Datamodel
* New table for email confirmation tokens
* User now has email-confirmed? column and confirmation timestamp column