### PR TITLE
170840682 Change detected-route unique index

### DIFF
--- a/database/src/main/resources/db/migration/V1_182__change_detection_route_unique_idx.sql
+++ b/database/src/main/resources/db/migration/V1_182__change_detection_route_unique_idx.sql
@@ -1,0 +1,4 @@
+-- drop unique index to "detection-route" table using columns package-id and route-hash-id
+DROP INDEX "detection-route_package-id_route-hash-id_uindex";
+-- Create new unique index to "detection-route" table using columns package-id and route-hash-id
+CREATE UNIQUE INDEX "detection-route_route_id_package-id_route-hash-id_uindex" ON "detection-route" ("route-id","package-id", "route-hash-id");


### PR DESCRIPTION
# Changed
* detected-route unique index
* Old index prevented same route be twice in the table when it did come from two different agency. Now duplicate check is a bit different and we allow same route-hash-id be in the table with same package-id if route-id remains different. This will allow two agencies to drive same trip with same route-hash-id but with different calendar days.
   
