### PR TITLE
167216897 stop order

### DIFF
--- a/ote/src/cljc/ote/transit_changes.cljc
+++ b/ote/src/cljc/ote/transit_changes.cljc
@@ -129,10 +129,11 @@
 (defn earliest-departure-time [stop]
   (let [minutes-from-midnight1 (some-> stop :gtfs/departure-time-date1 (time/minutes-from-midnight))
         minutes-from-midnight2 (some-> stop :gtfs/departure-time-date2 (time/minutes-from-midnight))]
-    ; Use date2 departure time as master when sorting results
-    (if (some? minutes-from-midnight2)
-      minutes-from-midnight2
-      (max minutes-from-midnight1 minutes-from-midnight2))))
+    ; Use date2 departure time as master when sorting results. If both are nil set time to zero
+    (cond
+      (some? minutes-from-midnight2) minutes-from-midnight2
+      (some? minutes-from-midnight1) minutes-from-midnight1
+      :default 0)))
 
 (defn format-stop-info
   "recieves 2 vectors, first vector has coordinates, which are not used here, second vector is other stop-information"

--- a/ote/src/cljc/ote/transit_changes.cljc
+++ b/ote/src/cljc/ote/transit_changes.cljc
@@ -129,10 +129,10 @@
 (defn earliest-departure-time [stop]
   (let [minutes-from-midnight1 (some-> stop :gtfs/departure-time-date1 (time/minutes-from-midnight))
         minutes-from-midnight2 (some-> stop :gtfs/departure-time-date2 (time/minutes-from-midnight))]
-    (cond
-      (nil? minutes-from-midnight1) minutes-from-midnight2
-      (nil? minutes-from-midnight2) minutes-from-midnight1
-      :default (max minutes-from-midnight1 minutes-from-midnight2))))
+    ; Use date2 departure time as master when sorting results
+    (if (some? minutes-from-midnight2)
+      minutes-from-midnight2
+      (max minutes-from-midnight1 minutes-from-midnight2))))
 
 (defn format-stop-info
   "recieves 2 vectors, first vector has coordinates, which are not used here, second vector is other stop-information"

--- a/ote/src/cljs/ote/style/transit_changes.cljs
+++ b/ote/src/cljs/ote/style/transit_changes.cljs
@@ -33,10 +33,8 @@
    :top "-0.5rem"
    :left "0.2rem"})
 
-(def date1-highlight-color "rgba(53,140,217,1)")
-(def date1-highlight-color-hover "rgba(53,140,217,0.5)")
-(def date2-highlight-color "rgba(219,25,169,1)")
-(def date2-highlight-color-hover "rgba(219,25,169,0.5)")
+(def date1-highlight-color "rgba(219,25,169,1)")
+(def date2-highlight-color "rgba(53,140,217,1)")
 (def date-highlight-color-hover colors/gray650)
 
 

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -500,7 +500,8 @@
     [tv-utilities/section {:open? (get open-sections :trip-stop-sequence true)
                            :toggle! #(e! (tv/->ToggleSection :trip-stop-sequence))}
      "Pysäkit"
-     "Pysäkkilistalla näytetään valitun vuoron pysäkkikohtaiset aikataulut."
+     (str "Pysäkkilistalla näytetään valitun vuoron pysäkkikohtaiset aikataulut. Pysäkit on järjestetty jälkimmäisen vertailupäivän mukaan ( "
+          (time/format-date (:date2 compare)) " ).")
      (let [second-stops-empty? (empty? (:stoptimes (second selected-trip-pair)))]
        [:div
         (when (seq (:differences compare))


### PR DESCRIPTION
# Changed
* transit-visualization - stop section: stops are now sorted by date2 departure time.

# Fixed 
* transit-visualization - map section:  map line colors where in wrong order.
   

