### PR TITLE
views: transit-visualization, stops table default icon to none

### DIFF
--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -542,8 +542,7 @@
                            (time/minutes-elapsed departure-time-date1 departure-time-date2))]
 
                         :default
-                        [icon-l/icon-labeled {:style color/icon-disabled}
-                         [ic/action-query-builder color/icon-disabled] nil]))}]
+                        ""))}]                              ;; Empty string just to ensure nil/null are never displayed
           combined-stop-sequence]]])]))
 
 (defn- selected-route-map [_ _ _ {show-stops? :show-stops?


### PR DESCRIPTION
# Changed
* Fixes default icon not using icon-disabled color because of missing :color keyword.
Instead of adding :color, remove icon because it's according to UX spec