### PR TITLE
168367747 dynamic db feature flag for sea route maintenance mode

### DIFF
--- a/database/src/main/resources/db/migration/V1_168__feature_table.sql
+++ b/database/src/main/resources/db/migration/V1_168__feature_table.sql
@@ -1,0 +1,33 @@
+CREATE TYPE feature_type AS ENUM (
+    'maintenance-break-sea-route'
+    );
+
+COMMENT ON TYPE feature_type IS
+E'Enumerates possible ids of dynamic feature flags';
+
+CREATE TABLE feature_variation(
+    id SERIAL PRIMARY KEY,
+    feature feature_type UNIQUE NOT NULL,
+    value INTEGER DEFAULT NULL,
+    created TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    modified TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE feature_variation IS
+E'Stores feature flags which can be toggled dynamically when a more dynamic variation than build-time configuration is needed';
+
+CREATE OR REPLACE FUNCTION update_modified() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.modified = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER feature_timestamp
+    BEFORE INSERT OR UPDATE ON feature_variation
+    FOR EACH ROW
+EXECUTE PROCEDURE update_modified();
+
+-- First feature flag
+INSERT INTO feature_variation (feature, value)
+VALUES ('maintenance-break-sea-route'::feature_type, NULL);

--- a/ote/project.clj
+++ b/ote/project.clj
@@ -116,7 +116,7 @@
   :repositories [["osgeo" "https://download.osgeo.org/webdav/geotools/"]
                  ["boundlessgeo" "https://repo.boundlessgeo.com/main/"]]
   :plugins [[lein-cljsbuild "1.1.7"]
-            [lein-figwheel "0.5.19"]
+            [lein-figwheel "0.5.13"]
             [lein-kibit "0.1.6"]]
 
   ;; Backend lähdekoodit: clj ja frontin kanssa jaettu cljc

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1333,6 +1333,10 @@ You can also draw the operating area or point to the map with drawing tools. You
  :gtfs-viewer
  {:gtfs-load-failed "Unfortunately, it is not possible to view route information for this service on the map as the processing of timetables and routes file failed."}
 
+ :error-landing
+ {:resource-not-found "Sorry! The resource or functionality you selected was not found"
+  :go-to-frontpage "Go to front page"
+  :txt-maintenance-break "Temporarily not available due to maintenance break"}
 
  :leaflet
  {:zoom-in "Zoom In"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1346,6 +1346,10 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
  :gtfs-viewer
  {:gtfs-load-failed "Valitettavasti tämän palvelun reittitietoja ei ole mahdollista tarkastella kartalla, sillä reitti- ja aikataulutiedoston käsittely epäonnistui."}
 
+ :error-landing
+ {:resource-not-found "Pahoittelut! Valitsemaasi resurssia tai toimintoa ei löytynyt"
+  :go-to-frontpage "Siirry etusivulle"
+  :txt-maintenance-break "Tilapäisesti poissa käytöstä huoltotoimenpiteiden vuoksi"}
 
  :leaflet
  {:zoom-in "Lähennä"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1335,6 +1335,10 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
  :gtfs-viewer
  {:gtfs-load-failed "Tyvärr är det inte möjligt att visa ruttinformation för den här tjänsten på kartan, eftersom behandlingen av tidtabeller och ruttfil misslyckades."}
 
+ :error-landing
+ {:resource-not-found "Pahoittelut! Valitsemaasi resurssia tai toimintoa ei löytynyt"
+  :go-to-frontpage "Siirry etusivulle"
+  :txt-maintenance-break "Tilapäisesti poissa käytöstä huoltotoimenpiteiden vuoksi"}
 
  :leaflet
  {:zoom-in "Zooma in"

--- a/ote/src/clj/ote/components/http.clj
+++ b/ote/src/clj/ote/components/http.clj
@@ -155,9 +155,12 @@
     :body (transit/clj->transit data)}))
 
 (defn no-cache-transit-response
-  "Return the given Clojure `data` as a Transit response with status code 200 and no-cache headers."
-  [data]
-  (with-no-cache-headers (transit-response data)))
+  "Return the given Clojure `data` as a Transit response, using status code 200 if no status is defined,
+  and no-cache headers."
+  ([data]
+   (no-cache-transit-response data 200))
+  ([data status]
+   (with-no-cache-headers (transit-response data status))))
 
 (defn json-response [data]
   {:status 200

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -19,7 +19,8 @@
             [cheshire.core :as cheshire]
             [ote.db.tx :as tx]
             [jeesql.core :refer [defqueries]]
-            [ote.environment :as environment])
+            [ote.environment :as environment]
+            [ote.db.feature])                               ; specql table definitions
   (:import (org.postgis PGgeometry Point Geometry)))
 
 (defqueries "ote/services/routes.sql")

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -32,7 +32,7 @@
                    :ote.db.feature/feature-variation
                    (specql/columns :ote.db.feature/feature-variation)
                    {:ote.db.feature/feature :maintenance-break-sea-route})))
-    (http/transit-response "Under maintenance" 503)))
+    (http/no-cache-transit-response "Under maintenance" 503)))
 
 (defn- interface-url
   "Create interface url for route."

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -25,7 +25,12 @@
 (defqueries "ote/services/routes.sql")
 
 (defn- service-state-response [db]
-  (when false                                               ;; TODO: fetch and check flag
+  (when (:ote.db.feature/value
+          (first
+            (fetch db
+                   :ote.db.feature/feature-variation
+                   (specql/columns :ote.db.feature/feature-variation)
+                   {:ote.db.feature/feature :maintenance-break-sea-route})))
     (http/transit-response "Under maintenance" 503)))
 
 (defn- interface-url

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -24,6 +24,10 @@
 
 (defqueries "ote/services/routes.sql")
 
+(defn- service-state-response [db]
+  (when false                                               ;; TODO: fetch and check flag
+    (http/transit-response "Under maintenance" 503)))
+
 (defn- interface-url
   "Create interface url for route."
   [operator-id]
@@ -286,41 +290,50 @@
                 {::t-operator/id operator-id})
        homepage)))
 
+(defn- get-route-response [db user id]
+  (let [route (get-route db user (Long/parseLong id))]
+    (cond
+      (not route) {:status 404}
+      (= "Forbidden" (:body route)) route
+      :else (http/no-cache-transit-response route))))
+
 (defn- routes-auth
   "Routes that require authentication"
   [db nap-config]
   (routes
     (GET "/routes/routes" {user :user}
-      (http/no-cache-transit-response
-        (get-user-routes db (:groups user) (:user user))))
+      (or (service-state-response db)
+          (http/no-cache-transit-response
+            (get-user-routes db (:groups user) (:user user)))))
 
     (POST "/routes/new" {form-data :body
                          user      :user}
-      (http/transit-response
-        (update-route-model! db user (http/transit-request form-data))))
+      (or (service-state-response db)
+          (http/transit-response
+            (update-route-model! db user (http/transit-request form-data)))))
 
     (POST "/routes/update-operator-homepage" {form-data :body
                                               user :user}
-      (http/transit-response
-        (update-operator-homepage! db user (http/transit-request form-data))))
+      (or (service-state-response db)
+          (http/transit-response
+            (update-operator-homepage! db user (http/transit-request form-data)))))
 
     (GET "/routes/:id" [id :as {user :user}]
-      (let [route (get-route db user (Long/parseLong id))]
-        (cond
-          (not route) {:status 404}
-          (= "Forbidden" (:body route)) route
-          :else (http/no-cache-transit-response route))))
+      (or (service-state-response db)
+          (get-route-response db user id)))
 
     (POST "/routes/delete" {form-data :body
                             user      :user}
-      (http/transit-response
-        (delete-route! db user
-                       (:id (http/transit-request form-data)))))
+      (or (service-state-response db)
+          (http/transit-response
+            (delete-route! db user
+                           (:id (http/transit-request form-data))))))
 
     (POST "/routes/link-interface" {form-data :body
                                     user :user}
-      (http/transit-response
-        (link-interface db user (http/transit-request form-data))))))
+      (or (service-state-response db)
+          (http/transit-response
+            (link-interface db user (http/transit-request form-data)))))))
 
 (defn- stops-geojson [db]
   (cheshire/encode
@@ -340,9 +353,10 @@
   [db]
   (routes
    (GET "/transit/stops.json" _
-        {:status 200
-         :headers {"Content-Type" "application/vnd.geo+json"}
-         :body (stops-geojson db)})))
+     (or (service-state-response db)
+         {:status 200
+          :headers {"Content-Type" "application/vnd.geo+json"}
+          :body (stops-geojson db)}))))
 
 (defrecord Routes [nap-config]
   component/Lifecycle

--- a/ote/src/cljc/ote/db/feature.cljc
+++ b/ote/src/cljc/ote/db/feature.cljc
@@ -1,0 +1,19 @@
+(ns ote.db.feature
+  "Data model for dynamic feature flags"
+  (:require
+            #?@(:clj [[ote.db.specql-db :refer [define-tables]]
+                      [specql.postgis]
+                      [clj-time.coerce :as tc]]
+                :cljs [[cljs-time.coerce :as tc]])
+            [specql.impl.registry]
+            [specql.data-types]
+            [ote.db.common]
+            ;[ote.db.modification]
+            [ote.db.user])
+
+  #?(:cljs
+     (:require-macros [ote.db.specql-db :refer [define-tables]])))
+
+(define-tables
+  ["feature_type" ::feature-type-enum (specql.transform/transform (specql.transform/to-keyword))]
+  ["feature_variation" ::feature-variation])

--- a/ote/src/cljc/ote/db/feature.cljc
+++ b/ote/src/cljc/ote/db/feature.cljc
@@ -8,7 +8,6 @@
             [specql.impl.registry]
             [specql.data-types]
             [ote.db.common]
-            ;[ote.db.modification]
             [ote.db.user])
 
   #?(:cljs

--- a/ote/src/cljs/ote/app/controller/common.cljs
+++ b/ote/src/cljs/ote/app/controller/common.cljs
@@ -1,13 +1,19 @@
 (ns ote.app.controller.common
   "Common controller functionality"
   (:require [tuck.core :as tuck :refer-macros [define-event]]
-            [ote.localization :refer [tr]]))
+            [ote.localization :refer [tr]]
+            [ote.app.routes :refer [navigate!]]))
+
+(defn error-landing [app txt]
+  (navigate! :error-landing)
+  (assoc-in app [:error-landing :desc] txt))
 
 (tuck/define-event ServerError [response]
   {}
-  (if (= 403 (:status response))
-    (assoc app :flash-message-error (tr [:common-texts :forbidden]))
-    (assoc app :flash-message-error (tr [:common-texts :server-error]))))
+  (case (:status response)
+    403 (assoc app :flash-message-error (tr [:common-texts :forbidden]))
+    503 (error-landing app (tr [:error-landing :txt-maintenance-break]))
+    :else (assoc app :flash-message-error (tr [:common-texts :server-error]))))
 
 (defn user-logged-in? [app]
   (not-empty (get-in app [:user])))

--- a/ote/src/cljs/ote/app/controller/common.cljs
+++ b/ote/src/cljs/ote/app/controller/common.cljs
@@ -13,7 +13,4 @@
   (case (:status response)
     403 (assoc app :flash-message-error (tr [:common-texts :forbidden]))
     503 (error-landing app (tr [:error-landing :txt-maintenance-break]))
-    :else (assoc app :flash-message-error (tr [:common-texts :server-error]))))
-
-(defn user-logged-in? [app]
-  (not-empty (get-in app [:user])))
+    (assoc app :flash-message-error (tr [:common-texts :server-error]))))

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -3,7 +3,7 @@
   (:require [bide.core :as r]
             [ote.app.state :as state]
             [tuck.core :as tuck]
-            [ote.app.controller.common :refer [user-logged-in?]]))
+            [ote.app.utils :refer [user-logged-in?]]))
 
 (def ga-tracking-code
   (.getAttribute js/document.body "data-ga-tracking-code"))

--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -11,13 +11,13 @@
 (def dev-mode?
   (.getAttribute js/document.body "data-dev-mode?"))
 
-
 ;; when adding a new view: also add the keyword to the auth-required set below, and
 ;; add behaviour for it in the (case ..) form in ote.views.main/ote-application.
 
 (def ote-router
   (r/router
    [["/" :front-page]
+    ["/error-landing" :error-landing]
     ["/login" :login]
     ["/reset-password" :reset-password]
     ["/register" :register]

--- a/ote/src/cljs/ote/app/utils.cljs
+++ b/ote/src/cljs/ote/app/utils.cljs
@@ -9,3 +9,6 @@
 
 
 (def email-regex #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+
+(defn user-logged-in? [app]
+  (not-empty (get-in app [:user])))

--- a/ote/src/cljs/ote/ui/main_header.cljs
+++ b/ote/src/cljs/ote/ui/main_header.cljs
@@ -19,7 +19,7 @@
             [clojure.string :as str]
             [ote.localization :as localization]
             [ote.util.text :as text]
-            [ote.app.controller.common :refer [user-logged-in?]]
+            [ote.app.utils :refer [user-logged-in?]]
             [ote.app.routes :as routes]))
 
 (defn header-scroll-sensor [is-scrolled? trigger-offset]

--- a/ote/src/cljs/ote/views/error/error_landing.cljs
+++ b/ote/src/cljs/ote/views/error/error_landing.cljs
@@ -1,7 +1,7 @@
-(ns ote.views.error-landing
+(ns ote.views.error.error-landing
   (:require [stylefy.core :as stylefy]
             [ote.style.buttons :as style-buttons]
-            [ote.localization :refer [tr] :as localization]))
+            [ote.localization :refer [tr]]))
 
 (defn error-landing-vw [{:keys [error-landing] :as app}]
   [:div

--- a/ote/src/cljs/ote/views/error_landing.cljs
+++ b/ote/src/cljs/ote/views/error_landing.cljs
@@ -1,0 +1,15 @@
+(ns ote.views.error-landing
+  (:require [stylefy.core :as stylefy]
+            [ote.style.buttons :as style-buttons]
+            [ote.localization :refer [tr] :as localization]))
+
+(defn error-landing-vw [{:keys [error-landing] :as app}]
+  [:div
+   [:h2 (tr [:error-landing :resource-not-found])]
+   [:div (:desc error-landing)]
+   [:br]
+   [:div
+    [:a (merge {:href (str "#/")
+                :id "btn-go-to-frontpage"}
+               (stylefy/use-style style-buttons/primary-button))
+     (tr [:error-landing :go-to-frontpage])]]])

--- a/ote/src/cljs/ote/views/front_page.cljs
+++ b/ote/src/cljs/ote/views/front_page.cljs
@@ -29,7 +29,7 @@
             [ote.views.transport-operator-selection :as t-operator-sel]
             [ote.ui.list-header :as list-header]
             [clojure.string :as str]
-            [ote.app.controller.common :refer [user-logged-in?]]))
+            [ote.app.utils :refer [user-logged-in?]]))
 
 
 (let [host (.-host (.-location js/document))]

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -42,7 +42,7 @@
             [ote.views.transit-changes :as transit-changes]
             [ote.views.register :as register]
             [ote.views.admin.monitor :as monitor]
-            [ote.views.error-landing :as error-landing]
+            [ote.views.error.error-landing :as error-landing]
             [ote.ui.common :as common-ui]
             [ote.ui.main-header :refer [top-nav] :as main-header]))
 

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -87,7 +87,8 @@
           (if (nil? app)
             [spinner/circular-progress]
             [:div.ote-sovellus {:style {:display "flex"
-                                        :flex-direction "column"}}
+                                        :flex-direction "column"
+                                        :height "100vh"}}
              [top-nav e! app is-scrolled? desktop?]
              [:div (merge (stylefy/use-style style-base/sticky-footer)
                      {:on-click #(e! (fp-controller/->CloseHeaderMenus))})

--- a/ote/src/cljs/ote/views/main.cljs
+++ b/ote/src/cljs/ote/views/main.cljs
@@ -42,6 +42,7 @@
             [ote.views.transit-changes :as transit-changes]
             [ote.views.register :as register]
             [ote.views.admin.monitor :as monitor]
+            [ote.views.error-landing :as error-landing]
             [ote.ui.common :as common-ui]
             [ote.ui.main-header :refer [top-nav] :as main-header]))
 
@@ -114,6 +115,7 @@
 
                   (case (:page app)
                     :login [login/login e! (:login app)]
+                    :error-landing [error-landing/error-landing-vw app]
                     :reset-password [login/reset-password e! app]
                     :register [register/register e! (:params app) (:register app) (:user app)]
                     :user [user/user e! (:user app)]


### PR DESCRIPTION
# Added
* language: error landing page and maintenance break strings
* services
routes: :maintenance-break-sea-route flag checked from db
routes: endpoints wrapped to service state check handler
* db
cljc specql namespace for feature variation
create feature_variation table and feature_type
* views
route-wizard: load stops failure handler to common servererror
route-list: load routes failure handler to common servererror
main: error-landing page selection
error-landing: first WIP version
 ote.sovellus height to 100vh to fill screen and put footer down
* controller: common: ServerError to redirect 503 to error-landing page
* ote: revert lein-figwheel to 0.5.13, connecting to browser not ok 

