### PR TITLE
Reset-password: added needed spaces to texts

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1303,7 +1303,7 @@ You can also draw the operating area or point to the map with drawing tools. You
  {:password-reset {:subject "NAP - Reset your password"
                    :body1 "We have received your request to change your password."
                    :body2 "Click the button"
-                   :body3 "to change your password."
+                   :body3 " to change your password."
                    :body4 "NB! The button link expires one hour after you have received this message."
                    :body5 "If necessary, you can request via NAP that your password is changed again."
                    :body6 "If you are unable to change your password successfully, contact NAP Helpdesk."

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1308,11 +1308,10 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
  {:password-reset {:subject "NAP - Återställ ditt lösenord"
                    :body1 "Vi har tagit emot din begäran om att byta lösenord."
                    :body2 "Klicka på knappen"
-                   :body3 "för att byta lösenord."
+                   :body3 " för att byta lösenord."
                    :body4 "OBS! Länken som knappen leder till förfaller en timme efter att du fått detta meddelande."
                    :body5 "Du kan begära via NAP att ditt lösenord byts igen, om det behövs."
                    :body6 "Om du inte lyckas byta lösenordet, kontakta NAP Helpdesk."
                    :body7 "Om du inte har försökt byta ditt lösenord, kan du ignorera detta meddelande."
                    :body8 "Detta meddelande har skickats automatiskt från NAP-systemet. Svara inte på det här meddelandet, eftersom svaren inte behandlas."
-                   :link-text "Återställ lösenord"}}
- }
+                   :link-text "Återställ lösenord"}}}


### PR DESCRIPTION
# Changed
* translations to include a needed space
* The translations for the email footer were in the email confirmation pull request