### PR TITLE
Pass detection/analysis date to rest of the detection algorithms

### DIFF
--- a/ote/src/clj/ote/tasks/util.clj
+++ b/ote/src/clj/ote/tasks/util.clj
@@ -30,10 +30,17 @@
         joda-date-year (.getYear joda-local-date)]
     (str joda-date-year "-" joda-date-month "-" joda-date-dayOfMonth)))
 
+(defn joda-datetime-to-java-time-local-date
+  "Format joda datetime to java.time.localdate"
+  [^org.joda.time.DateTime joda-datetime]
+  (java-time.local/local-date (joda-local-date-to-str (.toLocalDate joda-datetime))))
+
 (defn joda-local-date-to-java-time-local-date
   "Format joda local date to java.time.localdate"
   [^org.joda.time.LocalDate joda-local-date]
   (java-time.local/local-date (joda-local-date-to-str joda-local-date)))
 
-(defn joda-local-date-to-inst [^org.joda.time.LocalDate joda-local-date]
+(defn joda-local-date-to-inst
+  "Format joda-localdate to java datetime inst"
+  [^org.joda.time.LocalDate joda-local-date]
   (time/date-string->inst-date (joda-local-date-to-str joda-local-date)))

--- a/ote/test/clj/ote/transit_changes/detection_integration_test.clj
+++ b/ote/test/clj/ote/transit_changes/detection_integration_test.clj
@@ -136,7 +136,7 @@
                             :start-date (joda-datetime->inst (time/days-from current-start-date -63)) ; Keep monday as week start day
                             :end-date (joda-datetime->inst (time/days-from now 30))
                             :ignore-holidays? true}
-        detection-result (detection/detect-route-changes-for-service db route-query-params)
+        detection-result (detection/detect-route-changes-for-service db route-query-params (java.time.LocalDate/now))
         changes (->> detection-result
                      :route-changes
                      (filter :changes))


### PR DESCRIPTION
# Added
* To fix detection history we need to use given detection date in all detection algorithms instead of current date.
   
