### PR TITLE
167727513 pre notices email subject timestamp fixed, admin button to manually trigger pre-notice emails

### DIFF
--- a/ote/src/cljs/ote/app/controller/admin_transit_changes.cljs
+++ b/ote/src/cljs/ote/app/controller/admin_transit_changes.cljs
@@ -227,11 +227,29 @@
               :on-failure (tuck/send-async! ->CSVLoadFailure)})
   app)
 
+(define-event SendPreNoticeSuccess [response]
+  {}
+  (.log js/console "SendPreNoticeSuccess = " response)
+  (assoc-in app [:admin :responses :pre-notice-notify] :success))
+
+(define-event SendPreNoticeFailure [response]
+  {}
+  (.log js/console "SendPreNoticeFailure = " response)
+  (assoc-in app [:admin :responses :pre-notice-notify] response))
+
+(define-event SendPreNotices []
+  {}
+  (comm/get! "/admin/pre-notices/notify"
+             {
+              :on-success (tuck/send-async! ->SendPreNoticeSuccess)
+              :on-failure (tuck/send-async! ->SendPreNoticeFailure)})
+  app)
+
 (define-event GeneralTroubleshootingLog []
   {}
   (comm/get! "admin/general-troubleshooting-log"
-             {:on-success #(.log js/console "response " %)
-              :on-failure #(.log js/console "response " %)})
+             {:on-success #(.log js/console "response = " %)
+              :on-failure #(.log js/console "response = " %)})
   app)
 
 (defn ^:export force-detect-transit-changes []

--- a/ote/src/cljs/ote/app/controller/admin_transit_changes.cljs
+++ b/ote/src/cljs/ote/app/controller/admin_transit_changes.cljs
@@ -48,7 +48,7 @@
   app)
 
 (defmethod routes/on-navigate-event :admin-detected-changes [{params :params}]
-  (->LoadHashRecalculations ))
+  (->LoadHashRecalculations))
 
 (defmethod routes/on-navigate-event :admin-commercial-services [_]
   (->LoadCommercialServices))
@@ -94,7 +94,7 @@
     ;; When service-id is not given, do not try to start detection
     (when service-id
       (comm/post! (str "transit-changes/force-detect/" service-id) nil
-                 {:on-success (tuck/send-async! ->SetSingleDetectionServiceId service-id)}))
+                  {:on-success (tuck/send-async! ->SetSingleDetectionServiceId service-id)}))
     app))
 
 (define-event ForceInterfaceImportForGivenServiceSuccess [response]
@@ -202,7 +202,7 @@
 (define-event ResetHashRecalculations []
   {}
   (comm/delete! (str "transit-changes/hash-calculation") {}
-             {:on-success (tuck/send-async! ->LoadHashRecalculations)})
+                {:on-success (tuck/send-async! ->LoadHashRecalculations)})
   app)
 
 

--- a/ote/src/cljs/ote/views/admin/detected_changes.cljs
+++ b/ote/src/cljs/ote/views/admin/detected_changes.cljs
@@ -89,7 +89,7 @@
                                           500))})
      [:span btn-text]]]])
 
-(defn detect-changes [e! app-state]
+(defn detect-changes [e! {:keys [admin] :as app-state}]
   [:div (stylefy/use-style (style-base/flex-container "column"))
 
    [:h3 "Rajapintoihin kohdistuvat toimenpiteet"]
@@ -191,6 +191,20 @@
     "Laske sopimusliikenteelle kaikki päivätiivisteet uusiksi. Laskenta ei ota huomioon kaupallista liikennettä."
     "Laske sopimusliikenteelle päivätiivisteet"
     #(e! (admin-transit-changes/->CalculateDayHash "contract" "false"))]
+
+   [:br]
+   [day-hash-button-element e!
+    "Käynnistä uusi muutosilmoitusten sähköposti-ilmoituksen lähetys. Operaatio ei lähetä edellistä sähköpostia uudestaan,
+    vaan koostaa uudet ilmoitukset, lähettää ne, sekä päivittää lähetyshistorian.
+    Lähetettyjä ilmoituksia ei siis lähetetä uudestaan seuraavalla ajastetulla tai käsin käynnistetyllä ajolla."
+    "Käynnistä muutosilmoitusten lähetys"
+    #(e! (admin-transit-changes/->SendPreNotices))]
+   [:div (stylefy/use-style style-admin/detection-info-text)
+    (when-let [resp (get-in admin [:responses :pre-notice-notify])]
+      [notification/notification
+       (if (= :success resp)
+         {:type :success :text (str "Mahdolliset muutosilmoitusten sähköpostit lähetetty")}
+         {:type :error :text (str "Mahdollisten muutosilmoitusten sähköpostien lähettäminen ei onnistunut. Virhetietoja: " resp)})])]
 
    [:br]
    [day-hash-button-element e!

--- a/ote/test/clj/ote/tasks/pre_notices_task_test.clj
+++ b/ote/test/clj/ote/tasks/pre_notices_task_test.clj
@@ -19,7 +19,7 @@
                        :settings (component/using (settings/->Settings) [:db :http])))
 
 (defn send! []
-  (sut/send-notification! (:db *ote*) (:email *ote*) constantly))
+  (sut/send-pre-notice-email! (:db *ote*) (:email *ote*) constantly))
 
 (def test-pre-notice {::t-operator/id 1
                       ::transit/sent (java.util.Date.)


### PR DESCRIPTION
# Added
* views: admin: button to manually trigger pre-notice email sending
  controller: admin: SendPreNotices event for manual triggering
* services: admin: pre-notices/notify endpoint for manual email triggering

# Fixed
* services: pre-notices: email subject composition to dynamic, was static
 