### PR TITLE
167190672 user settings form, email change and password required warnings displayed only after field/form edited

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1236,7 +1236,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :exception "Exception description"}
 
  :user
- {:change-email-warning "Huom! Jos muokkaat sähköpostiosoitetta tulee sinun vahvistaa uusi sähköpostiosoite ennen kuin voit kirjautua uudelleen sisään."}
+ {:change-email-warning "Uusi sähköpostiosoite täytyy vahvistaa, ennen kuin voit kirjautua uudelleen sisään. Saat vahvistuksesta erillisen ohjeviestin sähköpostiisi tietojen tallentamisen jälkeen."}
 
  :register
  {:label "Register for an Account"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1250,7 +1250,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :exception "Poikkeus"}
 
  :user
- {:change-email-warning "Huom! Jos muokkaat sähköpostiosoitetta tulee sinun vahvistaa uusi sähköpostiosoite ennen kuin voit kirjautua uudelleen sisään."}
+ {:change-email-warning "Uusi sähköpostiosoite täytyy vahvistaa, ennen kuin voit kirjautua uudelleen sisään. Saat vahvistuksesta erillisen ohjeviestin sähköpostiisi tietojen tallentamisen jälkeen."}
 
  :register
  {:label "Rekisteröi uusi käyttäjätili"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1239,7 +1239,7 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :exception "Undantag"}
 
  :user
- {:change-email-warning "Huom! Jos muokkaat sähköpostiosoitetta tulee sinun vahvistaa uusi sähköpostiosoite ennen kuin voit kirjautua uudelleen sisään."}
+ {:change-email-warning "Uusi sähköpostiosoite täytyy vahvistaa, ennen kuin voit kirjautua uudelleen sisään. Saat vahvistuksesta erillisen ohjeviestin sähköpostiisi tietojen tallentamisen jälkeen."}
 
  :register
  {:label "Skapa ett nytt konto"

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -57,14 +57,18 @@
                           (when (and email-taken (email-taken data))
                             (tr [:register :errors :email-taken])))]
              :should-update-check form/always-update}
-            (form/info (tr [:user :change-email-warning]))
+
+            (when (and (not (clojure.string/blank? (:email form-data)))
+                       (not= (:email form-data) (:email app)))
+              (form/info (tr [:user :change-email-warning])))
+
             (form/subtitle :h3 (tr [:register :change-password]) {:margin-top "3rem"})
             {:name :password :type :string :password? true
              :label (tr [:register :fields :new-password])
              :full-width? true
              :validate [(fn [data _]
                           (when (and (not (str/blank? data))
-                                  (not (user/password-valid? data)))
+                                     (not (user/password-valid? data)))
                             (tr [:register :errors :password-not-valid])))]
              :should-update-check form/always-update}
             {:name :confirm :type :string :password? true

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -82,7 +82,7 @@
             (form/subtitle :h3 (tr [:register :confirm-changes]) {:margin-top "3rem"})
             {:name :current-password :type :string :password? true
              :full-width? true
-             :required? true
+             :required? (seq (::form/modified form-data))
              :validate [(fn [_ _]
                           (when password-incorrect?
                             (tr [:login :error :incorrect-password])))]})]


### PR DESCRIPTION
# Changed
*  views: user, profile form, password required warning only if form modified
*  views: user, profile form :change-email-warning only if field is edited
* language: :change-email-warning updated FI string to all languages