### PR TITLE
166180208 remove username field 167647241 session to use userid not username

### DIFF
--- a/database/src/main/resources/db/migration/V1_160__user_name_drop_unique_non_null.sql
+++ b/database/src/main/resources/db/migration/V1_160__user_name_drop_unique_non_null.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "user"
+    DROP CONSTRAINT "user_name_key",
+    ALTER COLUMN "name" DROP NOT NULL;

--- a/database/src/main/resources/db/migration/V1_161__user_email_constraint_unique_not_null.sql
+++ b/database/src/main/resources/db/migration/V1_161__user_email_constraint_unique_not_null.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ONLY "user"
+    ADD CONSTRAINT user_email_unique UNIQUE (email),
+    ALTER COLUMN "email" SET NOT NULL;

--- a/ote/src/clj/ote/nap/users.clj
+++ b/ote/src/clj/ote/nap/users.clj
@@ -15,9 +15,9 @@
 
 (defqueries "ote/nap/users.sql")
 
-(defn find-user [db username]
+(defn find-user [db user-id]
   (let [rows (map db-utils/underscore->structure
-                  (fetch-user-by-username db {:username username}))
+                  (fetch-user-by-id db {:user-id user-id}))
         user (first rows)]
     (when user
       (-> user
@@ -27,11 +27,11 @@
 
 
 (defn wrap-user-info
-  "Ring middleware to fetch user info based on :user-id (username)."
+  "Ring middleware to fetch user info based on :user-id."
   [{:keys [db allow-unauthenticated?]} handler]
-  (fn [{username :user-id :as req}]
-    (if-let [user (when username
-                    (find-user db username))]
+  (fn [{user-id :user-id :as req}]
+    (if-let [user (when user-id
+                    (find-user db user-id))]
       (handler (assoc req :user user))
       (if allow-unauthenticated?
         (handler req)

--- a/ote/src/clj/ote/nap/users.sql
+++ b/ote/src/clj/ote/nap/users.sql
@@ -1,4 +1,4 @@
--- name: fetch-user-by-username
+-- name: fetch-user-by-id
     SELECT u.id as user_id,
            u.name as user_username,
            u.fullname as user_name,
@@ -11,7 +11,7 @@
       FROM "user" u
  LEFT JOIN "member" m ON (m.table_name='user' AND m.state='active' AND m.table_id=u.id)
  LEFT JOIN "group" g ON g.id = m.group_id
-     WHERE u.name = :username;
+     WHERE u.id = :user-id;
 
 -- name: fetch-user-by-email
 SELECT u.id as user_id,

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -47,13 +47,13 @@
           (http/transit-response
             {:success? true
              :session-data
-             (let [user (users/find-user db (:name login-info))]
+             (let [user (users/find-user db (:id login-info))]
                (transport/get-user-transport-operators-with-services db (:groups user) (:user user)))}
             200)
           (cookie/unparse "0.0.0.0" (:shared-secret auth-tkt-config)
             {:digest-algorithm (:digest-algorithm auth-tkt-config)
              :timestamp (java.util.Date.)
-             :user-id (:name login-info)
+             :user-id (:id login-info)
              :user-data ""})
           (:domain auth-tkt-config))
 

--- a/ote/src/clj/ote/services/register.clj
+++ b/ote/src/clj/ote/services/register.clj
@@ -30,15 +30,15 @@
           group-info (when token
                        (first (fetch-operator-info db {:token token})))]
       (if email-taken?
-        ;; Username or email taken, return errors to form
+        ;; email taken, return errors to form
         {:success? false
          :email-taken (when email-taken? email)}
-        ;; Registration data is valid and username/email is not taken
+        ;; Registration data is valid and email is not taken
         (do
           (let [user-id (str (UUID/randomUUID))
                 new-user (specql/insert! db ::user/user
                            {::user/id user-id
-                            ::user/name user-id ;; Username not used anymore, use internally row id
+                            ::user/name user-id ;; Username not used anymore, use internal row id as placeholder just in case
                             ::user/fullname name
                             ::user/email email
                             ::user/password (encrypt/buddy->passlib (encrypt/encrypt password))

--- a/ote/src/clj/ote/services/register.clj
+++ b/ote/src/clj/ote/services/register.clj
@@ -38,9 +38,10 @@
          :email-taken (when email-taken? email)}
         ;; Registration data is valid and username/email is not taken
         (do
-          (let [new-user (specql/insert! db ::user/user
-                           {::user/id (str (UUID/randomUUID))
-                            ::user/name username
+          (let [user-id (str (UUID/randomUUID))
+                new-user (specql/insert! db ::user/user
+                           {::user/id user-id
+                            ::user/name user-id ;; Username not used anymore, use internally row id
                             ::user/fullname name
                             ::user/email email
                             ::user/password (encrypt/buddy->passlib (encrypt/encrypt password))

--- a/ote/src/clj/ote/services/register.sql
+++ b/ote/src/clj/ote/services/register.sql
@@ -1,7 +1,3 @@
--- name: username-exists?
--- single?: true
-SELECT EXISTS(SELECT id FROM "user" WHERE LOWER(name) = LOWER(:username));
-
 -- name: email-exists?
 -- single?: true
 SELECT EXISTS(SELECT id FROM "user" WHERE LOWER(email) = LOWER(:email));

--- a/ote/src/clj/ote/services/users.clj
+++ b/ote/src/clj/ote/services/users.clj
@@ -76,7 +76,7 @@
                                     (not (hashers/check (:current-password form-data)
                                            (encrypt/passlib->buddy (:password login-info))))))]
         (if
-          ;; Password incorrect, username or email taken => return errors to form
+          ;; Password incorrect or email taken => return errors to form
           (or email-taken? password-incorrect?)
           {:success? false
            :email-taken (when email-taken? new-email)
@@ -85,7 +85,7 @@
           ;; Request is valid, do update
           (let [_ (specql/update! db ::user/user
                        (merge
-                         {;; :user/name intentionally not set because it shall not be modified, previously it was possible all the way from UI
+                         {;; username intentionally not set because it shall not be modified, previously it was possible all the way from UI
                           ::user/fullname (:name form-data)}
                          ;; If new password provided, change it
                          (when-not (str/blank? (:password form-data))
@@ -126,13 +126,13 @@
   [db id]
   (let [user (first (specql/fetch db
                       ::user/user
-                      #{::user/id ::user/fullname ::user/email ::user/name ::user/email-confirmed?}
+                      #{::user/id ::user/fullname ::user/email
+                        ::user/email-confirmed?}
                       {::user/id id}))
         user (set/rename-keys user
                {::user/id :id
                 ::user/fullname :name
                 ::user/email :email
-                ::user/name :username
                 ::user/email-confirmed? :email-confirmed?})]
     user))
 

--- a/ote/src/clj/ote/services/users.clj
+++ b/ote/src/clj/ote/services/users.clj
@@ -207,7 +207,7 @@
 (defn clean-old-email-confirmation-tokens
   [db]
   (specql/delete! db ::user/email-confirmation-token
-    {::user/expiration (op/>= (tc/to-sql-date (t/now)))}))
+    {::user/expiration (op/< (tc/to-sql-date (t/now)))}))
 
 (define-service-component UsersService
   {:fields [auth-tkt-config]

--- a/ote/src/cljs/ote/app/controller/common.cljs
+++ b/ote/src/cljs/ote/app/controller/common.cljs
@@ -8,3 +8,6 @@
   (if (= 403 (:status response))
     (assoc app :flash-message-error (tr [:common-texts :forbidden]))
     (assoc app :flash-message-error (tr [:common-texts :server-error]))))
+
+(defn user-logged-in? [app]
+  (not-empty (get-in app [:user])))

--- a/ote/src/cljs/ote/app/controller/login.cljs
+++ b/ote/src/cljs/ote/app/controller/login.cljs
@@ -207,7 +207,6 @@
           :email-taken
           :password-incorrect?))
 
-
 (define-event UpdateResetPasswordForm [form-data]
   {:path [:reset-password]}
   form-data)
@@ -271,3 +270,10 @@
 
 (defmethod routes/on-navigate-event :register [_]
   (->CheckTokenValidity))
+
+(define-event LeaveUserRegister []
+  {}
+  (dissoc app :register))
+
+(defmethod routes/on-leave-event :register [_]
+  (->LeaveUserRegister))

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -2,7 +2,8 @@
   "Routes for the frontend app."
   (:require [bide.core :as r]
             [ote.app.state :as state]
-            [tuck.core :as tuck]))
+            [tuck.core :as tuck]
+            [ote.app.controller.common :refer [user-logged-in?]]))
 
 (def ga-tracking-code
   (.getAttribute js/document.body "data-ga-tracking-code"))
@@ -107,7 +108,7 @@
 
 (defn requires-authentication? [app]
   (and
-       (nil? (get-in app [:user :username]))
+       (not (user-logged-in? app))
        (contains? auth-required (:page app))))
 
 (defn- send-startup-events [event]

--- a/ote/src/cljs/ote/ui/main_header.cljs
+++ b/ote/src/cljs/ote/ui/main_header.cljs
@@ -56,7 +56,7 @@
          [:span {:ref "clicksensor"}])})))
 
 (defn logged-in? [app]
-  (not-empty (get-in app [:user :username])))
+  (not-empty (get-in app [:user])))
 
 (defn- is-user-menu-active [app]
   (when (= true (get-in app [:ote-service-flags :user-menu-open]))
@@ -101,7 +101,7 @@
                (str (str/upper-case lang) " - " flag)]]))]]]]]))
 
 (defn- user-menu [e! app]
-  (when (get-in app [:user :username])
+  (when (logged-in? app)
     (let [header-open? (get-in app [:ote-service-flags :user-menu-open])]
       [:div {:style (merge style-topnav/topnav-dropdown
                            (if header-open?
@@ -165,21 +165,21 @@
                      {:href "#/services"
                       :on-click #(e! (fp-controller/->OpenHeader))})
            (tr [:document-title :services])]]
-         (when (get-in app [:user :username])
+         (when (logged-in? app)
            [:li
             [:a (merge (stylefy/use-style
                          style-topnav/topnav-dropdown-link)
                        {:href "#/own-services"
                         :on-click #(e! (fp-controller/->OpenHeader))})
              (tr [:document-title :own-services])]])
-         (when (get-in app [:user :username])
+         (when (logged-in? app)
            [:li
             [:a (merge (stylefy/use-style
                          style-topnav/topnav-dropdown-link)
                        {:href "#/routes"
                         :on-click #(e! (fp-controller/->OpenHeader))})
              (tr [:common-texts :navigation-route])]])
-         (when (get-in app [:user :username])
+         (when (logged-in? app)
            [:li
             [:a (merge (stylefy/use-style
                          style-topnav/topnav-dropdown-link)
@@ -230,7 +230,7 @@
                   {:target "_blank"})]]]]
        [:div.col-sm-4.col-md-4
         [:ul (stylefy/use-style style-topnav/ul)
-         (if (nil? (get-in app [:user :username]))
+         (if (not (logged-in? app))
            [:ul (stylefy/use-style style-topnav/ul)
             [:li
              (if (flags/enabled? :ote-login)
@@ -347,7 +347,7 @@
           [ic/navigation-menu {:style {:color "#fff" :height 24 :width 30 :top 5}}])]
         [:span.hidden-xs {:style {:color "#fff"}} (tr [:common-texts :navigation-general-menu])]]]
 
-      (when (get-in app [:user :username])
+      (when (logged-in? app)
         [:li (stylefy/use-style style-topnav/li-right)
          [:div.header-user-menu (merge (stylefy/use-style (merge (if (get-in app [:ote-service-flags :user-menu-open])
                                                                    style-topnav/li-right-div-blue
@@ -364,7 +364,7 @@
             [ic/social-person {:style {:color "#fff" :height 24 :width 30 :top 5}}])]
           [:span.hidden-xs {:style {:color "#fff"}} (text/maybe-shorten-text-to 30 (get-in app [:user :name]))]]])
 
-      (when (nil? (get-in app [:user :username]))
+      (when (not (logged-in? app))
         [:li (stylefy/use-style style-topnav/li-right)
          [:div (merge (stylefy/use-style (merge style-topnav/li-right-div-white
                                                 (when @is-scrolled?
@@ -376,7 +376,7 @@
                                  {:margin-top "0px"}))}
            [:span.hidden-xs {:style {:color "#fff"}} (tr [:common-texts :navigation-register])]]]])
 
-      (when (and (nil? (get-in app [:user :username])) (flags/enabled? :ote-login))
+      (when (and (not (logged-in? app)) (flags/enabled? :ote-login))
         [:li (stylefy/use-style style-topnav/li-right)
          [:div (merge (stylefy/use-style (merge style-topnav/li-right-div-white
                                                 (when @is-scrolled?

--- a/ote/src/cljs/ote/ui/main_header.cljs
+++ b/ote/src/cljs/ote/ui/main_header.cljs
@@ -18,7 +18,8 @@
             [ote.app.controller.flags :as flags]
             [clojure.string :as str]
             [ote.localization :as localization]
-            [ote.util.text :as text]))
+            [ote.util.text :as text]
+            [ote.app.controller.common :refer [user-logged-in?]]))
 
 (defn header-scroll-sensor [is-scrolled? trigger-offset]
   (let [sensor-node (atom nil)
@@ -54,9 +55,6 @@
        :reagent-render
        (fn [_]
          [:span {:ref "clicksensor"}])})))
-
-(defn logged-in? [app]
-  (not-empty (get-in app [:user])))
 
 (defn- is-user-menu-active [app]
   (when (= true (get-in app [:ote-service-flags :user-menu-open]))
@@ -101,7 +99,7 @@
                (str (str/upper-case lang) " - " flag)]]))]]]]]))
 
 (defn- user-menu [e! app]
-  (when (logged-in? app)
+  (when (user-logged-in? app)
     (let [header-open? (get-in app [:ote-service-flags :user-menu-open])]
       [:div {:style (merge style-topnav/topnav-dropdown
                            (if header-open?
@@ -165,21 +163,21 @@
                      {:href "#/services"
                       :on-click #(e! (fp-controller/->OpenHeader))})
            (tr [:document-title :services])]]
-         (when (logged-in? app)
+         (when (user-logged-in? app)
            [:li
             [:a (merge (stylefy/use-style
                          style-topnav/topnav-dropdown-link)
                        {:href "#/own-services"
                         :on-click #(e! (fp-controller/->OpenHeader))})
              (tr [:document-title :own-services])]])
-         (when (logged-in? app)
+         (when (user-logged-in? app)
            [:li
             [:a (merge (stylefy/use-style
                          style-topnav/topnav-dropdown-link)
                        {:href "#/routes"
                         :on-click #(e! (fp-controller/->OpenHeader))})
              (tr [:common-texts :navigation-route])]])
-         (when (logged-in? app)
+         (when (user-logged-in? app)
            [:li
             [:a (merge (stylefy/use-style
                          style-topnav/topnav-dropdown-link)
@@ -230,7 +228,7 @@
                   {:target "_blank"})]]]]
        [:div.col-sm-4.col-md-4
         [:ul (stylefy/use-style style-topnav/ul)
-         (if (not (logged-in? app))
+         (if (not (user-logged-in? app))
            [:ul (stylefy/use-style style-topnav/ul)
             [:li
              (if (flags/enabled? :ote-login)
@@ -294,7 +292,7 @@
         (for [{:keys [page label url]}
               (filter some? [{:page  :services
                               :label [:common-texts :navigation-dataset]}
-                             (when (logged-in? app)
+                             (when (user-logged-in? app)
                                {:page  :own-services
                                 :label [:common-texts :navigation-own-service-list]})])]
           ^{:key page}
@@ -347,7 +345,7 @@
           [ic/navigation-menu {:style {:color "#fff" :height 24 :width 30 :top 5}}])]
         [:span.hidden-xs {:style {:color "#fff"}} (tr [:common-texts :navigation-general-menu])]]]
 
-      (when (logged-in? app)
+      (when (user-logged-in? app)
         [:li (stylefy/use-style style-topnav/li-right)
          [:div.header-user-menu (merge (stylefy/use-style (merge (if (get-in app [:ote-service-flags :user-menu-open])
                                                                    style-topnav/li-right-div-blue
@@ -364,7 +362,7 @@
             [ic/social-person {:style {:color "#fff" :height 24 :width 30 :top 5}}])]
           [:span.hidden-xs {:style {:color "#fff"}} (text/maybe-shorten-text-to 30 (get-in app [:user :name]))]]])
 
-      (when (not (logged-in? app))
+      (when (not (user-logged-in? app))
         [:li (stylefy/use-style style-topnav/li-right)
          [:div (merge (stylefy/use-style (merge style-topnav/li-right-div-white
                                                 (when @is-scrolled?
@@ -376,7 +374,7 @@
                                  {:margin-top "0px"}))}
            [:span.hidden-xs {:style {:color "#fff"}} (tr [:common-texts :navigation-register])]]]])
 
-      (when (and (not (logged-in? app)) (flags/enabled? :ote-login))
+      (when (and (not (user-logged-in? app)) (flags/enabled? :ote-login))
         [:li (stylefy/use-style style-topnav/li-right)
          [:div (merge (stylefy/use-style (merge style-topnav/li-right-div-white
                                                 (when @is-scrolled?

--- a/ote/src/cljs/ote/views/admin/user_edit.cljs
+++ b/ote/src/cljs/ote/views/admin/user_edit.cljs
@@ -9,7 +9,7 @@
             [clojure.string :as str]))
 
 (defn merge-user-data [user form-data]
-  (merge (select-keys user #{:name :username :email})
+  (merge (select-keys user #{:name :email})
     form-data))
 
 (defn edit-user
@@ -19,7 +19,7 @@
     {:reagent-render
      (fn
        [e! {:keys [user user-edit params] :as app}]
-       (let [{:keys [email-taken username-taken form-data email-confirmed?]} user-edit]
+       (let [{:keys [email-taken form-data email-confirmed?]} user-edit]
          [:div.user-edit.col-xs-12.col-sm-8.col-md-8.col-lg-6
           [list-header/header app (tr [:common-texts :user-menu-profile])]
           (when user-edit
@@ -39,18 +39,6 @@
                              (tr [:buttons :cancel])]])}
              [(form/group
                 {:expandable? false :columns 3 :layout :raw :card? false}
-
-                {:name :username :type :string :required? true :full-width? true
-                 :placeholder (tr [:register :placeholder :username])
-                 :validate [(fn [data _]
-                              (if (< (count data) 3)
-                                (tr [:common-texts :required-field])
-                                (when (not (user/username-valid? data))
-                                  (tr [:register :errors :username-invalid]))))
-                            (fn [data _]
-                              (when (and username-taken (username-taken data))
-                                (tr [:register :errors :username-taken])))]
-                 :should-update-check form/always-update}
 
                 {:name :name :type :string :required? true :full-width? true
                  :placeholder (tr [:register :placeholder :name])

--- a/ote/src/cljs/ote/views/admin/users.cljs
+++ b/ote/src/cljs/ote/views/admin/users.cljs
@@ -132,21 +132,21 @@
          [ui/table-header {:adjust-for-checkbox false
                            :display-select-all  false}
           [ui/table-row
-           [ui/table-header-column "Käyttäjätunnus"]
-           [ui/table-header-column "Nimi"]
            [ui/table-header-column "Sähköposti"]
+           [ui/table-header-column "Nimi"]
+           [ui/table-header-column "Sisäinen id"]
            [ui/table-header-column "Palveluntuottajat"]
            [ui/table-header-column "Toiminnot"]]]
 
          [ui/table-body {:display-row-checkbox false}
           (doall
             (for [{:keys [id username name email groups] :as user} results]
-              ^{:key (str "user-" username)}
+              ^{:key (str "user-" id)}
               [ui/table-row {:style      {:border-bottom "3px solid rgb(224, 224, 224)"}
                              :selectable false}
-               [ui/table-row-column username]
-               [ui/table-row-column name]
                [ui/table-row-column email]
+               [ui/table-row-column name]
+               [ui/table-row-column id]
                [ui/table-row-column {:style {:padding 0}}
                 [groups-list groups]]
                [ui/table-row-column

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -28,7 +28,8 @@
             [ote.ui.common :as ui-common]
             [ote.views.transport-operator-selection :as t-operator-sel]
             [ote.ui.list-header :as list-header]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [ote.app.controller.common :refer [user-logged-in?]]))
 
 
 (let [host (.-host (.-location js/document))]
@@ -110,7 +111,7 @@
         (tr [:front-page :column-transport-operator])]
 
        [:div {:style {:padding-top "20px"}}
-        (if (not (get-in app [:user :username]))
+        (if (not (user-logged-in? app))
           [:a {:style    {:text-decoration "none"}
                :on-click #(do
                             (.preventDefault %)

--- a/ote/src/cljs/ote/views/register.cljs
+++ b/ote/src/cljs/ote/views/register.cljs
@@ -31,10 +31,10 @@
 ;; component if it is needed in other components, but it needs too many changes
 ;; to be worth it for this form alone.
 
-(defn register [e! {:keys [token] :as params} {:keys [form-data email-taken username-taken token-info success?] :as register} user]
+(defn register [e! {:keys [token] :as params} {:keys [form-data email-taken token-info success?] :as register} user]
   (let [edited (r/atom #{})                                 ; keep track of blurred fields
         edit! #(swap! edited conj %)]
-    (fn [e! {:keys [token] :as params} {:keys [form-data email-taken username-taken token-info success?] :as register} user]
+    (fn [e! {:keys [token] :as params} {:keys [form-data email-taken token-info success?] :as register} user]
       (let [email (:email form-data)]
         [:div
          [:div.col-xs-12.col-md-6

--- a/ote/src/cljs/ote/views/register.cljs
+++ b/ote/src/cljs/ote/views/register.cljs
@@ -59,38 +59,6 @@
              :hide-error-until-modified? true}
             [(form/group
                {:expandable? false :columns 3 :card? false :layout :raw}
-               {:element-id "register-username"
-                :name :username
-                :type :string
-                :required? true
-                :full-width? true
-                :placeholder (tr [:register :placeholder :username])
-                :validate [(fn [data _]
-                             (if (< (count data) 3)
-                               (tr [:common-texts :required-field])
-                               (when (not (user/username-valid? data))
-                                 (tr [:register :errors :username-invalid]))))
-                           (fn [data _]
-                             (when (and username-taken (username-taken data))
-                               (tr [:register :errors :username-taken])))]
-                :on-blur #(edit! :username)
-                :show-errors? (or (and username-taken
-                                    (username-taken (:username form-data)))
-                                (@edited :username))
-                :should-update-check form/always-update}
-               {:type :component
-                :name :spacer
-                :component (fn [_]
-                             [:div {:style {:margin-top "20px"}}])}
-               {:element-id "register-name"
-                :name :name
-                :type :string
-                :required? true
-                :full-width? true
-                :placeholder (tr [:register :placeholder :name])
-                :on-blur #(edit! :name)
-                :show-errors? (@edited :name)
-                :should-update-check form/always-update}
                {:element-id "register-email"
                 :name :email
                 :type :string
@@ -107,6 +75,15 @@
                 :show-errors? (or (and email-taken
                                     (email-taken (:email form-data)))
                                 (@edited :email))
+                :should-update-check form/always-update}
+               {:element-id "register-name"
+                :name :name
+                :type :string
+                :required? true
+                :full-width? true
+                :placeholder (tr [:register :placeholder :name])
+                :on-blur #(edit! :name)
+                :show-errors? (@edited :name)
                 :should-update-check form/always-update}
                {:element-id "register-password"
                 :name :password

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -53,18 +53,6 @@
          [(form/group
             {:expandable? false :columns 3 :layout :raw :card? false}
 
-            {:name :username :type :string :required? true :full-width? true
-             :placeholder (tr [:register :placeholder :username])
-             :validate [(fn [data _]
-                          (if (< (count data) 3)
-                            (tr [:common-texts :required-field])
-                            (when (not (user/username-valid? data))
-                              (tr [:register :errors :username-invalid]))))
-                        (fn [data _]
-                          (when (and username-taken (username-taken data))
-                            (tr [:register :errors :username-taken])))]
-             :should-update-check form/always-update}
-
             {:name :name :type :string :required? true :full-width? true
              :placeholder (tr [:register :placeholder :name])
              :should-update-check form/always-update}

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -21,7 +21,7 @@
     {:component-will-unmount #(e! (lc/->CancelUserEdit false))
      :reagent-render
      (fn
-       [e! {:keys [form-data email-taken username-taken password-incorrect? edit-response] :as user}]
+       [e! {:keys [form-data email-taken password-incorrect? edit-response] :as user}]
 
        [:div.user-edit.col-xs-12.col-sm-8.col-md-8.col-lg-6
         [list-header/header app (tr [:common-texts :user-menu-profile])]

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -10,14 +10,6 @@
             [ote.ui.list-header :as list-header]
             [ote.ui.notification :as notification]))
 
-(defn require-current-password? [user form-data]
-  (or (and (not (str/blank? (:username form-data)))
-           (not= (:username user) (:username form-data)))
-      (and (not (str/blank? (:email form-data)))
-           (not= (:email user) (:email form-data)))
-      (not (str/blank? (:password form-data)))))
-
-
 (defn merge-user-data [user form-data]
   (merge (select-keys user #{:username :name :email})
          form-data))

--- a/ote/test/clj/ote/integration/export/geojson_test.clj
+++ b/ote/test/clj/ote/integration/export/geojson_test.clj
@@ -3,7 +3,7 @@
             [clojure.test :as t :refer [use-fixtures deftest is testing]]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.properties :as prop]
-            [ote.test :refer [system-fixture *ote* http-post http-get sql-execute!]]
+            [ote.test :refer [system-fixture *ote* http-post http-get sql-execute! fetch-id-for-username]]
             [com.stuartsierra.component :as component]
             [ote.services.transport :as transport-service]
             [ote.db.service-generators :as service-generators]
@@ -36,7 +36,8 @@
   ;; Make it public so that GeoJSON export can return it
   (sql-execute! "UPDATE \"transport-service\" SET published = to_timestamp(0) where id = " id)
   (let [geojson-url (str "export/geojson/" transport-operator-id "/" id)
-        json-response (http-get "admin" geojson-url)]
+        json-response (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                geojson-url)]
     (is (= 200 (:status json-response)))
     (is (:json json-response))
     (:json json-response)))
@@ -49,20 +50,22 @@
 (deftest export-geojson-with-interval
   (let [service (assoc (gen/generate (service-generators/service-type-generator :parking))
                        ::t-service/operation-area test-operation-area)
-        response (http-post "admin" "transport-service" service)
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "transport-service"
+                            service)
         id (get-in response [:transit ::t-service/id])]
 
     ;; Check that save is ok
     (is (pos? id))
 
     ;; Fetch exported GeoJSON
-    (let [geojson (export-geojson (:transit response))]
+    (let [geojson (export-geojson (:transit response))
+          maximum-stay (get-in geojson [:features 0 :properties :transport-service
+                                        :parking :maximum-stay])
+          interval-fields (juxt :years :months :days :hours :minutes :seconds)]
       ;; Check that maximum stay interval has the same fields in JSON and Clojure interval type
-      (let [maximum-stay (get-in geojson [:features 0 :properties :transport-service
-                                          :parking :maximum-stay])
-            interval-fields (juxt :years :months :days :hours :minutes :seconds)]
-        (is (= (interval-value (time/iso-8601-period->interval maximum-stay))
-               (interval-value (get-in service [::t-service/parking ::t-service/maximum-stay]))))))))
+      (is (= (interval-value (time/iso-8601-period->interval maximum-stay))
+             (interval-value (get-in service [::t-service/parking ::t-service/maximum-stay])))))))
 
 (deftest service-hours-export
   (testing "Service hours are exported properly and weekdays are sorted"
@@ -70,7 +73,9 @@
                          [:parking [::t-service/parking ::t-service/service-hours]]]
             :let [service (assoc (gen/generate (service-generators/service-type-generator type))
                                  ::t-service/operation-area test-operation-area)
-                  saved-service (:transit (http-post "admin" "transport-service" service))
+                  saved-service (:transit (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                                     "transport-service"
+                                                     service))
                   geojson (export-geojson saved-service)]]
 
       (let [generated-values (get-in service path)
@@ -126,7 +131,9 @@
   (prop/for-all
    [generated-service service-generators/gen-transport-service]
    (let [service (assoc generated-service ::t-service/operation-area test-operation-area)
-         response (http-post "admin" "transport-service" service)
+         response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                             "transport-service"
+                             service)
          id (get-in response [:transit ::t-service/id])]
 
      (and (pos? id)

--- a/ote/test/clj/ote/integration/import/ytj_test.clj
+++ b/ote/test/clj/ote/integration/import/ytj_test.clj
@@ -2,7 +2,7 @@
   (:require  [clojure.test :as t]
              [ote.integration.import.ytj :as ytj]
              [com.stuartsierra.component :as component]
-             [ote.test :as ote-test]
+             [ote.test :as ote-test :refer [fetch-id-for-username]]
              [cheshire.core :refer [encode]]
              [clj-http.client :as http-client]))
 
@@ -30,7 +30,8 @@
                                        :results [{:name "Acme"
                                                   :addresses {:endDate "2012-12-12"}
                                                   :auxiliaryNames [{:endDate "2012-12-12"}]}]}})]
-    (let [result (ote-test/http-get "normaluser" "fetch/ytj?company-id=123132-12")]
+    (let [result (ote-test/http-get (fetch-id-for-username (:db ote.test/*ote*) "normaluser")
+                                    "fetch/ytj?company-id=123132-12")]
       (t/is (= "Acme" (-> result :transit :name)))
       (t/is (not-empty (-> result :transit :addresses)))
       (t/is (empty? (-> result :transit :auxiliaryNames))))))

--- a/ote/test/clj/ote/services/admin_test.clj
+++ b/ote/test/clj/ote/services/admin_test.clj
@@ -4,12 +4,13 @@
             [ote.db.auditlog :as auditlog]
             [specql.core :refer [fetch update! insert! upsert! delete!] :as specql]
             [clojure.test :as t :refer [deftest testing is]]
-            [ote.test :refer [system-fixture http-get http-post http-delete]]
+            [ote.test :refer [system-fixture http-get http-post http-delete fetch-id-for-username]]
             [clojure.test.check.generators :as gen]
             [com.stuartsierra.component :as component]
             [ote.db.generators :as generators]
             [ote.db.service-generators :as s-generators]
-            [ote.services.transport :as transport-service]))
+            [ote.services.transport :as transport-service]
+            [ote.db.user :as user]))
 
 (t/use-fixtures :each
                 (system-fixture
@@ -21,18 +22,21 @@
                                [:http :db])))
 
 (deftest test-user-list-normaluser
-  (let [result (try (http-get "normaluser" "admin/user?type=any&search=napoteadmin")
+  (let [result (try (http-get (fetch-id-for-username (:db ote.test/*ote*) "normaluser")
+                              "admin/user?type=any&search=napoteadmin")
                     (catch clojure.lang.ExceptionInfo e     ;; sadly clj-http wants to communicate status as exceptions
                       (-> e ex-data)))]
     (is (= 403 (:status result))
         "Ensure normal user not allowed to query users")))
 
 (deftest test-user-list-all
-  (let [users (:transit (http-get "admin" "admin/user"))]
+  (let [users (:transit (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                  "admin/user"))]
     (is (= 2 (count users)))))
 
 (deftest test-user-list-email
-  (let [result (try (http-get "admin" "admin/user?type=any&search=admin@napoteadmin123.com")
+  (let [result (try (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                              "admin/user?type=any&search=admin@napoteadmin123.com")
                     (catch clojure.lang.ExceptionInfo e     ;; sadly clj-http wants to communicate status as exceptions
                       (-> e ex-data)))]
     (is (= 200 (:status result))
@@ -41,7 +45,8 @@
         "Ensure admin user gets a list of users")))
 
 (deftest test-user-list-partial-name
-  (let [resp (try (http-get "admin" "admin/user?type=any&search=userso")
+  (let [resp (try (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "admin/user?type=any&search=userso")
                     (catch clojure.lang.ExceptionInfo e
                       (-> e ex-data)))
         result (:transit resp)]
@@ -51,7 +56,8 @@
     (is (= 1 (count result)))))
 
 (deftest test-user-list-partial-email
-  (let [result (http-get "admin" "admin/user?type=any&search=napoteadmin123")
+  (let [result (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                         "admin/user?type=any&search=napoteadmin123")
         transit (:transit result)]
     (is (= 200 (:status result))
         "Ensure http status code is correct")
@@ -61,7 +67,8 @@
         "Ensure response email is correct for user search using a partial email")))
 
 (deftest test-user-not-found-name
-  (let [result (try (http-get "admin" "admin/user?type=any&search=xxxxxxxxyyyyyyyyzzzzzzzzääääääääööööööööåååååååå")
+  (let [result (try (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                              "admin/user?type=any&search=xxxxxxxxyyyyyyyyzzzzzzzzääääääääööööööööåååååååå")
                     (catch clojure.lang.ExceptionInfo e     ;; sadly clj-http wants to communicate status as exceptions
                       (-> e ex-data)))]
     (is (= 404 (:status result))
@@ -70,14 +77,16 @@
         "Ensure no data is returned")))
 
 (deftest test-user-delete-not-found
-  (let [result (try (http-delete "admin" "admin/user/000-000-000-000")
+  (let [result (try (http-delete (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                 "admin/user/000-000-000-000")
                     (catch clojure.lang.ExceptionInfo e     ;; sadly clj-http wants to communicate status as exceptions
                       (-> e ex-data)))]
     (is (= 404 (:status result))
         "Ensure http status code is correct")))
 
 (deftest test-user-memberships-not-found-normaluser
-  (let [result (try (http-get "normaluser" "admin/member?user=0")
+  (let [result (try (http-get (fetch-id-for-username (:db ote.test/*ote*) "normaluser")
+                              "admin/member?user=0")
                     (catch clojure.lang.ExceptionInfo e     ;; sadly clj-http wants to communicate status as exceptions
                       (-> e ex-data)))]
     (is (= 403 (:status result))
@@ -86,7 +95,8 @@
         "Ensure there is no content")))
 
 (deftest test-user-memberships-not-found-admin
-  (let [result (try (http-get "admin" "admin/member?userid=123")
+  (let [result (try (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                              "admin/member?userid=123")
                     (catch clojure.lang.ExceptionInfo e     ;; sadly clj-http wants to communicate status as exceptions
                       (-> e ex-data)))]
     (is (= 200 (:status result))
@@ -97,10 +107,14 @@
 (deftest test-delete-service-made-by-normaluser
   (let [generated-service (gen/generate s-generators/gen-transport-service)
         modified-service (assoc generated-service ::t-service/transport-operator-id 2)
-        response (http-post "normaluser" "transport-service" modified-service)
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "normaluser")
+                            "transport-service"
+                            modified-service)
         parsed-response (:transit response)
         id (::t-service/id parsed-response)
-        deleted-response (http-post "admin" (str "admin/transport-service/delete") {:id id})
+        deleted-response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                    (str "admin/transport-service/delete")
+                                    {:id id})
         auditlog (last (fetch
                          (:db ote.test/*ote*)
                          ::auditlog/auditlog

--- a/ote/test/clj/ote/services/pre_notice_test.clj
+++ b/ote/test/clj/ote/services/pre_notice_test.clj
@@ -1,6 +1,6 @@
 (ns ote.services.pre-notice-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [ote.test :refer [system-fixture http-get http-post]]
+            [ote.test :refer [system-fixture http-get http-post fetch-id-for-username]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.clojure-test :refer [defspec]]
             [com.stuartsierra.component :as component]
@@ -19,7 +19,9 @@
 
 (deftest save-pre-notice
   (let [generated-notice (gen/generate s-generators/gen-pre-notice)
-        response (http-post "admin" "pre-notice" generated-notice)
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "pre-notice"
+                            generated-notice)
         notice (:transit response)
         id (get notice :ote.db.transit/id)]
     ;; Saved ok
@@ -49,7 +51,9 @@
 
 (deftest edit-pre-notice
   (let [generated-notice (gen/generate s-generators/gen-pre-notice)
-        response (http-post "admin" "pre-notice" generated-notice)
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "pre-notice"
+                            generated-notice)
         notice (:transit response)
         id (get notice :ote.db.transit/id)]
 
@@ -59,29 +63,38 @@
     ;; Edit data
     (let [generated-url (gen/generate generators/gen-url)
           modified-notice (assoc notice :ote.db.transit/url generated-url)
-          edit-response (http-post "admin" "pre-notice" modified-notice)
+          edit-response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                   "pre-notice"
+                                   modified-notice)
           edited-notice (:transit edit-response)]
       (is (= generated-url (:ote.db.transit/url edited-notice))))))
 
 (deftest operator-pre-notice-list-draft
   (let [generated-notice (gen/generate s-generators/gen-pre-notice)
-        response (http-post "admin" "pre-notice" generated-notice)
-        list (:transit (http-get "admin" "pre-notices/list"))]
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "pre-notice"
+                            generated-notice)
+        list (:transit (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                 "pre-notices/list"))]
 
     ;; One draft
     (is (= 1 (notice-count list :draft)))
     (is (= 0 (notice-count list :sent)))
 
     ;; Save as sent
-    (http-post "admin" "pre-notice" (assoc generated-notice :ote.db.transit/pre-notice-state :sent))
+    (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin") "pre-notice" (assoc generated-notice :ote.db.transit/pre-notice-state :sent))
     ;; 1 sent
-    (is (= 1 (notice-count (:transit (http-get "admin" "pre-notices/list")) :sent)))))
+    (is (= 1 (notice-count (:transit (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                               "pre-notices/list")) :sent)))))
 
 (deftest operator-pre-notice-list-sent
   (let [generated-notice (gen/generate s-generators/gen-pre-notice)
         sent-notice (assoc generated-notice :ote.db.transit/pre-notice-state :sent)
-        response (http-post "admin" "pre-notice" sent-notice)
-        list (:transit (http-get "admin" "pre-notices/list"))]
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "pre-notice"
+                            sent-notice)
+        list (:transit (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                 "pre-notices/list"))]
 
     ;; 0 draft
     (is (= 0 (notice-count list :draft)))
@@ -91,8 +104,11 @@
 (deftest authority-pre-notice-list
   (let [generated-notice (gen/generate s-generators/gen-pre-notice)
         sent-notice (assoc generated-notice :ote.db.transit/pre-notice-state :sent)
-        response (http-post "admin" "pre-notice" sent-notice)
-        list (:transit (http-get "admin" "pre-notices/authority-list"))]
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "pre-notice"
+                            sent-notice)
+        list (:transit (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                 "pre-notices/authority-list"))]
 
     ;; 1 sent notice
     (is (= 1 (count list)))))

--- a/ote/test/clj/ote/services/service_search_test.clj
+++ b/ote/test/clj/ote/services/service_search_test.clj
@@ -1,7 +1,13 @@
 (ns ote.services.service-search-test
   (:require [ote.services.service-search :as sut]
             [clojure.test :as t :refer [deftest is testing use-fixtures]]
-            [ote.test :refer [system-fixture *ote* http-post http-get sql-execute! sql-query]]
+            [ote.test :refer [system-fixture 
+                              *ote* 
+                              http-post 
+                              http-get 
+                              sql-execute! 
+                              sql-query
+                              fetch-id-for-username]]
             [com.stuartsierra.component :as component]
             [clojure.test.check.generators :as gen]
             [ote.db.generators :as otegen]
@@ -37,7 +43,8 @@
 
   (let [services (generate-services)
         saved-services (mapv (comp :transit
-                                   (partial http-post "admin" "transport-service"))
+                                   (partial http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                            "transport-service"))
                              services)]
     (publish-services! (map ::t-service/id saved-services))
 
@@ -106,10 +113,13 @@
                                                                      :namefin "Hyrynsalmi",
                                                                      :type "finnish-municipality",
                                                                      :primary? true}])
-          saved-service (http-post "admin" "transport-service" service)]
+          saved-service (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                   "transport-service"
+                                   service)]
       (publish-services! [(::t-service/id (:transit saved-service))])
-      (let [services-in (fn [area] (get-in (http-get (str "service-search?operation_area=" area "&response_format=json"))
-                                           [:json :results]))]
+      (let [services-in (fn [area] (get-in
+                                     (http-get (str "service-search?operation_area=" area "&response_format=json"))
+                                     [:json :results]))]
         ;; Matches with itself
         (is (= 1 (count (services-in "Hyrynsalmi"))))
         ;; Doesn't match with neighbouring areas
@@ -131,10 +141,14 @@
                                                                      :namefin "90900 Kiiminki Keskus",
                                                                      :type "finnish-postal",
                                                                      :primary? true}])
-          saved-service (http-post "admin" "transport-service" service)]
+          saved-service (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                   "transport-service"
+                                   service)]
       (publish-services! [(::t-service/id (:transit saved-service))])
-      (let [services-in (fn [area] (get-in (http-get (str "service-search?operation_area=" area "&response_format=json"))
-                                           [:json :results]))]
+      (let [services-in (fn [area]
+                          (get-in
+                            (http-get (str "service-search?operation_area=" area "&response_format=json"))
+                            [:json :results]))]
         ;; Matches with itself
         (is (= 1 (count (services-in "90900 Kiiminki Keskus"))))
         ;; Doesn't match with neighbouring areas
@@ -162,10 +176,14 @@
                                                                      :namefin "Keuruu",
                                                                      :type "finnish-municipality",
                                                                      :primary? true}])
-          saved-service (http-post "admin" "transport-service" service)]
+          saved-service (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                   "transport-service"
+                                   service)]
       (publish-services! [(::t-service/id (:transit saved-service))])
-      (let [services-in (fn [area] (get-in (http-get (str "service-search?operation_area=" area "&response_format=json"))
-                                           [:json :results]))]
+      (let [services-in (fn [area]
+                          (get-in
+                            (http-get (str "service-search?operation_area=" area "&response_format=json"))
+                            [:json :results]))]
         ;; Matches with itself
         (is (= 1 (count (services-in "Keuruu"))))
         ;; Doesn't match with neighbouring areas
@@ -195,10 +213,14 @@
                                                                      :namefin "33200 Tampere Keskus Läntinen",
                                                                      :type "finnish-postal",
                                                                      :primary? true}])
-          saved-service (http-post "admin" "transport-service" service)]
+          saved-service (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                   "transport-service"
+                                   service)]
       (publish-services! [(::t-service/id (:transit saved-service))])
-      (let [services-in (fn [area] (get-in (http-get (str "service-search?operation_area=" area "&response_format=json"))
-                                           [:json :results]))]
+      (let [services-in (fn [area]
+                          (get-in
+                            (http-get (str "service-search?operation_area=" area "&response_format=json"))
+                            [:json :results]))]
         ;; Matches with itself
         (is (= 1 (count (services-in "33200 Tampere Keskus Läntinen"))))
         ;; Doesn't match with neighbouring areas
@@ -222,10 +244,14 @@
                                                       :ote.db.places/namefin "Kannus rautatieasema"
                                                       :ote.db.places/primary? true
                                                       :geojson "{\"type\":\"Point\",\"coordinates\":[23.914974,63.898401]}"}])
-          saved-service (http-post "admin" "transport-service" service)]
+          saved-service (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                   "transport-service"
+                                   service)]
       (publish-services! [(::t-service/id (:transit saved-service))])
-      (let [services-in (fn [area] (get-in (http-get (str "service-search?operation_area=" area "&response_format=json"))
-                                           [:json :results]))]
+      (let [services-in (fn [area]
+                          (get-in
+                            (http-get (str "service-search?operation_area=" area "&response_format=json"))
+                            [:json :results]))]
         ;; Doesn't match with neighbouring areas
         (is (zero? (count (services-in "Petäjävesi"))))
         (is (zero? (count (services-in "Virrat"))))
@@ -258,10 +284,15 @@
                                                                                              :namefin "33200 Tampere Keskus Läntinen",
                                                                                              :type "finnish-postal",
                                                                                              :primary? true}]))))
-          saved-services (map (partial http-post "admin" "transport-service") (shuffle services))]
+          saved-services (map (partial
+                                http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                "transport-service")
+                              (shuffle services))]
       (publish-services! (map #(::t-service/id (:transit %1)) saved-services))
-      (let [services-in (fn [area] (get-in (http-get (str "service-search?operation_area=" area "&response_format=json"))
-                                           [:json :results]))]
+      (let [services-in (fn [area]
+                          (get-in
+                            (http-get (str "service-search?operation_area=" area "&response_format=json"))
+                            [:json :results]))]
         ;; All services are in Tampere
         (is (= 31 (count (services-in "Tampere"))))
         ;; Services are found with postal code as well as it intersects with Tampere 
@@ -287,7 +318,10 @@
                                                                                              :namefin "33200 Tampere Keskus Läntinen",
                                                                                              :type "finnish-postal",
                                                                                              :primary? true}]))))
-          saved-services (map (partial http-post "admin" "transport-service") (shuffle services))]
+          saved-services (map (partial
+                                http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                "transport-service")
+                              (shuffle services))]
       (publish-services! (map #(::t-service/id (:transit %1)) saved-services))
       (let [services-in (fn [area] (get-in (http-get (str "service-search?operation_area=" area "&response_format=json&limit=25&offset=0"))
                                            [:json :results]))]

--- a/ote/test/clj/ote/services/transport_test.clj
+++ b/ote/test/clj/ote/services/transport_test.clj
@@ -1,6 +1,6 @@
 (ns ote.services.transport-test
   (:require  [clojure.test :as t :refer [deftest testing is]]
-             [ote.test :refer [system-fixture http-get http-post]]
+             [ote.test :refer [system-fixture http-get http-post fetch-id-for-username]]
              [clojure.java.jdbc :as jdbc]
              [clojure.test.check :as tc]
              [clojure.test.check.generators :as gen]
@@ -22,7 +22,6 @@
              [clojure.set :as set]
              [ote.time :as time]))
 
-
 (t/use-fixtures :each
   (system-fixture
    :transport (component/using
@@ -34,7 +33,8 @@
 ;; We have a single transport service inserted in the test data,
 ;; check that its information is fetched ok
 (deftest fetch-test-data-transport-service
-  (let [ts (http-get "admin" "transport-service/1")
+  (let [ts (http-get (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                     "transport-service/1")
         service (:transit ts)
         ps (::t-service/passenger-transportation service)]
     (is (= (::t-service/contact-address service)
@@ -150,7 +150,8 @@
      (compare-values comparison v1 v2))))
 
 (defn- save-and-fetch-compare [transport-service compare-key]
-  (let [response (http-post "admin" "transport-service"
+  (let [response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                            "transport-service"
                             transport-service)
         service (:transit response)
         fetch-response (http-get "admin"
@@ -183,7 +184,9 @@
 (deftest save-terminal-service-to-wrong-operator
   (let [generated-terminal-service (gen/generate s-generators/gen-terminal-service)
         modified-terminal-service (assoc generated-terminal-service ::t-service/transport-operator-id 2)
-        response (http-post "normaluser" "transport-service" modified-terminal-service)
+        response (http-post (fetch-id-for-username (:db ote.test/*ote*) "normaluser")
+                            "transport-service"
+                            modified-terminal-service)
         service (:transit response)
         ;; GET generated service from server
         terminal-service (http-get "normaluser" (str "transport-service/" (::t-service/id service)))
@@ -194,12 +197,16 @@
     ;; Gives error, because user doesn't have access rights to operator 1
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo #"status 403"
-          (http-post "normaluser" "transport-service" problematic-terminal-service)))))
+          (http-post (fetch-id-for-username (:db ote.test/*ote*) "normaluser")
+                     "transport-service"
+                     problematic-terminal-service)))))
 
 (deftest delete-transport-service
   (let [service (assoc (gen/generate s-generators/gen-transport-service)
                        ::t-service/transport-operator-id 2)
-        save-response (http-post "normaluser" "transport-service" service)
+        save-response (http-post (fetch-id-for-username (:db ote.test/*ote*) "normaluser")
+                                 "transport-service"
+                                 service)
         id (get-in save-response [:transit ::t-service/id])]
     ;; Saved ok
     (is (pos? id))
@@ -210,7 +217,11 @@
       (is (= id (get-in fetch-response [:transit ::t-service/id]))))
 
     ;; Delete
-    (let [delete-response (http-post "normaluser" "transport-service/delete" {:id id})]
+    (let [delete-response (http-post (fetch-id-for-username
+                                       (:db ote.test/*ote*)
+                                       "normaluser")
+                                     "transport-service/delete"
+                                     {:id id})]
       (is (= (:transit delete-response) id)))
 
     ;; Try to fetch now and it does not exist

--- a/ote/test/clj/ote/tasks/company_test.clj
+++ b/ote/test/clj/ote/tasks/company_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ote.tasks.company :refer [update-one-csv! store-daily-company-stats]]
             [ote.test :refer [system-fixture with-http-resource http-post
-                              sql-query sql-execute! *ote*]]
+                              sql-query sql-execute! *ote* fetch-id-for-username]]
             [ote.services.transport :as transport-service]
             [com.stuartsierra.component :as component]
             [ote.services.external :as external]
@@ -46,7 +46,9 @@
                     (dissoc ::t-service/companies)
                     (assoc ::t-service/companies-csv-url url
                            ::t-service/company-source :csv-url))
-            response (http-post "admin" "transport-service" ts)
+            response (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+                                "transport-service"
+                                ts)
             id (get-in response [:transit ::t-service/id])]
         (is (= 200 (:status response)))
 

--- a/ote/test/clj/ote/tasks/pre_notices_test.clj
+++ b/ote/test/clj/ote/tasks/pre_notices_test.clj
@@ -14,7 +14,6 @@
             [ote.time :as time]
             [clj-time.coerce :as tc]))
 
-
 (t/use-fixtures :each (system-fixture
                        :settings (component/using (settings/->Settings) [:db :http])))
 
@@ -66,13 +65,15 @@
                          {::transit/regions ["01"]}))
 
   (testing "Nothing is sent if the regions don't match"
-    (http-post "admin" "settings/email-notifications"
+    (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+               "settings/email-notifications"
                {::user-notifications/finnish-regions ["02"]})
     (send!)
     (is (empty? @outbox)))
 
   (testing "Email is sent when regions match"
-    (http-post "admin" "settings/email-notifications"
+    (http-post (fetch-id-for-username (:db ote.test/*ote*) "admin")
+               "settings/email-notifications"
                {::user-notifications/finnish-regions ["01" "02"]})
     (send!)
     (is (= 1 (count @outbox)))))

--- a/ote/test/clj/ote/test.clj
+++ b/ote/test/clj/ote/test.clj
@@ -16,7 +16,9 @@
              [clojure.string :as str]
              [clojure.java.io :as io]
              [ote.email :as email]
-             [ote.db.lock :as lock])
+             [ote.db.lock :as lock]
+             [ote.db.user :as user]
+             [specql.core :as specql])
   (:import (org.apache.http.client CookieStore)
            (org.apache.http.cookie Cookie)
            (java.io File)))
@@ -214,3 +216,8 @@
 (defn sql-execute! [& sql-string-parts]
   (jdbc/execute! (:db *ote*)
                  [(str/join sql-string-parts)]))
+
+(defn fetch-id-for-username [db username]
+  (::user/id (first (specql/fetch db ::user/user
+                                  #{::user/id}
+                                  {::user/name username}))))


### PR DESCRIPTION
# Fixed
* 6608475  services: users register fix for 167619111 future tokens deleted

# Changed
* test: fetch run-time the user id of username for session cookie
* db: user table add email field constaint unique not null
* views: admin, in admin user list replace username field using id field
* services: login, fetch user data based on id instead of username
* app: routes requires-authentication? check to use user-logged-in?
* views: front_page,main_header user-logged-in? moved to common controller
* views: main_header use appstate user key instead of username
* views:  remove username handling
* services: register-user to set db row id to username field
* services: save-user not to modify username db field
* controller: login, dissoc register from appstate when navigating away
* db: user username drop constraint unique not null
