### PR TITLE
168477239 sea route stop missing stop time error indication v2

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -821,6 +821,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :no-draft-routes "No draft routes."
   :no-public-routes "No finalised routes."
   :add-operator-and-service "To use the sea traffic route and timetable editor you have to create at least one transport operator or you must be a member of a transport operator."
+  :warn-check-stop-time "Check arrival and departure times"
   }
 
  :route-wizard-page

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -826,6 +826,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :no-draft-routes "Ei reittiluonnoksia."
   :no-public-routes "Ei valmiita reittejä."
   :add-operator-and-service "Merenkulun reitti- ja aikataulueditorin käyttäminen edellyttää, että olet lisännyt palveluntuottajan NAP:iin tai olet jonkun palveluntuottajan jäsen."
+  :warn-check-stop-time "Tarkista tulo- ja lähtöajat"
   }
 
  :route-wizard-page

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -824,6 +824,7 @@
   :no-draft-routes "Inga utkast till rutter."
   :no-public-routes "Inga färdiga rutter."
   :add-operator-and-service "Du kan endast använda kartverktyget för sjötrafik om du har skapat en eller flera tjänsteproducenter i NAP-tjänsten eller du är medlem av någon tjänsteproducent."
+  :warn-check-stop-time "Tarkista tulo- ja lähtöajat"
   }
 
  :route-wizard-page

--- a/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
+++ b/ote/src/cljs/ote/app/controller/route/route_wizard.cljs
@@ -260,12 +260,17 @@
   (reduce
     (fn [v curr]
       (let [stop-prev (last v)
+            curr-arrival (::transit/arrival-time curr)
+            prev-departure (::transit/departure-time stop-prev)
+            curr-departure (::transit/departure-time curr)
             chronology-problem (cond
                                  (nil? stop-prev) nil       ; First stop cannot be non-chronological
-                                 (time/interval< (::transit/arrival-time curr)
-                                                 (::transit/departure-time stop-prev)) ::transit/arrival-time
-                                 (time/interval< (::transit/departure-time curr)
-                                                 (::transit/arrival-time curr)) ::transit/departure-time
+                                 (and (not (time/empty-time? curr-arrival))
+                                      (time/interval< curr-arrival
+                                                      prev-departure)) ::transit/arrival-time
+                                 (and (not (time/empty-time? curr-departure))
+                                      (time/interval< curr-departure
+                                                      curr-arrival)) ::transit/departure-time
                                  :else nil)]
         (conj v
               (if chronology-problem

--- a/ote/src/cljs/ote/views/route/trips.cljs
+++ b/ote/src/cljs/ote/views/route/trips.cljs
@@ -117,6 +117,9 @@
         [:th {:style {:font-size "80%" :font-variant "small-caps"}}
          (tr [:route-wizard-page :trip-stop-departure-header])])))]])
 
+;; Space because material-ui TextField error prop requires some content to show error "underline" under input control
+(def stop-time-empty-hour-min-error-str (str " "))
+
 (defn trip-row
   "Render a single row of stop times."
   [e! stop-count can-delete? edit-service-calendar service-calendars row-idx {stops ::transit/stop-times :as trip}]
@@ -158,15 +161,15 @@
                 [:div.col-md-11
                  [form-fields/field {:type :time
                                      :element-id stop-idx
-                                     :error-hour #(when (nil? (:hours %)) (str " ")) ; To show error underline material TextField error requires content
-                                     :error-min  #(when (nil? (:minutes %)) (str " ")) ; To show error underline material TextField error requires content
+                                     :error-hour #(when (nil? (:hours %)) stop-time-empty-hour-min-error-str)
+                                     :error-min  #(when (nil? (:minutes %)) stop-time-empty-hour-min-error-str)
                                      :on-blur #(e! (rw/->ValidateStopTime row-idx stop-idx %))
                                      :required? true
                                      ;; Restricted because first departure cannot be before 24 hours.
                                      :unrestricted-hours? (> stop-idx 0)
                                      :update! #(update! {::transit/arrival-time (time/time->interval %)})
                                      :warning (when (= time-invalid ::transit/arrival-time)
-                                                (tr [:common-texts :check-your-input]))}
+                                                (tr [:route-list-page :warn-check-stop-time]))}
                   arrival-time]]
                 [:div.col-md-1 {:style {:margin-left "-10px"}}
                  [exception-icon e! :arrival drop-off-type stop-idx row-idx]]])
@@ -178,15 +181,15 @@
                 [:div.col-md-11
                  [form-fields/field {:type :time
                                      :element-id stop-idx
-                                     :error-hour #(when (nil? (:hours %)) (str " ")) ; To show error underline material TextField error requires content
-                                     :error-min #(when (nil? (:minutes %)) (str " ")) ; To show error underline material TextField error requires content
+                                     :error-hour #(when (nil? (:hours %)) stop-time-empty-hour-min-error-str)
+                                     :error-min #(when (nil? (:minutes %)) stop-time-empty-hour-min-error-str)
                                      :on-blur #(e! (rw/->ValidateStopTime row-idx stop-idx %))
                                      :required? true
                                      ;; All arrival hours allowed because time between two stops could be 24h or more
                                      :unrestricted-hours? true
                                      :update! #(update! {::transit/departure-time (time/time->interval %)})
                                      :warning (when (= time-invalid ::transit/departure-time)
-                                                (tr [:common-texts :check-your-input]))}
+                                                (tr [:route-list-page :warn-check-stop-time]))}
                   departure-time]]
                 [:div.col-md-1 {:style {:margin-left "-10px"}}
                  [exception-icon e! :departure pickup-type stop-idx row-idx]]]))))


### PR DESCRIPTION
# Changed
* controller: route-wizard: clear stop chronology error if input cleared
* views: trips: tweak stop time error for non-chronological stop times
* language: :route-list-page :warn-check-stop-time initial versions