### PR TITLE
Modify no-cache-response and take it into use when editin operator or service

### DIFF
--- a/ote/src/clj/ote/components/http.clj
+++ b/ote/src/clj/ote/components/http.clj
@@ -140,7 +140,8 @@
              (fn [handlers]
                (filterv (partial not= handler) handlers))))))
 
-(def no-cache-headers  {"Cache-Control" "no-cache, no-store"})
+(def no-cache-headers  {"Expires" "-1"
+                        "Cache-Control" "no-cache, no-store, must-revalidate"})
 
 (defn with-no-cache-headers [response]
   (update response :headers merge no-cache-headers))

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -100,7 +100,7 @@
                                 (specql/columns ::t-service/external-interface-description)])
                          {::t-service/id id}))]
     (if ts
-      (http/transit-response
+      (http/no-cache-transit-response
         (-> (assoc ts ::t-service/operation-area
                       (places/fetch-transport-service-operation-area db id))
             (append-ote-netex-interfaces config db))
@@ -343,7 +343,7 @@
                                 transport-service-personal-columns)
                          {::t-service/id id}))]
     (if ts
-      (http/transit-response
+      (http/no-cache-transit-response
         (-> (assoc ts ::t-service/operation-area
                       (places/fetch-transport-service-operation-area db id))
             (append-ote-netex-interfaces config db)))

--- a/ote/src/clj/ote/services/transport_operator.clj
+++ b/ote/src/clj/ote/services/transport_operator.clj
@@ -193,7 +193,7 @@
                                                          db {:id (::t-operator/ckan-group-id to)})
                                                        ""))]
     (if to
-      (http/transit-response to)
+      (http/no-cache-transit-response to)
       {:status 404})))
 
 (defn public-data-transport-operator
@@ -206,7 +206,7 @@
                            ::t-operator/homepage}
                          {::t-operator/id id}))]
     (if to
-      (http/transit-response to)
+      (http/no-cache-transit-response to)
       {:status 404})))
 
 (defn operator-users&invites


### PR DESCRIPTION
# Fixed
* IE11 caches operator and service data. This is now fixed using more aggressive no-cache-response function
   
