### PR TITLE
171809348 - Use only packages from valid interfaces in newest change detection

### DIFF
--- a/ote/project.clj
+++ b/ote/project.clj
@@ -105,6 +105,8 @@
 
                  ;; Time - Eclipse Public License 1.0
                  [com.andrewmcveigh/cljs-time "0.5.0"]
+                 ;; java-time - MIT
+                 [clojure.java-time "0.3.2"]
 
                  ;; HTML/XML generation from Clojure data - Eclipse Public License 1.0
                  [hiccup "1.0.5"]

--- a/ote/src/clj/ote/tasks/util.clj
+++ b/ote/src/clj/ote/tasks/util.clj
@@ -1,7 +1,10 @@
 (ns ote.tasks.util
   (:require [clj-time.core :as t]
-            [clj-time.periodic :refer [periodic-seq]])
-  (:import (org.joda.time DateTimeZone)))
+            [clj-time.periodic :refer [periodic-seq]]
+            [java-time :as java-time]
+            [ote.time :as time])
+  (:import (org.joda.time DateTimeZone)
+           (java.time LocalDate)))
 
 (defonce timezone (DateTimeZone/forID "Europe/Helsinki"))
 
@@ -14,3 +17,23 @@
                     (t/plus first-time (t/days 1))
                     first-time)
                   (t/days 1))))
+
+(defn joda-local-date-to-str [^org.joda.time.LocalDate joda-local-date]
+  (let [joda-date-dayOfMonth (.getDayOfMonth joda-local-date)
+        joda-date-dayOfMonth (if (= 1 (count (str joda-date-dayOfMonth)))
+                          (str "0" joda-date-dayOfMonth)
+                          joda-date-dayOfMonth)
+        joda-date-month (.getMonthOfYear joda-local-date)
+        joda-date-month (if (= 1 (count (str joda-date-month)))
+                          (str "0" joda-date-month)
+                          joda-date-month)
+        joda-date-year (.getYear joda-local-date)]
+    (str joda-date-year "-" joda-date-month "-" joda-date-dayOfMonth)))
+
+(defn joda-local-date-to-java-time-local-date
+  "Format joda local date to java.time.localdate"
+  [^org.joda.time.LocalDate joda-local-date]
+  (java-time.local/local-date (joda-local-date-to-str joda-local-date)))
+
+(defn joda-local-date-to-inst [^org.joda.time.LocalDate joda-local-date]
+  (time/date-string->inst-date (joda-local-date-to-str joda-local-date)))

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -14,7 +14,8 @@
             [ote.db.tx :as tx]
             [ote.transit-changes.change-history :as change-history]
             [ote.config.transit-changes-config :as config-tc])
-  (:import (java.time LocalDate DayOfWeek)))
+  (:import (java.time LocalDate)
+           (org.joda.time DateTime)))
 
 (def settings-tc (config-tc/config))
 
@@ -732,7 +733,7 @@
 (defn transform-route-change
   "Transform a detected route change into a database 'gtfs-route-change-info' type."
   [all-routes
-   {:keys [route-key change-date change-type changes] :as route-change} route-changes-all]
+   {:keys [route-key change-date change-type changes] :as route-change} route-changes-all ^LocalDate analysis-date]
   (spec/assert ::detected-route-changes-for-services-coll route-changes-all)
   (let [route-info (first (filter #(= route-key (:route-hash-id %))
                                   (map second all-routes)))
@@ -778,7 +779,7 @@
                                 {:gtfs/change-type :removed
                                  ;; For a removed route, the change-date is the day after traffic stops
                                  ;; BUT: If removed? is identified and route ends before current date, set change date as nil so we won't analyze this anymore.
-                                 :gtfs/change-date (if (.isBefore change-date (java.time.LocalDate/now))
+                                 :gtfs/change-date (if (.isBefore change-date (task-util/joda-local-date-to-java-time-local-date analysis-date))
                                                      nil
                                                      (time/sql-date change-date))
                                  :gtfs/different-week-date (time/sql-date change-date)
@@ -820,14 +821,14 @@
                               :gtfs/created-date (java.util.Date.)}
                              r)))))
 
-(defn update-transit-changes! [db analysis-date service-id package-ids {:keys [all-routes route-changes]}]
+(defn update-transit-changes! [db ^DateTime analysis-date service-id package-ids {:keys [all-routes route-changes]}]
   {:pre [(some? analysis-date)
          (or (zero? service-id)
              (pos? service-id))]}
   (tx/with-transaction
     db
     (let [route-change-infos (map (fn [detection-result]
-                                    (transform-route-change all-routes detection-result route-changes))
+                                    (transform-route-change all-routes detection-result route-changes (.toLocalDate analysis-date)))
                                   route-changes)
           change-infos-group (group-by :gtfs/change-type route-change-infos)
           earliest-route-change (first (drop-while (fn [{:gtfs/keys [change-date]}]
@@ -836,11 +837,12 @@
                                                          (date-in-the-past? (.toLocalDate change-date))))
                                                    (sort-by :gtfs/change-date route-change-infos)))
           ;; Set change date to future (every 2 weeks at monday) - This is the day when changes are detected for next time
-          new-change-date (time/sql-date (time/native->date (.plusDays (time/beginning-of-week (.toLocalDate (time/now))) (:detection-interval-service-days settings-tc))))
+          new-change-date (time/sql-date (time/native->date (.plusDays (time/beginning-of-week (.toLocalDate analysis-date)) (:detection-interval-service-days settings-tc))))
+          new-change-date-old (time/sql-date (time/native->date (.plusDays (time/beginning-of-week (.toLocalDate (time/now))) (:detection-interval-service-days settings-tc))))
           transit-chg-res (specql/upsert! db :gtfs/transit-changes
                                           #{:gtfs/transport-service-id :gtfs/date}
                                           {:gtfs/transport-service-id service-id
-                                           :gtfs/date analysis-date
+                                           :gtfs/date (task-util/joda-local-date-to-inst (.toLocalDate analysis-date))
                                            :gtfs/change-date new-change-date
                                            :gtfs/different-week-date (:gtfs/different-week-date earliest-route-change)
                                            :gtfs/current-week-date (:gtfs/current-week-date earliest-route-change)
@@ -852,8 +854,8 @@
 
                                            :gtfs/package-ids package-ids
                                            :gtfs/created (java.util.Date.)})]
-      (update-route-changes! db (time/sql-date analysis-date) service-id route-change-infos)
-      (change-history/update-change-history db (time/sql-date analysis-date) service-id package-ids route-change-infos))))
+      (update-route-changes! db (time/sql-date (task-util/joda-local-date-to-java-time-local-date (.toLocalDate analysis-date))) service-id route-change-infos)
+      (change-history/update-change-history db (time/sql-date (task-util/joda-local-date-to-java-time-local-date (.toLocalDate analysis-date))) service-id package-ids route-change-infos))))
 
 (defn override-holidays [db date-route-hashes]
   (map (fn [row]
@@ -1020,8 +1022,10 @@
         headsign (:gtfs/trip-headsign x)]
     (str short "-" long "-" headsign)))
 
-(defn service-package-ids-for-date-range [db query-params]
-  (mapv :id (service-packages-for-date-range db query-params)))
+(defn service-package-ids-for-date-range [db query-params detection-date-in-the-past?]
+  (if detection-date-in-the-past?
+    (mapv :id (service-packages-for-detection-date db query-params))
+    (mapv :id (service-packages-for-date-range db query-params))))
 
 ;; This is only for local development
 ;; Add route-hash-id for all routes in gtfs-transit-changes table in column route-hashes.

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -988,7 +988,7 @@
         all-route-keys (set (keys all-routes))
 
         route-hashes (sort-by :date
-                              (apply concat
+                                (apply concat
                                      (mapv (fn [route-key]
                                              (let [query-params (merge {:route-hash-id route-key} route-query-params)]
                                                (service-route-hashes-for-date-range db query-params)))

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -31,7 +31,7 @@ SELECT DISTINCT pids.id
   JOIN LATERAL unnest(gtfs_service_packages_for_date(:service-id::INTEGER, d.date)) pids (id) ON TRUE;
 
 -- name: service-routes-with-date-range
-SELECT * FROM gtfs_service_routes_with_daterange(:service-id::INTEGER);
+SELECT * FROM gtfs_routes_for_change_detection(:service-id::INTEGER);
 
 -- name: fetch-route-trips-for-date
 WITH routes AS (

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -30,6 +30,15 @@ SELECT DISTINCT pids.id
   FROM dates d
   JOIN LATERAL unnest(gtfs_service_packages_for_date(:service-id::INTEGER, d.date)) pids (id) ON TRUE;
 
+-- name: service-packages-for-detection-date
+WITH dates AS (
+    SELECT :start-date::DATE + d AS date
+    FROM generate_series(0, :end-date::DATE - :start-date::DATE) s (d)
+)
+SELECT DISTINCT pids.id
+  FROM dates d
+       JOIN LATERAL unnest(gtfs_packages_for_detection(:service-id::INTEGER, d.date)) pids (id) ON TRUE;
+
 -- name: service-routes-with-date-range
 SELECT * FROM gtfs_routes_for_change_detection(:service-id::INTEGER);
 


### PR DESCRIPTION
# Changed
* Create new sql query to get change detection routes
* Deleted interfaces must be filtered out from change detection. To enable this, we needed new queries to get gtfs packages
