### PR TITLE
Transit visualization calendar day font color from theme

### DIFF
--- a/ote/src/cljs/ote/theme/colors.cljs
+++ b/ote/src/cljs/ote/theme/colors.cljs
@@ -52,6 +52,8 @@
 (def success green-basic)
 (def warning red-basic)
 
+(def calendar-day-font gray950)
+
 (def monitor-taxi-color "rgb(0,170,187)")
 (def monitor-request-color "rgb(102,204,102)")
 (def monitor-schedule-color "rgb(153,204,0)")

--- a/ote/src/cljs/ote/theme/colors.cljs
+++ b/ote/src/cljs/ote/theme/colors.cljs
@@ -1,13 +1,10 @@
 (ns ote.theme.colors)
 
-
 (def blue-lighter "#66a3e0")
 (def blue-light "#3385d6")
 (def blue "#0066cc")
 (def blue-dark "#0048c2")
 (def blue-darker "#0029B8")
-
-(def cyan "#00AABB")
 
 (def gray950 "#191919")
 (def gray900 "#323232")
@@ -37,8 +34,9 @@
 (def yellow-basic "#ddcc00")
 (def yellow-dark "#cfb800")
 
-(def spinner cyan)
-
+(def add-color green-basic)
+(def icon-disabled gray550)
+(def icon-gray gray900)
 (def negative-button red-basic)
 (def negative-text white-basic)
 (def negative-button-hover red-dark)
@@ -50,12 +48,9 @@
 (def primary-light blue-light)
 (def secondary gray900)
 (def progress primary)
+(def remove-color red-darker)
 (def success green-basic)
 (def warning red-basic)
-(def add-color green-basic)
-(def remove-color red-darker)
-(def icon-disabled gray550)
-(def icon-gray gray900)
 
 (def monitor-taxi-color "rgb(0,170,187)")
 (def monitor-request-color "rgb(102,204,102)")

--- a/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/calendar.cljs
@@ -37,7 +37,7 @@
       (merge
         {:font-size "0.75rem"
          :background-color hash-color
-         :color "rgb (0, 255, 255)"
+         :color colors/calendar-day-font
          :transition "box-shadow 0.25s"
          :box-shadow "inset 0 0 0 2px transparent, inset 0 0 0 3px transparent, inset 0 0 0 100px transparent"}
         (cond (and (= (time/format-date-iso-8601 date1) d) (some? date2))


### PR DESCRIPTION
# Changed
* theme: remove unused color spinner code and order defs by name 
* views: transit-visualization calendar day font color to existing theme 
