### PR TITLE
167393604 sea route stop-time validation moved to :on-blur event 

### DIFF
--- a/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
@@ -90,6 +90,7 @@
 (defrecord DeleteTrip [trip-idx])
 
 (defrecord EditStopTime [trip-idx stop-idx form-data])
+(defrecord ValidateStopTime [trip-idx stop-idx form-data])
 (defrecord ShowStopException [stop-type stop-idx icon-type trip-idx])
 
 ;; Event to set service calendar
@@ -250,6 +251,26 @@
   (and (seq (::transit/service-rules calendar))
        (every? valid-calendar-rule?
                (::transit/service-rules calendar))))
+
+(defn stop-times-validated [stop-times]
+  ;; Marks arrival/departure time which is too early compared to previous, so view may
+  ;; display warning and disable saving
+  (reduce
+    (fn [v curr]
+      (let [stop-prev (last v)
+            chronology-problem (cond
+                                 (nil? stop-prev) nil       ; First stop cannot be non-chronological
+                                 (time/interval< (::transit/arrival-time curr)
+                                                 (::transit/departure-time stop-prev)) ::transit/arrival-time
+                                 (time/interval< (::transit/departure-time curr)
+                                                 (::transit/arrival-time curr)) ::transit/departure-time
+                                 :else nil)]
+        (conj v
+              (if chronology-problem
+                (assoc curr :time-invalid chronology-problem)
+                (dissoc curr :time-invalid)))))
+    []
+    stop-times))
 
 (extend-protocol tuck/Event
   LoadStops
@@ -595,29 +616,14 @@
 
   EditStopTime
   (process-event [{:keys [trip-idx stop-idx form-data]} app]
-    (let [stop-times-validated (fn [stop-times]
-                                 ;; Marks arrival/departure time which is too early compared to previous, so view may
-                                 ;; display warning and disable saving
-                                 (reduce
-                                   (fn [v curr]
-                                     (let [stop-prev (last v)
-                                           chronology-problem (cond
-                                                                (nil? stop-prev) nil ; First stop cannot be non-chronological
-                                                                (time/interval< (::transit/arrival-time curr)
-                                                                                (::transit/departure-time stop-prev)) ::transit/arrival-time
-                                                                (time/interval< (::transit/departure-time curr)
-                                                                                (::transit/arrival-time curr)) ::transit/departure-time
-                                                                :else nil)]
-                                       (conj v
-                                             (if chronology-problem
-                                               (assoc curr :time-invalid chronology-problem)
-                                               (dissoc curr :time-invalid)))))
-                                   []
-                                   stop-times))]
-      (-> app
-          (route-updated)
-          (update-in [:route ::transit/trips trip-idx ::transit/stop-times stop-idx] merge form-data)
-          (update-in [:route ::transit/trips trip-idx ::transit/stop-times] stop-times-validated))))
+    (-> app
+        (route-updated)
+        (update-in [:route ::transit/trips trip-idx ::transit/stop-times stop-idx] merge form-data)))
+
+  ValidateStopTime
+  (process-event [{:keys [trip-idx stop-idx form-data] :as event} app]
+    (-> app
+        (update-in [:route ::transit/trips trip-idx ::transit/stop-times] stop-times-validated)))
 
   ShowStopException
   (process-event [{stop-type :stop-type stop-idx :stop-idx icon-type :icon-type trip-idx :trip-idx :as evt} app]

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -600,7 +600,7 @@
 ;; Matches empty or any valid minute (0 (or 00) - 59)
 (def minute-regex #"^(^$|0?[0-9]|[1-5][0-9])$")
 
-(defmethod field :time [{:keys [update! error warning required? unrestricted-hours? element-id] :as opts}
+(defmethod field :time [{:keys [update! error warning required? unrestricted-hours? element-id on-blur] :as opts}
                         {:keys [hours hours-text minutes minutes-text] :as data}]
   [:div (stylefy/use-style style-base/inline-block)
    [field (merge
@@ -614,6 +614,8 @@
              :error-text false
              :input-style {:text-align "right"}
              :hint-style {:position "absolute" :right "0"}
+             :on-blur (when on-blur
+                        on-blur)
              :update! (fn [hour]
                         (let [h (if (str/blank? hour)
                                   nil
@@ -635,6 +637,8 @@
              :regex minute-regex
              :style {:width 30}
              :error-text false
+             :on-blur (when on-blur
+                        on-blur)
              :update! (fn [minute]
                         (let [m (if (str/blank? minute)
                                   nil


### PR DESCRIPTION
# Added
* form fields support in :time field for :on-blur event
   
# Fixed
* views: route: stop-time validation moved to :on-blur event 
