### PR TITLE
169115839 old routes have wrong data in calendar

### DIFF
--- a/database/src/main/resources/db/migration/R__GTFS_query.sql
+++ b/database/src/main/resources/db/migration/R__GTFS_query.sql
@@ -184,9 +184,7 @@ SELECT array_agg(x.id)
          ORDER BY "external-interface-description-id", created DESC) x
 $$ LANGUAGE SQL STABLE;
 
--- New sproc for getting packages is need when calendar wants to show what kind of traffic was back
--- in the day. We need to set detection_date to pick only those packages that were downloaded when detection
--- was run.
+-- Returns list of packages for service_id, which were the latest on detection_date. I.e. excludes those downloaded after detection_date.
 CREATE OR REPLACE FUNCTION gtfs_service_packages_for_detection_date(service_id INTEGER, dt DATE, detection_date DATE)
     RETURNS INTEGER[]
 AS $$

--- a/database/src/main/resources/db/migration/R__GTFS_query.sql
+++ b/database/src/main/resources/db/migration/R__GTFS_query.sql
@@ -184,6 +184,21 @@ SELECT array_agg(x.id)
          ORDER BY "external-interface-description-id", created DESC) x
 $$ LANGUAGE SQL STABLE;
 
+-- New sproc for getting packages is need when calendar wants to show what kind of traffic was back
+-- in the day. We
+CREATE OR REPLACE FUNCTION gtfs_service_packages_for_detection_date(service_id INTEGER, dt DATE)
+    RETURNS INTEGER[]
+AS $$
+SELECT array_agg(x.id)
+FROM (SELECT DISTINCT ON ("external-interface-description-id") p.id
+      FROM gtfs_package p
+      WHERE "transport-service-id" = service_id
+        AND p."deleted?" = FALSE
+        AND  p.created::DATE <= dt
+        AND p.created::DATE <= detection_date
+      ORDER BY "external-interface-description-id", created DESC) x
+$$ LANGUAGE SQL STABLE;
+
 CREATE OR REPLACE FUNCTION gtfs_trip_stop_departure_time(trip "gtfs-package-trip-info", stopname TEXT)
 RETURNS interval
 AS $$

--- a/database/src/main/resources/db/migration/R__GTFS_query.sql
+++ b/database/src/main/resources/db/migration/R__GTFS_query.sql
@@ -185,8 +185,9 @@ SELECT array_agg(x.id)
 $$ LANGUAGE SQL STABLE;
 
 -- New sproc for getting packages is need when calendar wants to show what kind of traffic was back
--- in the day. We
-CREATE OR REPLACE FUNCTION gtfs_service_packages_for_detection_date(service_id INTEGER, dt DATE)
+-- in the day. We need to set detection_date to pick only those packages that were downloaded when detection
+-- was run.
+CREATE OR REPLACE FUNCTION gtfs_service_packages_for_detection_date(service_id INTEGER, dt DATE, detection_date DATE)
     RETURNS INTEGER[]
 AS $$
 SELECT array_agg(x.id)
@@ -194,7 +195,7 @@ FROM (SELECT DISTINCT ON ("external-interface-description-id") p.id
       FROM gtfs_package p
       WHERE "transport-service-id" = service_id
         AND p."deleted?" = FALSE
-        AND  p.created::DATE <= dt
+        AND p.created::DATE <= dt
         AND p.created::DATE <= detection_date
       ORDER BY "external-interface-description-id", created DESC) x
 $$ LANGUAGE SQL STABLE;

--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -71,11 +71,14 @@
                  {:gtfs/transport-service-id service-id
                   :gtfs/date date})))
 
-(defn service-calendar-for-route [db service-id route-hash-id]
-  (into {}
-        (map (juxt :date :hash))
-        (fetch-date-hashes-for-route-with-route-hash-id db {:service-id service-id
-                                                            :route-hash-id route-hash-id})))
+(defn service-calendar-for-route [db service-id route-hash-id detection-date]
+  (if (and (integer? service-id) (string? route-hash-id) (string? detection-date))
+    (into {}
+          (map (juxt :date :hash))
+          (fetch-date-hashes-for-route-with-route-hash-id db {:service-id service-id
+                                                              :route-hash-id route-hash-id
+                                                              :detection-date detection-date}))
+    nil))
 
 (defn parse-gtfs-stoptimes [pg-array]
   (let [string (str pg-array)]
@@ -132,10 +135,10 @@
   ^{:unauthenticated false :format :transit}
   (GET "/transit-visualization/:service-id/route"
        {{:keys [service-id]} :params
-        {:strs [route-hash-id]} :query-params
+        {:strs [route-hash-id detection-date]} :query-params
         user :user}
     (or (authorization/transit-authority-authorization-response user)
-        {:calendar (service-calendar-for-route db (Long/parseLong service-id) route-hash-id)}))
+        {:calendar (service-calendar-for-route db (Long/parseLong service-id) route-hash-id detection-date)}))
 
 
   ^{:unauthenticated false}

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -147,7 +147,7 @@ SELECT x.date::text, string_agg(x.hash,' ' ORDER BY x.e_id asc) as hash
   FROM (SELECT d.date, package_id, rh.hash::text, p."external-interface-description-id" as e_id
           FROM dates d
           -- Join packages for each date
-          JOIN LATERAL unnest(gtfs_service_packages_for_date(:service-id::INTEGER, d.date))
+          JOIN LATERAL unnest(gtfs_service_packages_for_detection_date(:service-id::INTEGER, d.date, :detection-date::DATE))
             AS ps (package_id) ON TRUE
           -- Join gtfs_package to get external-interface-description-id
           JOIN gtfs_package p ON p.id = package_id AND p."deleted?" = FALSE

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -14,6 +14,15 @@
             [clojure.set :as set]
             [clojure.string :as str]))
 
+(defn change-visualization-url [route]
+  (let [window-loc (str js/window.location)
+        current-url (if (str/includes? window-loc "/now")
+                      (str/replace window-loc #"/now(.*)" "/now/")
+                      (str/replace window-loc #"/all(.*)" "/all/"))]
+    (if route
+      (.pushState js/window.history #js {} js/document.title (str current-url route))
+      (.pushState js/window.history #js {} js/document.title current-url))))
+
 (defn ensure-route-hash-id
   "Some older detected route changes might not contain route-hash-id key, so ensure that one is found."
   [route]

--- a/ote/src/cljs/ote/views/transit_visualization.cljs
+++ b/ote/src/cljs/ote/views/transit_visualization.cljs
@@ -306,15 +306,14 @@
                    :name->label str
                    :show-row-hover? true
                    :on-select #(when (first %)
-                                 (let [current-url (str/replace (str js/window.location) #"/now(.*)" "/now/")
-                                       route (str/replace (:route-hash-id (first %)) #"\s" "")]
-                                   (.pushState js/window.history #js {} js/document.title
-                                     (str current-url route))
-                                   (e! (tv/->SelectRouteForDisplay (first %)))
-                                   (.setTimeout js/window
-                                                (fn []
-                                                  (scroll/scroll-to-id "route-calendar-anchor"))
-                                                150)))
+                                 (let [route (str/replace (:route-hash-id (first %)) #"\s" "")]
+                                   (do
+                                     (tv/change-visualization-url route)
+                                     (e! (tv/->SelectRouteForDisplay (first %)))
+                                     (.setTimeout js/window
+                                                  (fn []
+                                                    (scroll/scroll-to-id "route-calendar-anchor"))
+                                                  150))))
                    :row-selected? #(= (:route-hash-id %) (:route-hash-id selected-route))}
 
       [{:name ""


### PR DESCRIPTION
# Fixed
* Transit visualization view: Fixed calendar traffic by adding detection date as a limit in used package list
* Transit visualization view: Fixed url when route was selected in /all/ mode   

