### PR TITLE
171620402 - transit changes current stats

### DIFF
--- a/database/src/main/resources/db/migration/V1_186__add_transit_change_over_night_updates.sql
+++ b/database/src/main/resources/db/migration/V1_186__add_transit_change_over_night_updates.sql
@@ -1,0 +1,13 @@
+-- Transit changes are updated every night to match current date situation.
+-- We need to store those nightly changes to different columns than original detection to store original changes somewhere
+ALTER TABLE "gtfs-transit-changes"
+    ADD COLUMN "current-added-routes" INTEGER, -- How many new routes are in the different week
+    ADD COLUMN "current-removed-routes" INTEGER, -- How many routes are missing from the different week
+    ADD COLUMN "current-changed-routes" INTEGER, -- How many routes have changes (stop sequence or stop time)
+    ADD COLUMN "current-no-traffic-routes" INTEGER; -- How many routes have no-traffic segments
+
+-- update current values
+UPDATE "gtfs-transit-changes" SET "current-added-routes" = "added-routes";
+UPDATE "gtfs-transit-changes" SET "current-removed-routes" = "removed-routes";
+UPDATE "gtfs-transit-changes" SET "current-changed-routes" = "changed-routes";
+UPDATE "gtfs-transit-changes" SET "current-no-traffic-routes" = "no-traffic-routes";

--- a/ote/src/clj/ote/services/transit_changes.sql
+++ b/ote/src/clj/ote/services/transit_changes.sql
@@ -15,10 +15,10 @@ SELECT ts.id AS "transport-service-id",
        ts."commercial-traffic?" AS "commercial?",
        ts.name AS "transport-service-name",
        op.name AS "transport-operator-name",
-       c."added-routes" as "added-routes",
-       c."removed-routes" as "removed-routes",
-       c."no-traffic-routes" as "no-traffic-routes",
-       c."changed-routes" as "changed-routes",
+       c."current-added-routes" as "added-routes",
+       c."current-removed-routes" as "removed-routes",
+       c."current-no-traffic-routes" as "no-traffic-routes",
+       c."current-changed-routes" as "changed-routes",
        CURRENT_DATE as "current-date",
        c."change-date",
        c."date",
@@ -73,7 +73,7 @@ WHERE 'road' = ANY(ts."transport-type")
   AND ts.published IS NOT NULL
 -- Group so that each group represents a distinct change date, allows summing up changes in SELECT section of this query
 GROUP BY ts.id, c."date", op.name, c."change-date", c."package-ids", c."different-week-date", "sent-emails"."email-sent",
-         c."added-routes", c."removed-routes", c."no-traffic-routes", c."changed-routes"
+         c."current-added-routes", c."current-removed-routes", c."current-no-traffic-routes", c."current-changed-routes"
 
 ORDER BY "different-week-date" ASC, "interfaces-has-errors?" DESC, "no-interfaces?" DESC, "no-interfaces-imported?" ASC,
          op.name ASC;

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -167,13 +167,14 @@ different-week-date value and skip all expired changes."
 
         (log/info (inc i) "/" (count upcoming-changes) " Recalculating detected change amounts (by change type) for service " (:transport-service-id change-row) " detection date " (:date change-row))
         ;; Update sinle transit-change (change-row)
-        (specql/update! db :gtfs/transit-changes
-                        {:gtfs/removed-routes (count (group-by :route-hash-id (:removed grouped-changes)))
-                         :gtfs/added-routes (count (group-by :route-hash-id (:added grouped-changes)))
-                         :gtfs/changed-routes (count (group-by :route-hash-id (:changed grouped-changes)))
-                         :gtfs/no-traffic-routes (count (group-by :route-hash-id (:no-traffic grouped-changes)))}
-                        {:gtfs/date (:date change-row)
-                         :gtfs/transport-service-id (:transport-service-id change-row)})))
+        (when (not (nil? (:date change-row)))
+          (specql/update! db :gtfs/transit-changes
+                          {:gtfs/current-removed-routes (count (group-by :route-hash-id (:removed grouped-changes)))
+                           :gtfs/current-added-routes (count (group-by :route-hash-id (:added grouped-changes)))
+                           :gtfs/current-changed-routes (count (group-by :route-hash-id (:changed grouped-changes)))
+                           :gtfs/current-no-traffic-routes (count (group-by :route-hash-id (:no-traffic grouped-changes)))}
+                          {:gtfs/date (:date change-row)
+                           :gtfs/transport-service-id (:transport-service-id change-row)}))))
     (log/info "Detected change count recalculation ready!")))
 
 (defrecord GtfsTasks [at config]

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -848,9 +848,13 @@
                                            :gtfs/current-week-date (:gtfs/current-week-date earliest-route-change)
 
                                            :gtfs/removed-routes (count (group-by :gtfs/route-hash-id (:removed change-infos-group)))
+                                           :gtfs/current-removed-routes (count (group-by :gtfs/route-hash-id (:removed change-infos-group)))
                                            :gtfs/added-routes (count (group-by :gtfs/route-hash-id (:added change-infos-group)))
+                                           :gtfs/current-added-routes (count (group-by :gtfs/route-hash-id (:added change-infos-group)))
                                            :gtfs/changed-routes (count (group-by :gtfs/route-hash-id (:changed change-infos-group)))
+                                           :gtfs/current-changed-routes (count (group-by :gtfs/route-hash-id (:changed change-infos-group)))
                                            :gtfs/no-traffic-routes (count (group-by :gtfs/route-hash-id (:no-traffic change-infos-group)))
+                                           :gtfs/current-no-traffic-routes (count (group-by :gtfs/route-hash-id (:no-traffic change-infos-group)))
 
                                            :gtfs/package-ids package-ids
                                            :gtfs/created (java.util.Date.)})]

--- a/ote/src/cljs/ote/app/controller/admin_transit_changes.cljs
+++ b/ote/src/cljs/ote/app/controller/admin_transit_changes.cljs
@@ -260,8 +260,7 @@
 (define-event SendPreNotices []
   {}
   (comm/get! "/admin/pre-notices/notify"
-             {
-              :on-success (tuck/send-async! ->SendPreNoticeSuccess)
+             {:on-success (tuck/send-async! ->SendPreNoticeSuccess)
               :on-failure (tuck/send-async! ->SendPreNoticeFailure)})
   app)
 
@@ -270,6 +269,13 @@
   (comm/get! "admin/general-troubleshooting-log"
              {:on-success #(.log js/console "response = " %)
               :on-failure #(.log js/console "response = " %)})
+  app)
+
+(define-event CleanupOldTransitChanges []
+  {}
+  (comm/post! "admin/recalculate-detected-changes-count" {}
+              {:on-success #(.log js/console "response = " %)
+               :on-failure #(.log js/console "response = " %)})
   app)
 
 (defn ^:export force-detect-transit-changes []

--- a/ote/src/cljs/ote/ui/table.cljs
+++ b/ote/src/cljs/ote/ui/table.cljs
@@ -193,8 +193,8 @@
                      :let [_ (swap! column-inx inc)
                            width (when (map? column)
                                    (:width column))
-                           text (if (string? column)
-                                  column
-                                  (:text column))]]
+                           text (if (map? column)
+                                  (:text column)
+                                  column)]]
                  ^{:key (str @column-inx "-row-column-" text)}
                  [:td (when width {:style {:width width}}) text]))]))]]]]))

--- a/ote/src/cljs/ote/views/admin/detected_changes.cljs
+++ b/ote/src/cljs/ote/views/admin/detected_changes.cljs
@@ -209,7 +209,13 @@
    [day-hash-button-element e!
     "Selvitä tuotannon päiväyksiin liittyvää formatointiongelmaa"
     "Logita päiväykset"
-    #(e! (admin-transit-changes/->GeneralTroubleshootingLog))]])
+    #(e! (admin-transit-changes/->GeneralTroubleshootingLog))]
+
+   [:br]
+   [day-hash-button-element e!
+    "Käynnistä yöllinen muutostunnistusten gtfs-transit-changes siivous, koska muutokset voivat vanhentua kalenteripäivien edetessä ja muutosten jäädessä historiaan."
+    "Siivoa vanhat muutostunnistukset"
+    #(e! (admin-transit-changes/->CleanupOldTransitChanges))]])
 
 (defn route-id [e! app-state recalc?]
   (let [services (get-in app-state [:admin :transit-changes :route-hash-services])]


### PR DESCRIPTION
# Changed
* When transit changes were analyzed every night we were removing data that could be needed later. Now added new columns to store this changing transit changes data.
   
# Datamodel
* new columns to store current added-changes, removed-changes, no-transit-changes, changes
   