### PR TITLE
164826821 random fixes

### DIFF
--- a/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
@@ -339,6 +339,8 @@
   UpdateOperatorHomepageResponse
   (process-event [{response :response} app]
     (-> app
+        ; clear operator homepage from route - to prevent unnecessary save
+        (dissoc [:route :operator-homepage])
         (update :transport-operators-with-services
                 (fn [operators]
                   (map
@@ -367,7 +369,9 @@
   (process-event [{new-homepage :new-homepage} app]
     (-> app
         (assoc-in [:selected-operator ::t-operator/homepage] new-homepage)
-        (assoc-in [:transport-operator ::t-operator/homepage] new-homepage)))
+        (assoc-in [:transport-operator ::t-operator/homepage] new-homepage)
+        ; Update operator homepage to route while operator homepage is not saved to db
+        (assoc-in [:route :operator-homepage] new-homepage)))
 
   AddStop
   (process-event [{feature :feature} app]

--- a/ote/src/cljs/ote/views/admin/sea_routes.cljs
+++ b/ote/src/cljs/ote/views/admin/sea_routes.cljs
@@ -64,7 +64,9 @@
                                (if (true? ((weekday-index-to-keyword last-weekday-index) route))
                                  (* -1 index)
                                  (recur (inc index) (dec last-weekday-index)))
-                               nil))]
+                               ; return 0 days only if to-date and weekday are given.
+                               (when (and to-date weekday)
+                                 0)))]
     (if (not (nil? last-weekday-count))
       (time/native->date
         (t/plus (time/native->date-time to-date) (t/days last-weekday-count)))

--- a/ote/src/cljs/ote/views/admin/sea_routes.cljs
+++ b/ote/src/cljs/ote/views/admin/sea_routes.cljs
@@ -64,13 +64,13 @@
                                (if (true? ((weekday-index-to-keyword last-weekday-index) route))
                                  (* -1 index)
                                  (recur (inc index) (dec last-weekday-index)))
-                               ; return 0 days only if to-date and weekday are given.
+                               ;; return 0 days if only to-date and weekday are given and selected weekdays are missing
+                               ;; because there is no need to count backwards the days when exact date is given (to-date without weekday)
                                (when (and to-date weekday)
                                  0)))]
-    (if (not (nil? last-weekday-count))
+    (when-not (nil? last-weekday-count)
       (time/native->date
-        (t/plus (time/native->date-time to-date) (t/days last-weekday-count)))
-      nil)))
+        (t/plus (time/native->date-time to-date) (t/days last-weekday-count))))))
 
 (defn sea-routes [e! app]
   (let [{:keys [loading? results filters]}


### PR DESCRIPTION
# Fixed
* Sea route on-blur when save is clicked without clicking "off" from homepage input field
* Admin sea-route-list last active day when only added calendar date is given and no calendar rule
   