### PR TITLE
170094026 preserve download history

### DIFF
--- a/database/devdb_rewrite_db_template.sh
+++ b/database/devdb_rewrite_db_template.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+### HOX: This will be run inside napotedb container ###
+
+set -e
+
+cd /database
+
+echo "Drop napotetest_template database if it exist"
+psql -h napotedb -U napote napote -c "DROP DATABASE IF EXISTS napotetest_template;"
+
+echo "Drop napotetest database if it exist"
+psql -h napotedb -U napote napote -c "DROP DATABASE IF EXISTS napotetest;"
+
+echo "Clean up and free connections"
+psql -h napotedb -U napote napote -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'napote' AND pid <> pg_backend_pid();"
+
+echo "Create napotetest_template database using napote database"
+psql -h napotedb -U napote napote -c "CREATE DATABASE napotetest_template WITH TEMPLATE napote OWNER napotetest;"
+
+echo "Create napotetest database using napotetest_template database"
+psql -h napotedb -U napote napote -c "CREATE DATABASE napotetest WITH TEMPLATE napotetest_template OWNER napotetest;"
+
+echo "Done."

--- a/database/devdb_simple_migrate.sh
+++ b/database/devdb_simple_migrate.sh
@@ -13,3 +13,5 @@ done
 
 echo "Connection established!"
 mvn flyway:migrate
+cd -
+docker run -v $DIR:/database -v -it --network docker_napote --link napotedb:postgres --rm postgres sh /database/devdb_rewrite_db_template.sh

--- a/database/src/main/resources/db/migration/V1_185__interface_download_status_service.sql
+++ b/database/src/main/resources/db/migration/V1_185__interface_download_status_service.sql
@@ -1,19 +1,22 @@
--- Remove interface-id from external-interface-download-status and replace it with service id
--- Add service-id
+-- Goal is to remove interface-id from external-interface-download-status and replace it with service-id
+-- But to reduce risks we do not yet remove interface-id. The code is here (and it is tested) but it doesn't do anything yet. It is commented off.
+-- When everything is ok in production db, then it can be used.
+
+-- First; Add service-id
 ALTER TABLE "external-interface-download-status"
     ADD COLUMN "transport-service-id" INTEGER REFERENCES "transport-service" (id) ON DELETE CASCADE ON UPDATE CASCADE;
 
 
--- UPDATE all existing rows with service-id
+-- Second: UPDATE all existing rows with service-id
 UPDATE  "external-interface-download-status" eid
    SET "transport-service-id" = i."transport-service-id"
   FROM "external-interface-description" i
  WHERE i.id = eid."external-interface-description-id";
 
--- Remove foreign key from external-interface-download-status
+-- Third: Remove foreign key from external-interface-download-status
 ALTER TABLE "external-interface-download-status"
     DROP CONSTRAINT "external-interface-download-s_external-interface-descripti_fkey";
 
--- Remove interface if
+-- Fourth: Remove interface-id from the table -- actually, add this to another flyway migration file.
 --ALTER TABLE "external-interface-download-status"
 --    DROP COLUMN "external-interface-description-id";

--- a/database/src/main/resources/db/migration/V1_185__interface_download_status_service.sql
+++ b/database/src/main/resources/db/migration/V1_185__interface_download_status_service.sql
@@ -1,0 +1,19 @@
+-- Remove interface-id from external-interface-download-status and replace it with service id
+-- Add service-id
+ALTER TABLE "external-interface-download-status"
+    ADD COLUMN "transport-service-id" INTEGER REFERENCES "transport-service" (id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+-- UPDATE all existing rows with service-id
+UPDATE  "external-interface-download-status" eid
+   SET "transport-service-id" = i."transport-service-id"
+  FROM "external-interface-description" i
+ WHERE i.id = eid."external-interface-description-id";
+
+-- Remove foreign key from external-interface-download-status
+ALTER TABLE "external-interface-download-status"
+    DROP CONSTRAINT "external-interface-download-s_external-interface-descripti_fkey";
+
+-- Remove interface if
+--ALTER TABLE "external-interface-download-status"
+--    DROP COLUMN "external-interface-description-id";

--- a/ote/src/clj/ote/services/transit_changes.clj
+++ b/ote/src/clj/ote/services/transit_changes.clj
@@ -95,6 +95,7 @@
           ;; Mark interface download a success
           (specql/insert! db ::t-service/external-interface-download-status
                           {::t-service/external-interface-description-id interface-id
+                           ::t-service/transport-service-id service-id
                            ::t-service/download-status :success
                            ::t-service/package-id (:gtfs/id package)
                            ::t-service/url interface-url

--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -7,7 +7,6 @@
             [ote.components.service :refer [define-service-component]]
             [specql.core :as specql]
             [clojure.string :as str]
-            [taoensso.timbre :as log]
             [specql.impl.composite :as composite]
             [specql.impl.registry :as specql-registry]
             [ote.util.fn :refer [flip]]
@@ -17,6 +16,14 @@
             [ote.authorization :as authorization]))
 
 (defqueries "ote/services/transit_visualization.sql")
+;; Testing to declare jeesql functions to make clj-kondo work better
+(declare fetch-date-hashes-for-route-with-route-hash-id)
+(declare fetch-route-trips-by-hash-and-date)
+(declare fetch-service-info)
+(declare detected-service-change-by-date)
+(declare detected-route-changes-by-date)
+(declare fetch-gtfs-packages-for-service)
+(declare fetch-route-trip-info-by-name-and-date)
 
 (defn- parse-stops [stops]
   (mapv (fn [stop]
@@ -138,6 +145,7 @@
                                            :specql.core/order-direction :desc
                                            :specql.core/limit 50})})))
 
+  
   ^{:unauthenticated false :format :transit}
   (GET "/transit-visualization/:service-id/route"
        {{:keys [service-id]} :params

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -181,7 +181,7 @@ SELECT p.id, p.created,
   FROM gtfs_package p
   JOIN LATERAL gtfs_package_date_range(p.id) as dr (daterange) ON TRUE
   JOIN "external-interface-description" eid ON p."external-interface-description-id" = eid.id
-  LEFT JOIN "external-interface-download-status" id ON id."external-interface-description-id" = eid.id AND id."package-id" = p.id
+  LEFT JOIN "external-interface-download-status" id ON id."transport-service-id" = :service-id AND id."package-id" = p.id
  WHERE p."transport-service-id" = :service-id AND p."deleted?" = FALSE
  ORDER BY p.created DESC;
 

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -180,7 +180,6 @@ SELECT p.id, p.created,
        concat(id."db-error", id."download-error") as error
   FROM gtfs_package p
   JOIN LATERAL gtfs_package_date_range(p.id) as dr (daterange) ON TRUE
-  JOIN "external-interface-description" eid ON p."external-interface-description-id" = eid.id
   LEFT JOIN "external-interface-download-status" id ON id."transport-service-id" = :service-id AND id."package-id" = p.id
  WHERE p."transport-service-id" = :service-id AND p."deleted?" = FALSE
  ORDER BY p.created DESC;

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -74,7 +74,10 @@
          interface (if (contains? interface :data-content)  ; Avoid creating a coll with empty key when coll doesn't exist
                      (update interface :data-content PgArray->vec)
                      interface)
-         force-download? (integer? service-id)]
+         force-download? (integer? service-id)
+         used-service-id (if service-id
+                           service-id
+                           (:ts-id interface))]
      (if interface
        (try
          (if-let [conversion-meta (import-gtfs/download-and-store-transit-package
@@ -94,7 +97,7 @@
 
         (catch Exception e
           (log/spy :warn "GTFS: Error importing, uploading or saving gtfs package to db! Exception=" e)))
-      (log/spy :warn "GTFS: No gtfs files to upload. service-id = " service-id)))))
+      (log/spy :warn "GTFS: No gtfs files to upload. service-id = " used-service-id)))))
 
 (def night-hours #{0 1 2 3 4})
 


### PR DESCRIPTION
# Changed
* external interfaces: Remove cascade delete from interface -> download status to prevent loss of download history
* external interface download history: Add service-id to the table to make history independent of interface.
   
