### PR TITLE
jenkins: remove task 'Deploy CKAN plugin'

### DIFF
--- a/aws/ansible/jenkins/jobs/staging.groovy
+++ b/aws/ansible/jenkins/jobs/staging.groovy
@@ -5,11 +5,6 @@ job('Daily staging env deploy') {
     }
     steps {
         downstreamParameterized {
-            trigger('Deploy CKAN plugin') {
-                parameters {
-                    predefinedProp('ENV','staging')
-                }
-            }
             trigger('Deploy OTE') {
                 parameters {
                     predefinedProp('ENV','staging')


### PR DESCRIPTION
This should be merged after all environment infras are updated similarly.

# Environment
* jenkins: remove task 'Deploy CKAN plugin'
