### PR TITLE
views, services: revert endpoint url export/gtfs-sea to export/gtfs

### DIFF
--- a/ote/src/clj/ote/integration/export/gtfs.clj
+++ b/ote/src/clj/ote/integration/export/gtfs.clj
@@ -28,7 +28,7 @@
            db :db :as this}]
     (assoc this
            ::stop (http/publish! http {:authenticated? false}
-                                 (GET "/export/gtfs-sea/:transport-operator-id{[0-9]+}"
+                                 (GET "/export/gtfs/:transport-operator-id{[0-9]+}"
                                       [transport-operator-id]
                                       (export-sea-gtfs db (Long/parseLong transport-operator-id))))))
   (stop [{stop ::stop :as this}]

--- a/ote/src/clj/ote/services/routes.clj
+++ b/ote/src/clj/ote/services/routes.clj
@@ -38,7 +38,7 @@
 (defn- interface-url
   "Create interface url for route."
   [operator-id]
-  (str (environment/base-url) "export/gtfs-sea/" operator-id))
+  (str (environment/base-url) "export/gtfs/" operator-id))
 
 (def route-list-columns  #{::transit/route-id
                            ::transit/transport-operator-id

--- a/ote/src/cljs/ote/views/admin/sea_routes.cljs
+++ b/ote/src/cljs/ote/views/admin/sea_routes.cljs
@@ -110,5 +110,5 @@
                                                               "Ajopäivissä virhe")]
                [ui/table-row-column {:style {:width "10%"}}
                 [:a {:href (str (.-protocol loc) "//" (.-host loc) (.-pathname loc)
-                                "export/gtfs-sea/" operator-id)}
+                                "export/gtfs/" operator-id)}
                  "Lataa gtfs"]]]))]]])]))

--- a/ote/src/cljs/ote/views/route/route_list.cljs
+++ b/ote/src/cljs/ote/views/route/route_list.cljs
@@ -224,7 +224,7 @@
        (if (not (empty? public-routes))
          (let [loc (.-location js/document)
                url (str (.-protocol loc) "//" (.-host loc) (.-pathname loc)
-                        "export/gtfs-sea/" (::t-operator/id operator))]
+                        "export/gtfs/" (::t-operator/id operator))]
            [:div {:style {:padding-top "1rem"}}
             [:h4 (tr [:route-list-page :header-sea-route-interface])]
             [:p {:style (merge


### PR DESCRIPTION
# Fixed
* reverts 206a154c3c5a83d9dca37d14601df7ea060815f0 i.e. revert endpoint url export/gtfs-sea to export/gtfs
 