### PR TITLE
172691911 trips wont show up

### DIFF
--- a/ote/project.clj
+++ b/ote/project.clj
@@ -114,8 +114,8 @@
                  [org.clojure/data.zip "0.1.3"]
 
                  ;; GeoTools - LGPL
-                 [org.geotools/gt-epsg-wkt "20.0"]
-                 [org.geotools/gt-geometry "20.0"]
+                 [org.geotools/gt-epsg-wkt "20.1"]
+                 [org.geotools/gt-geometry "20.1"]
 
                  ;; Data/file formats and file handling
                  ;; JSON - MIT
@@ -150,8 +150,8 @@
                                   [webjure/json-schema "0.7.4"]]
                    :test-paths ["test/clj"]}}
 
-  :repositories [["osgeo" "https://download.osgeo.org/webdav/geotools/"]
-                 ["boundlessgeo" "https://repo.boundlessgeo.com/main/"]]
+  :repositories [["osgeo-release" "https://repo.osgeo.org/repository/release/"]
+                 ["osgeo" "https://download.osgeo.org/webdav/geotools/"]]
   :plugins [;; Automatically compile your ClojureScript code into Javascript - Eclipse Public License 1.0
             [lein-cljsbuild "1.1.7"]
             ;; Figwheel builds your ClojureScript code and hot loads it into the browser - Eclipse Public License 1.0

--- a/ote/src/clj/ote/services/operators.sql
+++ b/ote/src/clj/ote/services/operators.sql
@@ -3,7 +3,7 @@ SELECT t."transport-operator-id" as id, COUNT(t.id) AS services
   FROM "transport-service" t
  WHERE t."transport-operator-id" IN (:operators) AND
        t.published IS NOT NULL
-GROUP BY t."transport-operator-id"
+GROUP BY t."transport-operator-id";
 
 -- name: count-matching-operators
 -- single?: true

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -10,7 +10,7 @@
             [ote.db.tx :as tx]
             [ote.db.transport-service :as t-service]
             [ote.db.lock :as lock]
-            [ote.util.db :refer [PgArray->vec]]
+            [ote.util.db :as util-db]
             [ote.util.feature :as feature]
             [ote.tasks.util :as tasks-util]
             [ote.integration.import.gtfs :as import-gtfs]
@@ -75,7 +75,7 @@
                      (fetch-given-gtfs-interface! db service-id interface-id)
                      (fetch-next-gtfs-interface! db config))
          interface (if (contains? interface :data-content)  ; Avoid creating a coll with empty key when coll doesn't exist
-                     (update interface :data-content PgArray->vec)
+                     (update interface :data-content  util-db/PgArray->vec)
                      interface)
          force-download? (integer? service-id)
          used-service-id (if service-id

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -59,7 +59,7 @@ SELECT t."package-id", trip."trip-id",
   JOIN "gtfs-stop" stop ON (stop."package-id" = r."package-id" AND stop."stop-id" = stoptime."stop-id")
  WHERE ROW(r."package-id", t."service-id")::service_ref IN
        (SELECT * FROM gtfs_services_for_date(
-        (SELECT gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)), :date::DATE))
+        (SELECT gtfs_service_packages_for_detection_date(:service-id::INTEGER, :date::DATE, :detection-date::DATE)), :date::DATE))
    AND r."route-hash-id" = :route-hash-id
  ORDER BY p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence";
 

--- a/ote/src/clj/ote/util/db.clj
+++ b/ote/src/clj/ote/util/db.clj
@@ -9,3 +9,10 @@
   (if arr
     (vec (.getArray arr))
     []))
+
+(defn str-vec->str [v]
+  "Mainly convert used-packages vector of strings to list of integers"
+  (let [val (str "{"
+                 (clojure.string/join "," v)
+                 "}")]
+    val))


### PR DESCRIPTION
# Fixed
* transit-visualization: Fixed trip fetch. It used wrong package to get trips. Now changed to those packages that were present when detection was made.
* There were also another bug in these situations where service has multiple interfaces. Detection used to find same date has twice which ended up adding non change to route changes list. Those non-changes are now filtered out.
   
