### PR TITLE
161918381 move icon placement

### DIFF
--- a/ote/src/cljs/ote/views/parking.cljs
+++ b/ote/src/cljs/ote/views/parking.cljs
@@ -230,11 +230,11 @@
                        (ts-common/place-search-group (ts-common/place-search-dirty-event e!) ::t-service/parking)
                        (ts-common/external-interfaces e!)
                        (ts-common/advance-reservation-group)
-                       (ts-common/service-url
+                       (ts-common/service-url "real-time-information-url"
                         (tr [:field-labels :parking ::t-service/real-time-information])
                         ::t-service/real-time-information
                         (tr [:form-help :real-time-info]))
-                       (ts-common/service-url
+                       (ts-common/service-url "booking-service-url"
                          (tr [:field-labels :parking ::t-service/booking-service])
                          ::t-service/booking-service)
                        (ts-common/service-urls

--- a/ote/src/cljs/ote/views/passenger_transportation.cljs
+++ b/ote/src/cljs/ote/views/passenger_transportation.cljs
@@ -197,12 +197,12 @@
               (ts-common/place-search-group (ts-common/place-search-dirty-event e!) ::t-service/passenger-transportation)
               (ts-common/external-interfaces e! (get service ::t-service/type) (get service ::t-service/sub-type) (get-in service [::t-service/passenger-transportation ::t-service/transport-type]))
               (luggage-restrictions-group)
-              (ts-common/service-url
+              (ts-common/service-url "real-time-information-url"
                (tr [:field-labels :passenger-transportation ::t-service/real-time-information])
                ::t-service/real-time-information
                (tr [:form-help :real-time-info]))
               (ts-common/advance-reservation-group)
-              (ts-common/service-url
+              (ts-common/service-url "booking-service-url"
                (tr [:field-labels :transport-service-common ::t-service/booking-service])
                ::t-service/booking-service)
               (accessibility-group)

--- a/ote/src/cljs/ote/views/rental.cljs
+++ b/ote/src/cljs/ote/views/rental.cljs
@@ -309,12 +309,12 @@
                      (accessibility-group)
                      (additional-services)
                      (usage-area)
-                     (ts-common/service-url
+                     (ts-common/service-url "real-time-information-url"
                       (tr [:field-labels :rentals ::t-service/real-time-information])
                       ::t-service/real-time-information
                       (tr [:form-help :real-time-info]))
                      (ts-common/advance-reservation-group)
-                     (ts-common/service-url
+                     (ts-common/service-url "booking-service-url"
                       (tr [:field-labels :transport-service-common ::t-service/booking-service])
                       ::t-service/booking-service)
                      (pick-up-locations e!)]

--- a/ote/src/cljs/ote/views/terminal.cljs
+++ b/ote/src/cljs/ote/views/terminal.cljs
@@ -26,7 +26,7 @@
                   [ts-common/footer e! data schemas app])})
 
 (defn- indoor-map-group []
-  (ts-common/service-url
+  (ts-common/service-url "indoor-map-url"
    (tr [:field-labels :terminal ::t-service/indoor-map])
    ::t-service/indoor-map))
 

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -415,6 +415,7 @@
       (when (seq (:differences compare))
         [:div {:style {:padding-top "0.5rem"}}
          [tv-change-icons/change-icons-for-trips compare true]
+         [:div {:style {:padding-bottom "1rem"}}]
          [tv-change-icons/change-icons-for-dates compare date1-label date2-label]])
       [:div.route-trips
        ;; Group by different (d1 start, d1 stop, d2 start, d2 stop) stops
@@ -505,6 +506,7 @@
         (when (seq (:differences compare))
           [:div {:style {:padding-top "0.5rem"}}
            [tv-change-icons/change-icons-for-stops compare true]
+           [:div {:style {:padding-bottom "1rem"}}]
            [tv-change-icons/change-icons-for-dates compare date1-label date2-label]])
 
         [:div.trip-stop-sequence {:style {:margin-top "1em"}}

--- a/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
@@ -126,12 +126,17 @@
                0)
      (when with-labels? " poistettua vuoroa")]]])
 
-(defn- show-trip-sequences [diff with-labels?]
-  [:div {:style {:flex "1"}}
+(defn- show-trip-sequences [diff with-labels? use-flex?]
+  [:div (when use-flex? {:style {:flex 1}})
    [stop-seq-changes-icon (:trip-stop-sequence-changes-lower diff) (:trip-stop-sequence-changes-upper diff) with-labels?]])
 
-(defn- show-stop-times [diff with-labels?]
-  [:div {:style {:flex "1"}}
+(defn- show-stop-times
+  "This element should be rendered differently every time it is used. Which is really nice. So we need to know how many other elements
+  there are in the same row when this is used. This is designed for four elements. When only two elements are in the same row, this element
+  can't be as far as it is when there is four."
+  [diff with-labels? use-flex?]
+  [:div
+   (when use-flex? {:style {:flex 1}})
    [stop-time-changes-icon (:trip-stop-time-changes-lower diff) (:trip-stop-time-changes-upper diff) with-labels?]])
 
 (defn change-icons-for-calendar
@@ -142,8 +147,8 @@
    [:div (stylefy/use-style (style-base/flex-container "row"))
     [show-added-trips diff with-labels?]
     [show-removed-trips diff with-labels?]
-    [show-trip-sequences diff with-labels?]
-    [show-stop-times diff with-labels?]
+    [show-trip-sequences diff with-labels? true]
+    [show-stop-times diff with-labels? true]
 
     (if (str/includes? (str change-type) "no-traffic")
       [:div {:style {:flex "0.5"} :title (tr [:transit-changes :no-traffic])}
@@ -164,16 +169,16 @@
    [:div (stylefy/use-style (style-base/flex-container "row"))
     [show-added-trips diff with-labels?]
     [show-removed-trips diff with-labels?]
-    [show-trip-sequences diff with-labels?]
-    [show-stop-times diff with-labels?]]))
+    [show-trip-sequences diff with-labels? true]
+    [show-stop-times diff with-labels? true]]))
 
 (defn change-icons-for-stops
   ([diff]
    [change-icons-for-stops diff false])
   ([diff with-labels?]
    [:div (stylefy/use-style (style-base/flex-container "row"))
-    [show-trip-sequences diff with-labels?]
-    [show-stop-times diff with-labels?]]))
+    [show-trip-sequences diff with-labels? false]
+    [show-stop-times diff with-labels? false]]))
 
 (defn change-icons-for-dates
   ([compare-data]
@@ -191,4 +196,5 @@
   (when (seq (:differences compare-data))
     [:div {:style {:padding "0.5rem 0rem 1rem 0rem"}}
      [change-icons-for-trips (:differences compare-data) true]
+     [:div {:style {:padding-bottom "1rem"}}]
      (change-icons-for-dates compare-data)]))

--- a/ote/src/cljs/ote/views/transport_service.cljs
+++ b/ote/src/cljs/ote/views/transport_service.cljs
@@ -82,7 +82,8 @@
               transport-operator]]]]
     [:div.row
      [:div {:class "col-sx-12 col-sm-4 col-md-4"}
-      [ui/raised-button {:style {:margin-top "20px"}
+      [ui/raised-button {:id "own-service-next-btn"
+                         :style {:margin-top "20px"}
                          :label    (tr [:buttons :next])
                          :on-click #(e! (ts/->NavigateToNewService))
                          :primary  true

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -45,8 +45,8 @@
 
 (defn service-url
   "Creates a form group for service url that creates two form elements url and localized text area"
-  ([label service-url-field] (service-url label service-url-field nil))
-  ([label service-url-field info-message]
+  ([element-id label service-url-field] (service-url element-id label service-url-field nil))
+  ([element-id label service-url-field info-message]
    (apply
     form/group
     {:label label
@@ -58,6 +58,7 @@
        [(form/info info-message)])
 
      [{:class "set-bottom"
+       :element-id element-id
        :name   ::t-service/url
        :type   :string
        :read   (comp ::t-service/url service-url-field)
@@ -510,10 +511,12 @@
                       :type :localized-text}
                      {:name ::t-service/from-date
                       :type :date-picker
-                      :label (tr* :from-date)}
+                      :label (tr* :from-date)
+                      :element-id "service-exception-from-date"}
                      {:name ::t-service/to-date
                       :type :date-picker
-                      :label (tr* :to-date)}]
+                      :label (tr* :to-date)
+                      :element-id "service-exception-to-date"}]
       :delete? true
       :add-label (tr [:buttons :add-new-service-exception])}
 


### PR DESCRIPTION
# Fixed
* Removed all warning from transport service page by adding missing id's and removing empty error messages
   
# Changed
* Added more space to sequence and date icons
* Moved time and sequence icons closer together when there is only two elements on the same row
