### PR TITLE
167723828 clear deleted user email  167723801 clear email token on admins delete user

### DIFF
--- a/ote/src/clj/ote/nap/users.sql
+++ b/ote/src/clj/ote/nap/users.sql
@@ -121,4 +121,4 @@ AND m.state = 'active';
 
 -- name: delete-user!
 -- "Delete" user from the database - only changes user data to null to preserve foreign key links
-UPDATE "user" SET name = :name, fullname = NULL, email = NULL, state = 'deleted' WHERE id = :id;
+UPDATE "user" SET name = :name, fullname = NULL, email = :id, state = 'deleted' WHERE id = :id;

--- a/ote/src/clj/ote/services/register.clj
+++ b/ote/src/clj/ote/services/register.clj
@@ -14,7 +14,6 @@
             [taoensso.timbre :as log])
   (:import (java.util UUID)))
 
-(defqueries "ote/services/register.sql")
 (defqueries "ote/services/user_service.sql")
 
 (defn- valid-registration? [{:keys [name email password]}]

--- a/ote/src/clj/ote/services/register.sql
+++ b/ote/src/clj/ote/services/register.sql
@@ -1,3 +1,0 @@
--- name: email-exists?
--- single?: true
-SELECT EXISTS(SELECT id FROM "user" WHERE LOWER(email) = LOWER(:email));


### PR DESCRIPTION
# Fixed
* services: remove reqister.sql, the only query is also in user_service.sql
  services: register, use email-exists? form user_service.sql
* services: admin, clear email token when user is deleted
* services: allow delete-user! by setting email to id instead of null