### PR TITLE
167393604 sea transit route data model to unrestricted stop times 2

### DIFF
--- a/database/src/main/resources/db/migration/V1_166__alter-transit-stop-time-to-interval.sql
+++ b/database/src/main/resources/db/migration/V1_166__alter-transit-stop-time-to-interval.sql
@@ -1,0 +1,49 @@
+-- Normalize transit_trip and transit_trip into new tables
+CREATE TABLE transit_route_trip
+(
+    id                     SERIAL PRIMARY KEY,
+    "transit-route-id"     INTEGER REFERENCES "transit_route" (id) ON DELETE CASCADE,
+    "service-calendar-idx" INTEGER,
+    "stop-times"           transit_stop_time[] -- temporary column for to allow flattening data to transit_stop_time on migration
+);
+CREATE TABLE transit_route_stop_time
+(
+    id                            SERIAL PRIMARY KEY,
+    "transit-trip-id"             INTEGER REFERENCES "transit_route_trip" (id) ON DELETE CASCADE,
+    "stop-idx"                    INTEGER,
+    "arrival-time"                INTERVAL, -- converted to INTERVAL to support 24h+ trips
+    "departure-time"              INTERVAL, -- converted to INTERVAL to support 24h+ trips
+    "pickup-type"                 transit_stopping_type,
+    "drop-off-type"               transit_stopping_type
+);
+
+INSERT INTO "transit_route_trip" ("transit-route-id",
+                                  "service-calendar-idx",
+                                  "stop-times")
+    (SELECT r.id, t."service-calendar-idx", t."stop-times"
+     FROM "transit_route" AS r,
+          UNNEST(r.trips) AS t);
+
+--
+INSERT INTO transit_route_stop_time ("transit-trip-id",
+                                     "stop-idx",
+                                     "pickup-type",
+                                     "drop-off-type",
+                                     "arrival-time",
+                                     "departure-time")
+    (SELECT t.id,
+            s."stop-idx",
+            s."pickup-type",
+            s."drop-off-type",
+            s."arrival-time"::INTERVAL,
+            s."departure-time"::INTERVAL
+     FROM transit_route_trip AS t,
+          UNNEST(t."stop-times") AS s);
+
+-- Drop old replaced data structures
+ALTER TABLE transit_route
+    DROP COLUMN "trips";
+ALTER TABLE transit_route_trip
+    DROP COLUMN "stop-times";
+DROP TYPE transit_trip CASCADE;
+DROP TYPE transit_stop_time CASCADE;

--- a/ote/src/clj/ote/integration/export/gtfs.clj
+++ b/ote/src/clj/ote/integration/export/gtfs.clj
@@ -25,7 +25,7 @@
            db :db :as this}]
     (assoc this
            ::stop (http/publish! http {:authenticated? false}
-                                 (GET "/export/gtfs/:transport-operator-id{[0-9]+}"
+                                 (GET "/export/gtfs-sea/:transport-operator-id{[0-9]+}"
                                       [transport-operator-id]
                                       (export-sea-gtfs db (Long/parseLong transport-operator-id))))))
   (stop [{stop ::stop :as this}]

--- a/ote/src/clj/ote/integration/export/gtfs.clj
+++ b/ote/src/clj/ote/integration/export/gtfs.clj
@@ -14,9 +14,10 @@
             [taoensso.timbre :as log]
             [ote.util.fn :refer [flip]]
             [ote.db.transport-service :as t-service]
-            [ote.localization :refer [*language*]]))
+            [ote.localization :refer [*language*]]
+            [ote.services.routes :refer [fetch-sea-trips]]))
 
-(declare export-gtfs)
+(declare export-sea-gtfs)
 
 (defrecord GTFSExport []
   component/Lifecycle
@@ -26,25 +27,28 @@
            ::stop (http/publish! http {:authenticated? false}
                                  (GET "/export/gtfs/:transport-operator-id{[0-9]+}"
                                       [transport-operator-id]
-                                      (export-gtfs db (Long/parseLong transport-operator-id))))))
+                                      (export-sea-gtfs db (Long/parseLong transport-operator-id))))))
   (stop [{stop ::stop :as this}]
     (stop)
     (dissoc this ::stop)))
 
-(defn- current-routes
-  "Return the currently available published routes of the given transport operator."
+(defn- fetch-sea-routes-published
+  "Return the currently available published sea routes of the given transport operator."
   [db transport-operator-id]
-  (let [now (java.util.Date.)]
-    (fetch db ::transit/route
-           #{::transit/id ::transit/name ::transit/stops ::transit/trips
-             ::transit/route-type ::transit/service-calendars}
-           {::transit/transport-operator-id transport-operator-id
-            ::transit/published? true})))
+  (let [routes (fetch db ::transit/route
+               #{::transit/route-id ::transit/name ::transit/stops
+                 ::transit/route-type ::transit/service-calendars}
+               {::transit/transport-operator-id transport-operator-id
+                ::transit/published? true})]
+    (mapv #(assoc %
+            ::transit/trips
+            (fetch-sea-trips db (::transit/route-id %)))
+          routes)))
 
-(defn routes-gtfs-zip
+(defn sea-routes-gtfs-zip
   [transport-operator routes output-stream]
   (try
-    (write-zip (gtfs-transform/routes-gtfs transport-operator routes)
+    (write-zip (gtfs-transform/sea-routes-gtfs transport-operator routes)
                output-stream)
     (catch Exception e
       (log/warn "Exception while generating GTFS zip" e))))
@@ -53,16 +57,14 @@
                                             ::t-operator/homepage ::t-operator/phone
                                             ::t-operator/email})
 
-(defn export-gtfs [db transport-operator-id]
+(defn export-sea-gtfs [db transport-operator-id]
   (let [transport-operator (first (fetch db ::t-operator/transport-operator
                                          transport-operator-columns
                                          {::t-operator/id transport-operator-id}))
-        routes (map #(-> %
-                       (update ::transit/name (flip t-service/localized-text-with-fallback) *language*)
-                       (update ::transit/trips (flip mapv) transit/trip-stop-times-from-24h))
-                    (current-routes db transport-operator-id))]
+        routes (map #(update % ::transit/name (flip t-service/localized-text-with-fallback) *language*)
+                    (fetch-sea-routes-published db transport-operator-id))]
     {:status 200
      :headers {"Content-Type" "application/zip"
                "Content-Disposition" "attachment; filename=gtfs.zip"}
      :body (ring-io/piped-input-stream
-            (partial routes-gtfs-zip transport-operator routes))}))
+            (partial sea-routes-gtfs-zip transport-operator routes))}))

--- a/ote/src/clj/ote/services/admin.clj
+++ b/ote/src/clj/ote/services/admin.clj
@@ -207,7 +207,7 @@
 
 (defn- list-sea-routes [db user query]
   (specql/fetch db ::transit/route
-                #{::transit/id ::transit/transport-operator-id ::transit/name ::transit/published?
+                #{::transit/route-id ::transit/transport-operator-id ::transit/name ::transit/published?
                   [::transit/operator #{::t-operator/name ::t-operator/id}]}
                 {::transit/operator {::t-operator/name (op/ilike (str "%" query "%"))}}))
 

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -197,8 +197,6 @@
                                       ::transit/trip
                                       (op/and {:transit-trip/route-id route-id}
                                               {:transit-trip/trip-id (op/not (op/in trip-ids-saved))}))]
-    (log/debug "Updating trip model: trip ids saved =" trip-ids-saved
-               ", count of trip records deleted = " trip-records-deleted)
     ;; ::transit/stop-time records referencing the deleted ::transit/trip records are not deleted explicitly here,
     ;; because design relies to implicit deletion as a result of the ON DELETE CASCADE constraint
     trips-saved))
@@ -218,9 +216,6 @@
                     (modification/with-modification-fields ::transit/id user)
                     (update ::transit/stops #(mapv stop-location-geometry %))
                     (update ::transit/service-calendars #(mapv service-calendar-dates->db %)))
-              _ (log/debug "Saving route: route-id =" (::transit/route-id r)
-                           ", trip count = " (count (::transit/trips r))
-                           ", object =" r)
               route-saved (upsert! db ::transit/route (dissoc r ::transit/trips))
               route-id (::transit/route-id route-saved)]
           (update-trip-model! db

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -171,7 +171,7 @@
                                                                         stop-times-saved)))}))
     stop-times-saved))
 
-(defn- update-trips!
+(defn- update-trips-and-stops!
   "Takes `trips` and updates them to db as well as stop-time records which refer to them.
   Returns a collection of saved trips with updated primary key."
   [db trips]
@@ -191,7 +191,7 @@
   "Takes a collection of `trips` for `route-id` and saves the trips and deletes trips not part of route anymore"
   [db trips route-id]
   {:pre [(clojure.test/is (not (neg-int? route-id)))]}            ; `is` used to print the value of a failed precondition
-  (let [trips-saved (update-trips! db trips)
+  (let [trips-saved (update-trips-and-stops! db trips)
         trip-ids-saved (set-for-keys :transit-trip/trip-id trips-saved)
         trip-records-deleted (delete! db                    ; Orphaned trips must be removed
                                       ::transit/trip

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -213,7 +213,7 @@
         db
         (let [r (-> route
                     (save-custom-stops db user)
-                    (modification/with-modification-fields ::transit/id user)
+                    (modification/with-modification-fields ::transit/route-id user)
                     (update ::transit/stops #(mapv stop-location-geometry %))
                     (update ::transit/service-calendars #(mapv service-calendar-dates->db %)))
               route-saved (upsert! db ::transit/route (dissoc r ::transit/trips))

--- a/ote/src/cljc/ote/db/transit.cljc
+++ b/ote/src/cljc/ote/db/transit.cljc
@@ -31,11 +31,26 @@
   ["transit_service_rule" ::service-rule]
   ["transit_service_calendar" ::service-calendar]
   ["transit_stopping_type" ::stopping-type (specql.transform/transform (specql.transform/to-keyword))]
-  ["transit_stop_time" ::stop-time]
-  ["transit_trip" ::trip]
+  ["transit_route_stop_time" ::stop-time
+   {"id" :transit-stop-time/stop-time-id
+    "transit-trip-id" :transit-stop-time/trip-id}]
+  ["transit_route_trip" ::trip
+   {"id" :transit-trip/trip-id
+    "transit-route-id" :transit-trip/route-id}
+   {::stop-times (specql.rel/has-many
+                   :transit-trip/trip-id
+                   :ote.db.transit/stop-time
+                   :transit-stop-time/trip-id)}]
   ["transit_route" ::route
    ote.db.modification/modification-fields
-   {::operator (specql.rel/has-one ::transport-operator-id :ote.db.transport-operator/transport-operator :ote.db.transport-operator/id)}]
+   {"id" :ote.db.transit/route-id}
+   {::operator (specql.rel/has-one ::transport-operator-id
+                                   :ote.db.transport-operator/transport-operator
+                                   :ote.db.transport-operator/id)
+    ::trips (specql.rel/has-many
+              :ote.db.transit/route-id
+              :ote.db.transit/trip
+              :transit-trip/route-id)}]
 
   ["finnish_ports" ::finnish-ports
    ote.db.modification/modification-fields]

--- a/ote/src/cljc/ote/db/transit.cljc
+++ b/ote/src/cljc/ote/db/transit.cljc
@@ -103,42 +103,6 @@
   [time]
   (update time :hours mod 24))
 
-(defn trip-stop-times-to-24h
-  "Convert all stop times to be within 24h hours. Trips that span multiple days
-  may have stop times greater than 24h but they must be stored in the database
-  in 24h format."
-  [trip]
-  (update trip ::stop-times (flip mapv)
-          (fn [st]
-            (-> st
-                (update ::arrival-time #(when % (time-to-24h %)))
-                (update ::departure-time #(when % (time-to-24h %)))))))
-
-(defn trip-stop-times-from-24h
-  "Convert trip stop times from 24h to continuous hours.
-  A trip that spans multiple days will have stop times greater than 24h."
-  [trip]
-  (update trip ::stop-times
-          (fn [stop-times]
-            (loop [hours-to-add 0
-                   acc []
-                   previous-departure nil
-                   [st & stop-times] stop-times]
-              (if (nil? st)
-                acc
-                (let [hours-to-add (if (and previous-departure
-                                            (< (time/minutes-from-midnight (::arrival-time st))
-                                               (time/minutes-from-midnight previous-departure)))
-                                     (+ hours-to-add 24)
-                                     0)]
-                  (recur hours-to-add
-                         (conj acc (-> st
-                                       (update ::arrival-time #(when % (update % :hours + hours-to-add)))
-                                       (update ::departure-time #(when % (update % :hours + hours-to-add)))))
-                         (::departure-time st)
-                         stop-times)))))))
-
-
 (defn service-calendar-date-fields
   "Convert service calendar dates from database (with time part) to date fields."
   [service-calendar]

--- a/ote/src/cljs/ote/app/controller/route/route_list.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_list.cljs
@@ -25,7 +25,7 @@
 (defn- update-route-by-id [app id update-fn & args]
   (update app :routes-vector
           (fn [services]
-            (map #(if (= (::transit/id %) id)
+            (map #(if (= (::transit/route-id %) id)
                     (apply update-fn % args)
                     %)
                  services))))
@@ -75,7 +75,7 @@
 
   DeleteRouteResponse
   (process-event [{response :response} app]
-    (let [filtered-map (filter #(not= (::transit/id %) (int response)) (get app :routes-vector))]
+    (let [filtered-map (filter #(not= (::transit/route-id %) (int response)) (get app :routes-vector))]
       (assoc app :routes-vector filtered-map
                  :flash-message (tr [:common-texts :delete-route-success])
                  :routes-changed? true)))

--- a/ote/src/cljs/ote/views/admin/sea_routes.cljs
+++ b/ote/src/cljs/ote/views/admin/sea_routes.cljs
@@ -1,4 +1,5 @@
-(ns ote.views.admin.sea-routes
+(ns
+  ote.views.admin.sea-routes
   "Admin panel views. Note this has a limited set of users and is not
   currently localized, all UI text is in Finnish."
   (:require [cljs-react-material-ui.reagent :as ui]
@@ -11,7 +12,8 @@
             [ote.ui.form-fields :as form-fields]
             [ote.db.transport-service :as t-service]
             [ote.db.transport-operator :as t-operator]
-            [ote.db.transit :as transit]))
+            [ote.db.transit :as transit]
+            [ote.ui.circular_progress :as circular]))
 
 (defn sea-routes-page-controls [e! app]
   [:div.row {:style {:padding-top "20px"}}
@@ -35,7 +37,8 @@
         loc (.-location js/document)]
      [:div.row {:style {:padding-top "40px"}}
       (when loading?
-        [:span "Ladataan merireittejä..."])
+        [circular/circular-progress
+         [:span "Ladataan merireittejä..."]])
 
       (when results
         [:div

--- a/ote/src/cljs/ote/views/admin/sea_routes.cljs
+++ b/ote/src/cljs/ote/views/admin/sea_routes.cljs
@@ -51,15 +51,15 @@
             ]]
           [ui/table-body {:display-row-checkbox false}
            (doall
-             (for [{::transit/keys [id name operator published?] :as sea-route} results]
-               ^{:key (str "link_" id)}
+             (for [{::transit/keys [route-id name operator published?] :as sea-route} results]
+               ^{:key (str "link_" route-id)}
                [ui/table-row {:selectable false}
                 [ui/table-row-column {:style {:width "30%"}} (::t-operator/name operator)]
                 [ui/table-row-column {:style {:width "40%"}} [:a {:href "#"
                                                                   :on-click #(do
                                                                                (.preventDefault %)
                                                                                (e! (admin-controller/->ChangeRedirectTo :admin))
-                                                                               (e! (fp/->ChangePage :edit-route {:id id})))}
+                                                                               (e! (fp/->ChangePage :edit-route {:id route-id})))}
                                                               (t-service/localized-text-with-fallback @selected-language name)]]
                 [ui/table-row-column {:style {:width "10%"}} (if published? "Kyllä" "Ei") ]
                 [ui/table-row-column {:style {:width "20%"}}

--- a/ote/src/cljs/ote/views/admin/sea_routes.cljs
+++ b/ote/src/cljs/ote/views/admin/sea_routes.cljs
@@ -67,5 +67,5 @@
                 [ui/table-row-column {:style {:width "10%"}} (if published? "Kyllä" "Ei") ]
                 [ui/table-row-column {:style {:width "20%"}}
                  [:a {:href (str (.-protocol loc) "//" (.-host loc) (.-pathname loc)
-                     "export/gtfs/" (::t-operator/id operator))}
+                     "export/gtfs-sea/" (::t-operator/id operator))}
                   "Lataa gtfs"]]]))]]])]))

--- a/ote/src/cljs/ote/views/route/route_list.cljs
+++ b/ote/src/cljs/ote/views/route/route_list.cljs
@@ -22,15 +22,15 @@
     [ote.ui.buttons :as buttons]
     [ote.style.dialog :as style-dialog]))
 
-(defn- delete-route-action [e! {::transit/keys [id name]
+(defn- delete-route-action [e! {::transit/keys [route-id name]
                                   :keys [show-delete-modal?]
                                   :as route}]
   [:span
-   [ui/icon-button {:id       (str "delete-route-" id)
+   [ui/icon-button {:id       (str "delete-route-" route-id)
                     :href     "#"
                     :on-click #(do
                                  (.preventDefault %)
-                                 (e! (route-list/->OpenDeleteRouteModal id)))}
+                                 (e! (route-list/->OpenDeleteRouteModal route-id)))}
     [ic/action-delete]]
    (when show-delete-modal?
      [ui/dialog
@@ -41,13 +41,13 @@
                    [buttons/cancel
                     {:on-click #(do
                                   (.preventDefault %)
-                                  (e! (route-list/->CancelDeleteRoute id)))}
+                                  (e! (route-list/->CancelDeleteRoute route-id)))}
                     (tr [:buttons :cancel])])
                  (r/as-element
                    [buttons/delete
                     {:on-click  #(do
                                    (.preventDefault %)
-                                   (e! (route-list/->ConfirmDeleteRoute id)))}
+                                   (e! (route-list/->ConfirmDeleteRoute route-id)))}
                     (tr [:buttons :delete])])]}
 
       (str (tr [:route-list-page :delete-dialog-remove-route]) (t-service/localized-text-with-fallback @selected-language name))])])
@@ -70,16 +70,16 @@
     [ui/table-body {:display-row-checkbox false}
      (doall
        (map-indexed
-         (fn [i {::transit/keys      [id name published? available-from available-to
+         (fn [i {::transit/keys      [route-id name published? available-from available-to
                                       departure-point-name destination-point-name]
                  ::modification/keys [created modified] :as row}]
            ^{:key (str "route-" i)}
            [ui/table-row {:key (str "route-" i) :selectable false :display-border false}
             [ui/table-row-column {:style {:width "18%"}}
-             [:a {:href     "#"
+             [:a {:href "#"
                   :on-click #(do
                                (.preventDefault %)
-                               (e! (fp/->ChangePage :edit-route {:id id})))} (t-service/localized-text-with-fallback @selected-language name)]]
+                               (e! (fp/->ChangePage :edit-route {:id route-id})))} (t-service/localized-text-with-fallback @selected-language name)]]
             [ui/table-row-column {:class "hidden-xs hidden-sm " :style {:width "10%"}} (tr [:route-list-page :route-list-published?-values published?])]
             [ui/table-row-column {:style {:width "10%"}} (t-service/localized-text-with-fallback @selected-language departure-point-name)]
             [ui/table-row-column {:style {:width "10%"}} (t-service/localized-text-with-fallback @selected-language destination-point-name)]
@@ -87,10 +87,10 @@
             [ui/table-row-column {:style {:width "10%"}} (when available-to (time/format-date available-to))]
             [ui/table-row-column {:class "hidden-xs hidden-sm " :style {:width "15%"}} (time/format-timestamp-for-ui (or modified created))]
             [ui/table-row-column {:class "hidden-xs hidden-sm " :style {:width "13%"}}
-             [ui/icon-button {:href     "#"
+             [ui/icon-button {:href "#"
                               :on-click #(do
                                            (.preventDefault %)
-                                           (e! (fp/->ChangePage :edit-route {:id id})))}
+                                           (e! (fp/->ChangePage :edit-route {:id route-id})))}
               [ic/content-create]]
              [delete-route-action e! row]]])
          routes))]]])

--- a/ote/src/cljs/ote/views/route/route_list.cljs
+++ b/ote/src/cljs/ote/views/route/route_list.cljs
@@ -123,7 +123,7 @@
      (when routes
        (let [loc (.-location js/document)
              url (str (.-protocol loc) "//" (.-host loc) (.-pathname loc)
-                      "export/gtfs/" (::t-operator/id operator))]
+                      "export/gtfs-sea/" (::t-operator/id operator))]
          [:span
           [:br]
           [common/help

--- a/ote/src/cljs/ote/views/route/trips.cljs
+++ b/ote/src/cljs/ote/views/route/trips.cljs
@@ -153,10 +153,11 @@
            ^{:key (str stop-idx "-arr")}
            [:td style
             [:div.col-md-11
-             [form-fields/field {:type    :time
+             [form-fields/field {:type :time
                                  :required? true
+                                 ;; Restricted because first departure cannot be before 24 hours.
                                  :unrestricted-hours? (> stop-idx 0)
-                                 :update! #(update! {::transit/arrival-time %})}
+                                 :update! #(update! {::transit/arrival-time (time/time->interval %)})}
               arrival-time]]
             [:div.col-md-1 {:style {:margin-left "-10px"}}
              [exception-icon e! :arrival drop-off-type stop-idx row-idx]]])
@@ -166,10 +167,11 @@
            ^{:key (str stop-idx "-dep")}
            [:td style
             [:div.col-md-11
-             [form-fields/field {:type    :time
+             [form-fields/field {:type :time
                                  :required? true
-                                 :unrestricted-hours? (> stop-idx 0)
-                                 :update! #(update! {::transit/departure-time %})}
+                                 ;; All arrival hours allowed because time between two stops could be 24h or more
+                                 :unrestricted-hours? true
+                                 :update! #(update! {::transit/departure-time (time/time->interval %)})}
               departure-time]]
             [:div.col-md-1 {:style {:margin-left "-10px"}}
              [exception-icon e! :departure pickup-type stop-idx row-idx]]]))))


### PR DESCRIPTION
# Added
* services: route: sort trips by stop time, fetch-sea-trips for reuse
* views: admin: spinner to accompany loading content placeholder message
   
# Changed
* integration, views: endpoint export gtfs renamed to gtfs-sea
* route-id key renamed from id in various places
* views: route: unrestricted stop times except first departure
* views: route-wizard addtrip to use data model with trip or stop-time ids
* services: routes: trips and stop-times from new db tables
* db: specql define transit-trip and stop-time tables, route table id key
* gtfs: transform: sea route-id key renamed from id, renamed functions
  gtfs: route: route-id key renamed from id and reuse db fetching
   
# Datamodel
* db: alter sea transit stop time to interval and drop old types
  