### PR TITLE
170258400 duplicate public service

### DIFF
--- a/database/src/main/resources/db/migration/V1_180__add_parent_id_for_service.sql
+++ b/database/src/main/resources/db/migration/V1_180__add_parent_id_for_service.sql
@@ -1,3 +1,29 @@
 -- Add parent-id integer to transport-service table
 ALTER TABLE "transport-service"
     ADD COLUMN "parent-id" INTEGER DEFAULT NULL;
+
+-- Make foreign key deferrable to enable conflicted state
+ALTER TABLE "external-interface-description" ALTER CONSTRAINT "external-interface-description_transport-service-id_fkey" DEFERRABLE;
+
+CREATE OR REPLACE FUNCTION child_parent_interfaces(parent_id INTEGER, child_id INTEGER) RETURNS VOID AS $$
+DECLARE
+    unused_id INTEGER;
+BEGIN
+
+    -- Find next unused transport-service-id and give it some gap
+    SELECT i.id + 9999 as id
+    INTO unused_id
+    FROM "transport-service" i ORDER BY i.id DESC LIMIT 1;
+
+    -- Change parent interfaces to belong some service that doesn't exist
+    SET CONSTRAINTS ALL DEFERRED;
+    UPDATE "external-interface-description" SET "transport-service-id" = unused_id WHERE "transport-service-id" = parent_id;
+
+    -- Move child interfaces to parent
+    UPDATE "external-interface-description" SET "transport-service-id" = parent_id WHERE "transport-service-id" = child_id;
+
+    -- Move unused interfaces to child - they are deleted when child is deleted.
+    UPDATE "external-interface-description" SET "transport-service-id" = child_id WHERE "transport-service-id" = unused_id;
+
+END
+$$ LANGUAGE plpgsql;

--- a/database/src/main/resources/db/migration/V1_180__add_parent_id_for_service.sql
+++ b/database/src/main/resources/db/migration/V1_180__add_parent_id_for_service.sql
@@ -1,0 +1,3 @@
+-- Add parent-id integer to transport-service table
+ALTER TABLE "transport-service"
+    ADD COLUMN "parent-id" INTEGER DEFAULT NULL;

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -608,7 +608,9 @@ You can also draw the operating area or point to the map with drawing tools. You
                      :if-no-interfaces "If you do not have any interfaces for route and timetable data, you can digitalize your transport service´s route and timetable data with the tools listed below."
                      :open-rae "Open Traficom’s route and timetable editor (RAE)"
                      :open-sea-rae "Open the Sea traffic route and timetable editor in the NAP service"
-                     :service-in-validation-info "Palveluntuottaja vastaa itse palveluun julkaistuista tiedoista. Tiedot ovat julkaisujonossa. Julkaisun jälkeen tiedot näkyvät julkisessa NAP-palvelukatalogissa."}
+                     :service-in-validation-info "Palveluntuottaja vastaa itse palveluun julkaistuista tiedoista. Tiedot ovat julkaisujonossa. Julkaisun jälkeen tiedot näkyvät julkisessa NAP-palvelukatalogissa."
+                     :not-in-use "Not in use"
+                     :published-service-cannot-be-modified "Voit muokata vain julkaisua odottavaa palvelua."}
 
  :transport-users-page {:username "Name"
                         :members "Members"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -609,7 +609,9 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
                      :if-no-interfaces "Mikäli sinulla ei ole reitti- ja aikataulutietorajapintoja, voit tuottaa niitä alla listattujen työkalujen avulla."
                      :open-rae "Avaa Traficomin RAE-työkalu"
                      :open-sea-rae "Avaa NAP:in Merenkulun reitti- ja aikataulueditori"
-                     :service-in-validation-info "Palveluntuottaja vastaa itse palveluun julkaistuista tiedoista. Tiedot ovat julkaisujonossa. Julkaisun jälkeen tiedot näkyvät julkisessa NAP-palvelukatalogissa."}
+                     :service-in-validation-info "Palveluntuottaja vastaa itse palveluun julkaistuista tiedoista. Tiedot ovat julkaisujonossa. Julkaisun jälkeen tiedot näkyvät julkisessa NAP-palvelukatalogissa."
+                     :not-in-use "Ei käytössä"
+                     :published-service-cannot-be-modified "Voit muokata vain julkaisua odottavaa palvelua."}
 
  :transport-users-page {:username "Nimi"
                         :members "Jäsenet"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -610,7 +610,9 @@
                      :if-no-interfaces "Om du inte har några gränssnitt för rutt- och tidtabellsdata, kan du skapa sådana med hjälp av verktygen nedan"
                      :open-rae "Öppna Traficoms verktyg (RAE) för editering av rutter och tidtabeller"
                      :open-sea-rae "Öppna Kartverktyget för sjötrafik i NAP-tjänsten"
-                     :service-in-validation-info "Palveluntuottaja vastaa itse palveluun julkaistuista tiedoista. Tiedot ovat julkaisujonossa. Julkaisun jälkeen tiedot näkyvät julkisessa NAP-palvelukatalogissa."}
+                     :service-in-validation-info "Palveluntuottaja vastaa itse palveluun julkaistuista tiedoista. Tiedot ovat julkaisujonossa. Julkaisun jälkeen tiedot näkyvät julkisessa NAP-palvelukatalogissa."
+                     :not-in-use "Ei käytössä"
+                     :published-service-cannot-be-modified "Voit muokata vain julkaisua odottavaa palvelua."}
 
  :transport-users-page {:username "Namn"
                         :add-member "Lägg till medlem"

--- a/ote/src/clj/ote/services/admin.sql
+++ b/ote/src/clj/ote/services/admin.sql
@@ -206,3 +206,6 @@ SELECT s.name, s.id, s."sub-type", s."type", s.created, s.modified, s.published,
     WHERE s.validate IS NOT NULL
       AND s."transport-operator-id" = o.id
     ORDER BY s.validate ASC;
+
+-- name: update-child-parent-interfaces
+SELECT child_parent_interfaces(:parent-id::INTEGER, :child-id::INTEGER);

--- a/ote/src/clj/ote/services/admin.sql
+++ b/ote/src/clj/ote/services/admin.sql
@@ -206,6 +206,3 @@ SELECT s.name, s.id, s."sub-type", s."type", s.created, s.modified, s.published,
     WHERE s.validate IS NOT NULL
       AND s."transport-operator-id" = o.id
     ORDER BY s.validate ASC;
-
--- name: update-child-parent-interfaces
-SELECT child_parent_interfaces(:parent-id::INTEGER, :child-id::INTEGER);

--- a/ote/src/clj/ote/services/places.clj
+++ b/ote/src/clj/ote/services/places.clj
@@ -7,7 +7,6 @@
             [compojure.core :refer [routes GET]]
             [clojure.string :as str]
             [taoensso.timbre :as log]
-            [ote.geo :as geo]
             [ote.util.functor :refer [fmap]]
             [specql.core :as specql]
             [ote.db.places :as places]
@@ -76,6 +75,9 @@
                 #{::t-service/id ::t-service/description ::t-service/location-geojson
                   ::t-service/primary?}
                 {::t-service/transport-service-id transport-service-id}))
+
+(defn duplicate-operation-area [db old-service-id new-service-id]
+  (copy-operation-area db {:old-service-id old-service-id :new-service-id new-service-id}))
 
 (defrecord Places [sources]
   component/Lifecycle

--- a/ote/src/clj/ote/services/places.clj
+++ b/ote/src/clj/ote/services/places.clj
@@ -25,9 +25,9 @@
 
 (defn place-by-id [db id]
   (first
-   (specql/fetch db ::places/places
-                 #{::places/namefin ::places/id ::places/type ::places/location}
-                 {::places/id id})))
+    (specql/fetch db ::places/places
+                  #{::places/namefin ::places/id ::places/type ::places/location}
+                  {::places/id id})))
 
 (defn save-transport-service-operation-area!
   "Clear old place links and insert new links for the given transport service.
@@ -49,7 +49,7 @@
   (doseq [{::places/keys [id namefin type primary?] :as place} places]
     (case type
       "drawn"
-      (let [{id :id} 
+      (let [{id :id}
             (insert-geojson-for-transport-service<! db {:transport-service-id transport-service-id
                                                         :name namefin
                                                         :geojson (:geojson place)
@@ -84,7 +84,7 @@
         created-places (filter #(not (integer? (:ote.db.places/id %))) places-from-ui)
         ;; Copy all places that are stored in db to the new service
         copied-places (copy-operation-area db {:old-service-id old-service-id :new-service-id new-service-id
-                                            :ids (map :ote.db.places/id places-in-db)})
+                                               :ids (map :ote.db.places/id places-in-db)})
 
         ;; Save new places
         new-places (save-transport-service-operation-area! db new-service-id created-places false)]
@@ -94,17 +94,17 @@
   component/Lifecycle
   (start [{db :db http :http :as this}]
     (assoc this ::stop
-           (http/publish!
-            http
-            {:authenticated? false}
-            (routes
-             (GET "/place-completions/:term" [term]
-                  (http/transit-response
-                   (place-completions db term)))
-             (GET "/place/:id" [id]
-                  {:status 200
-                   :headers {"Content-Type" "application/json"}
-                   :body (fetch-place-geojson-by-id db {:id id})})))))
+                (http/publish!
+                  http
+                  {:authenticated? false}
+                  (routes
+                    (GET "/place-completions/:term" [term]
+                      (http/transit-response
+                        (place-completions db term)))
+                    (GET "/place/:id" [id]
+                      {:status 200
+                       :headers {"Content-Type" "application/json"}
+                       :body (fetch-place-geojson-by-id db {:id id})})))))
 
   (stop [{stop ::stop :as this}]
     (stop)

--- a/ote/src/clj/ote/services/places.sql
+++ b/ote/src/clj/ote/services/places.sql
@@ -17,7 +17,7 @@ VALUES (:transport-service-id,
 -- name: fetch-operation-area-geojson
 SELECT id, "transport-service-id", ST_AsGeoJSON(location)
   FROM "operation_area"
- WHERE "transport-service-id" = :transport-service-id
+ WHERE "transport-service-id" = :transport-service-id;
 
 -- name: insert-geojson-for-transport-service<!
 -- return-keys: ["id"]
@@ -62,3 +62,9 @@ SELECT namefin as "ote.db.places/namefin", id as "ote.db.places/id", type as "ot
   WHEN 'continent' THEN 5
    END,
   namefin;
+
+-- name: copy-operation-area
+INSERT INTO operation_area ("transport-service-id", description, location, "primary?")
+ SELECT :new-service-id as "transport-service-id", oa.description, oa.location, oa."primary?"
+   FROM operation_area oa
+  WHERE oa."transport-service-id" = :old-service-id RETURNING id;

--- a/ote/src/clj/ote/services/places.sql
+++ b/ote/src/clj/ote/services/places.sql
@@ -67,4 +67,6 @@ SELECT namefin as "ote.db.places/namefin", id as "ote.db.places/id", type as "ot
 INSERT INTO operation_area ("transport-service-id", description, location, "primary?")
  SELECT :new-service-id as "transport-service-id", oa.description, oa.location, oa."primary?"
    FROM operation_area oa
-  WHERE oa."transport-service-id" = :old-service-id RETURNING id;
+  WHERE oa."transport-service-id" = :old-service-id
+    AND oa.id IN (:ids)
+    RETURNING id;

--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -10,6 +10,11 @@ SELECT ts.id,
        ts."sub-type",
        ts."published",
        ts."validate",
+       ts."parent-id",
+       CASE WHEN (select service."parent-id" as "child-parent-id" FROM "transport-service" service WHERE service."parent-id" = ts.id)
+            IS NOT NULL THEN true
+           ELSE false
+       END as "has-child?",
        ts."created",
        ts."modified",
        ts."transport-type",

--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -25,3 +25,6 @@ SELECT ts.id,
   FROM "transport-service" ts
  WHERE ts."transport-operator-id" in (:operator-ids)
  ORDER BY ts."type" DESC, ts.modified DESC NULLS LAST;
+
+-- name: update-child-parent-interfaces
+SELECT child_parent_interfaces(:parent-id::INTEGER, :child-id::INTEGER);

--- a/ote/src/cljs/ote/ui/form_fields.cljs
+++ b/ote/src/cljs/ote/ui/form_fields.cljs
@@ -647,11 +647,11 @@
 (def minute-regex #"^(^$|0?[0-9]|[1-5][0-9])$")
 
 (defmethod field :time [{:keys [update! element-id error-hour error-min on-blur required? unrestricted-hours? warning
-                                style input-style container-style disabled?] :as opts}
+                                style input-style container-style disabled? row-number] :as opts}
                         {:keys [hours hours-text minutes minutes-text] :as data}]
   [:div {:style (merge style-base/inline-block container-style)}
    [field (merge
-            {:id (str "hours-" element-id)
+            {:element-id (str "hours-" element-id "-" row-number)
              :type :string
              :name "hours"
              :error (when error-hour
@@ -683,7 +683,7 @@
       (or hours-text (str hours)))]
    "."
    [field (merge
-            {:id (str "minutes-" element-id)
+            {:element-id (str "minutes-" element-id "-" row-number)
              :type :string
              :name "minutes"
              :error (when error-min
@@ -893,7 +893,8 @@
                                 (when missing?
                                   {:warning (tr [:common-texts :required-field])})
                                 (when field-error
-                                  {:error field-error}))
+                                  {:error field-error})
+                                {:row-number i})
                         value]
                        :else nil)]))
                 (when inner-delete?

--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -82,7 +82,7 @@
                   :display-row-checkbox false}
    (doall
      (map
-       (fn [{::t-service/keys [id type sub-type interface-types published validate re-edit name]
+       (fn [{::t-service/keys [id type sub-type interface-types published validate re-edit name has-child?]
              ::modification/keys [created modified] :as row}]
          (let [service-state (ts-controller/service-state validate re-edit published)]
            ^{:key id}
@@ -92,10 +92,12 @@
                                   :overflow "visible"}}
             [ui/table-row-column {:class "table-col-style-semi-wrap"
                                   :style {:width "20%"}}
-             [:a (merge {:href (str "/#/edit-service/" id)
-                         :on-click #(do (.preventDefault %)
-                                        (e! (fp-controller/->ChangePage :edit-service {:id id})))}
-                        (stylefy/use-sub-style style-base/basic-table :link)) name]]
+             (if has-child?
+               name
+               [:a (merge {:href (str "/#/edit-service/" id)
+                           :on-click #(do (.preventDefault %)
+                                          (e! (fp-controller/->ChangePage :edit-service {:id id})))}
+                          (stylefy/use-sub-style style-base/basic-table :link)) name])]
             [ui/table-row-column {:class "hidden-xs table-col-style-semi-wrap"
                                   :style {:overflow "visible"
                                           :width "20%"}}
@@ -130,20 +132,27 @@
                 (tr [:field-labels :transport-service ::t-service/published?-values false])])]
             [ui/table-row-column {:class "table-col-style-semi-wrap"
                                   :style {:width "20%"
+                                          :overflow "visible"
                                           :padding-top "0.5rem"}}
-             [:a (merge {:href (str "#/edit-service/" id)
-                         :style {:padding-right "0.5rem"}
-                         :id (str "edit-service-button" id)
-                         :on-click #(do
-                                      (.preventDefault %)
-                                      (e! (fp-controller/->ChangePage :edit-service {:id id})))}
-                        (stylefy/use-style style-base/gray-link-with-icon))
-              (ic/content-create {:style {:width 24
-                                          :height 24
-                                          :margin-right "2px"
-                                          :color colors/icon-gray}})
-              [:span {:style {:padding-top "4px"}} (tr [:buttons :edit])]]
-             [delete-service-action e! row]]]))
+             (if has-child?
+               [:span "Ei käytössä"
+                [common/tooltip-icon {:text (tr [:own-services-page :published-service-cannot-be-modified])
+                                      :len "medium"
+                                      :pos "up"}]]
+               [:span
+                [:a (merge {:href (str "#/edit-service/" id)
+                            :style {:padding-right "0.5rem"}
+                            :id (str "edit-service-button" id)
+                            :on-click #(do
+                                         (.preventDefault %)
+                                         (e! (fp-controller/->ChangePage :edit-service {:id id})))}
+                           (stylefy/use-style style-base/gray-link-with-icon))
+                 (ic/content-create {:style {:width 24
+                                             :height 24
+                                             :margin-right "2px"
+                                             :color colors/icon-gray}})
+                 [:span {:style {:padding-top "4px"}} (tr [:buttons :edit])]]
+                [delete-service-action e! row]])]]))
        services))])
 
 (defn- route-error

--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -135,7 +135,7 @@
                                           :overflow "visible"
                                           :padding-top "0.5rem"}}
              (if has-child?
-               [:span "Ei käytössä"
+               [:span (tr [:own-services-page :not-in-use])
                 [common/tooltip-icon {:text (tr [:own-services-page :published-service-cannot-be-modified])
                                       :len "medium"
                                       :pos "up"}]]

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -745,6 +745,7 @@
               {:label (tr [:common-texts :start-time])})
             {:name ::t-service/from
              :label (tr [:field-labels :transport-service ::t-service/from])
+             :element-id "start-time"
              :type :time
              :disabled? in-validation?
              :container-style {:padding-top "1.5rem"}
@@ -757,6 +758,7 @@
               {:label (tr [:common-texts :ending-time])})
             {:name ::t-service/to
              :label (tr [:field-labels :transport-service ::t-service/to])
+             :element-id "end-time"
              :type :time
              :disabled? in-validation?
              :container-style {:padding-top "1.5rem"}

--- a/ote/src/cljs/ote/views/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service_common.cljs
@@ -600,7 +600,8 @@
         admin-validating-id (get-in app [:admin :in-validation :validating])
         cannot-be-saved-text (if (flags/enabled? :service-validation)
                                (tr [:form-help :validate-missing-required])
-                               (tr [:form-help :publish-missing-required]))]
+                               (tr [:form-help :publish-missing-required]))
+        admin-unsaved-data (some #{:unsaved-data} (:before-unload-message app))]
     [:div
      ;; Show brokering dialog
      [brokering-dialog e! app]
@@ -634,13 +635,13 @@
                           (tr [:buttons :discard])]]]
            :re-edit [:div {:style {:display "flex" :flex-direction "row" :flex-wrap "wrap"}}
                      [:div {:style {:margin-top "1rem"}}
-                      [buttons/save-draft {:on-click #(e! (ts-controller/->SaveTransportService schemas false))
-                                           :disabled name-missing?}
-                       (tr [:buttons :back-to-draft])]]
-                     [:div {:style {:margin-top "1rem"}}
                       [buttons/save-publish {:on-click #(e! (ts-controller/->ConfirmSaveTransportService schemas))
                                              :disabled (not (form/can-save? data))}
-                       (tr [:buttons :save-and-validate])]]]
+                       (tr [:buttons :save-and-validate])]]
+                     [:div {:style {:margin-top "1rem"}}
+                      [buttons/save-draft {:on-click #(e! (ts-controller/->SaveTransportService schemas false))
+                                           :disabled name-missing?}
+                       (tr [:buttons :back-to-draft])]]]
            :draft [render-draft-state-buttons e! schemas data name-missing?])]]
        ;; admin is editing
        (and
@@ -652,9 +653,13 @@
           [buttons/save-publish {:on-click #(e! (ts-controller/->ConfirmSaveTransportService schemas))
                                  :disabled (not (form/can-save? data))}
            (tr [:buttons :save])]]
+
+         ;; Admin cannot publish service with modifications
          [:div {:style {:margin-top "1rem"}}
           [buttons/save-publish {:on-click #(e! (admin-validation/->OpenConfirmPublishModal service-id))
-                                 :disabled (not (form/can-save? data))}
+                                 :disabled (when (or
+                                                   (not (form/can-save? data))
+                                                   admin-unsaved-data) true)}
            (tr [:buttons :publish])]]
          [:div {:style {:margin-top "1rem"}}
           [buttons/cancel-with-icon {:on-click #(e! (ts-controller/->CancelTransportServiceForm true))}


### PR DESCRIPTION
# Added
* When user edits published services they are duplicated in database and duplicated service is moved to validation process and original is staying in published state.

  
# Datamodel
* Added parent-id to transport-service table
* Added new sproc to handle copying interfaces from child service to parent service
   

