### PR TITLE
167190672 user profile form hide fields after email change

### DIFF
--- a/ote/src/cljs/ote/app/controller/login.cljs
+++ b/ote/src/cljs/ote/app/controller/login.cljs
@@ -197,7 +197,7 @@
                :on-failure (tuck/send-async! ->SaveUserError)})
   app)
 
-(define-event CancelUserEdit [navigate-back?]
+(define-event UserSettingsInit [navigate-back?]
   {:path [:user]}
   (when navigate-back?
     (.back js/history))
@@ -205,7 +205,8 @@
           :form-data
           :username-taken
           :email-taken
-          :password-incorrect?))
+          :password-incorrect?
+          :edit-response))
 
 (define-event UpdateResetPasswordForm [form-data]
   {:path [:reset-password]}

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -32,7 +32,7 @@
                        [:div {:style {:margin-top "1em"}}
                         (when (:email-changed? edit-response)
                           [:div {:style {:margin-bottom "2rem"}}
-                           [notification/notification {:text (str "Sähköpostiosoitteeseen: " (:new-email edit-response) " on lähetetty vahvistusviesti")
+                           [notification/notification {:text (str "Sähköpostiosoitteeseen " (:new-email edit-response) " on lähetetty vahvistusviesti")
                                                        :type :success}]])
                         [buttons/save {:on-click #(e! (lc/->SaveUser
                                                         (merge-user-data

--- a/ote/src/cljs/ote/views/user.cljs
+++ b/ote/src/cljs/ote/views/user.cljs
@@ -18,72 +18,80 @@
   "Edit own user info"
   [e! app]
   (r/create-class
-    {:component-will-unmount #(e! (lc/->CancelUserEdit false))
+    {:component-did-mount #(e! (lc/->UserSettingsInit false))
+     :component-will-unmount #(e! (lc/->UserSettingsInit false))
      :reagent-render
      (fn
        [e! {:keys [form-data email-taken password-incorrect? edit-response] :as user}]
 
        [:div.user-edit.col-xs-12.col-sm-8.col-md-8.col-lg-6
         [list-header/header app (tr [:common-texts :user-menu-profile])]
-        [form/form
-         {:update! #(e! (lc/->UpdateUser %))
-          :name->label (tr-key [:register :fields])
-          :footer-fn (fn [data]
-                       [:div {:style {:margin-top "1em"}}
-                        (when (:email-changed? edit-response)
-                          [:div {:style {:margin-bottom "2rem"}}
-                           [notification/notification {:text (str "Sähköpostiosoitteeseen " (:new-email edit-response) " on lähetetty vahvistusviesti")
-                                                       :type :success}]])
-                        [buttons/save {:on-click #(e! (lc/->SaveUser
-                                                        (merge-user-data
-                                                          user
-                                                          (form/without-form-metadata data))))
-                                       :disabled (form/disable-save? data)}
-                         (tr [:buttons :save])]
-                        [buttons/cancel {:on-click #(e! (lc/->CancelUserEdit true))}
-                         (tr [:buttons :cancel])]])}
-         [(form/group
-            {:expandable? false :columns 3 :layout :raw :card? false}
 
-            {:name :name :type :string :required? true :full-width? true
-             :placeholder (tr [:register :placeholder :name])
-             :should-update-check form/always-update}
-            {:name :email :type :string :autocomplete "email" :required? true
-             :full-width? true :placeholder (tr [:register :placeholder :email])
-             :validate [(fn [data _]
-                          (when (not (user/email-valid? data))
-                            (tr [:common-texts :required-field])))
-                        (fn [data _]
-                          (when (and email-taken (email-taken data))
-                            (tr [:register :errors :email-taken])))]
-             :should-update-check form/always-update}
+        (if (:success? edit-response)
+          ;; After submitting a successful email change action display only info box and action button
+          [:div
+           (when (:email-changed? edit-response)
+             [:div {:style {:margin-bottom "2rem"}}
+              [notification/notification {:text (str "Sähköpostiosoitteeseen " (:new-email edit-response) " on lähetetty vahvistusviesti")
+                                          :type :success}]])
+           [buttons/cancel {:on-click #(e! (lc/->UserSettingsInit true))}
+            (tr [:buttons :cancel])]]
+          ;; When arriving to view or after a failed form submission: display form.
+          [form/form
+           {:update! #(e! (lc/->UpdateUser %))
+            :name->label (tr-key [:register :fields])
+            :footer-fn (fn [data]
+                         [:div {:style {:margin-top "1em"}}
+                          [buttons/save {:on-click #(e! (lc/->SaveUser
+                                                          (merge-user-data
+                                                            user
+                                                            (form/without-form-metadata data))))
+                                         :disabled (form/disable-save? data)}
+                           (tr [:buttons :save])]
+                          [buttons/cancel {:on-click #(e! (lc/->UserSettingsInit true))}
+                           (tr [:buttons :cancel])]])}
+           [(form/group
+              {:expandable? false :columns 3 :layout :raw :card? false}
 
-            (when (and (not (clojure.string/blank? (:email form-data)))
-                       (not= (:email form-data) (:email app)))
-              (form/info (tr [:user :change-email-warning])))
+              {:name :name :type :string :required? true :full-width? true
+               :placeholder (tr [:register :placeholder :name])
+               :should-update-check form/always-update}
+              {:name :email :type :string :autocomplete "email" :required? true
+               :full-width? true :placeholder (tr [:register :placeholder :email])
+               :validate [(fn [data _]
+                            (when (not (user/email-valid? data))
+                              (tr [:common-texts :required-field])))
+                          (fn [data _]
+                            (when (and email-taken (email-taken data))
+                              (tr [:register :errors :email-taken])))]
+               :should-update-check form/always-update}
 
-            (form/subtitle :h3 (tr [:register :change-password]) {:margin-top "3rem"})
-            {:name :password :type :string :password? true
-             :label (tr [:register :fields :new-password])
-             :full-width? true
-             :validate [(fn [data _]
-                          (when (and (not (str/blank? data))
-                                     (not (user/password-valid? data)))
-                            (tr [:register :errors :password-not-valid])))]
-             :should-update-check form/always-update}
-            {:name :confirm :type :string :password? true
-             :full-width? true
-             :validate [(fn [data row]
-                          (when (not= data (:password row))
-                            (tr [:register :errors :passwords-must-match])))]
-             :should-update-check form/always-update}
+              (when (and (not (clojure.string/blank? (:email form-data)))
+                         (not= (:email form-data) (:email app)))
+                (form/info (tr [:user :change-email-warning])))
 
-            ;; Show current password field if it is required for update
-            (form/subtitle :h3 (tr [:register :confirm-changes]) {:margin-top "3rem"})
-            {:name :current-password :type :string :password? true
-             :full-width? true
-             :required? (seq (::form/modified form-data))
-             :validate [(fn [_ _]
-                          (when password-incorrect?
-                            (tr [:login :error :incorrect-password])))]})]
-         (merge-user-data user form-data)]])}))
+              (form/subtitle :h3 (tr [:register :change-password]) {:margin-top "3rem"})
+              {:name :password :type :string :password? true
+               :label (tr [:register :fields :new-password])
+               :full-width? true
+               :validate [(fn [data _]
+                            (when (and (not (str/blank? data))
+                                       (not (user/password-valid? data)))
+                              (tr [:register :errors :password-not-valid])))]
+               :should-update-check form/always-update}
+              {:name :confirm :type :string :password? true
+               :full-width? true
+               :validate [(fn [data row]
+                            (when (not= data (:password row))
+                              (tr [:register :errors :passwords-must-match])))]
+               :should-update-check form/always-update}
+
+              ;; Show current password field if it is required for update
+              (form/subtitle :h3 (tr [:register :confirm-changes]) {:margin-top "3rem"})
+              {:name :current-password :type :string :password? true
+               :full-width? true
+               :required? (seq (::form/modified form-data))
+               :validate [(fn [_ _]
+                            (when password-incorrect?
+                              (tr [:login :error :incorrect-password])))]})]
+           (merge-user-data user form-data)])])}))


### PR DESCRIPTION
# Changed
* views: user profile, clear state on init and no form after email change
* controller: login, event UserSettingsInit and dissoc :edit-response
* views: user, profile form, remove colon from email change info note