### PR TITLE
views: route: trip stop list vertical-align top so warning doesn't jump

### DIFF
--- a/ote/src/cljs/ote/views/route/trips.cljs
+++ b/ote/src/cljs/ote/views/route/trips.cljs
@@ -121,7 +121,7 @@
   "Render a single row of stop times."
   [e! stop-count can-delete? edit-service-calendar service-calendars row-idx {stops ::transit/stop-times :as trip}]
   ^{:key row-idx}
-  [:tr {:style {:max-height "40px"}}
+  [:tr {:style {:max-height "40px" :vertical-align "top"}}
    [:td [:div
          [:span {:data-balloon        (tr [:route-wizard-page :trip-stop-calendar])
                  :data-balloon-pos    "right"


### PR DESCRIPTION
# Fixed
* views: route: trip stop list vertical-align top so warning doesn't jump 

When added, an invalid input warning element moves the input control,
which user is editing, up.
This commit aligns cell elements to top so that appearing warning
element only pushes following elements down,
instead of pushing preceding elements up.