### PR TITLE
views: transit-visualization, custom trip stop diff icon layout

### DIFF
--- a/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization/change_icons.cljs
@@ -170,10 +170,13 @@
 (defn change-icons-for-stops
   ([diff]
    [change-icons-for-stops diff false])
-  ([diff with-labels?]
+  ([{:keys [trip-stop-sequence-changes-lower trip-stop-sequence-changes-upper] :as diff} with-labels?]
    [:div (stylefy/use-style (style-base/flex-container "row"))
-    [show-trip-sequences diff with-labels?]
-    [show-stop-times diff with-labels?]]))
+    ;; show-trip-sequences not used here because of needed custom layout
+    [:div {:style {:flex 1}}
+     [stop-seq-changes-icon trip-stop-sequence-changes-lower trip-stop-sequence-changes-upper with-labels?]]
+    [:div {:style {:flex 3}}
+     [show-stop-times diff with-labels?]]]))
 
 (defn change-icons-for-dates
   ([compare-data]


### PR DESCRIPTION
# Changed
* Changed existing feature.Stop time icons happen to align with the above change icons.
New layout from UX to avoid impression that the change-icon's change
count would apply only for the day below it. When it actually displays
the difference of the two days.
The problem is not just as bad for the view's other tables, because
there the change-icon row has more than just two indicators.
