### PR TITLE
173657270 Filter wrong data-contents off from child-parent interfaces update

### DIFF
--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -35,3 +35,8 @@ UPDATE gtfs_package p SET "external-interface-description-id" = :new-interface-i
 -- name: select-old-packages
 select * from gtfs_package p WHERE p."transport-service-id" = :service-id AND p."external-interface-description-id" NOT IN (:ids);
 
+-- name: fetch-child-service-interfaces
+SELECT e.id, (e."external-interface").url as url
+  FROM "external-interface-description" e
+ WHERE e."transport-service-id" = :service-id
+   AND 'route-and-schedule' = ANY(e."data-content");


### PR DESCRIPTION
## Fixed
* Edit transport service: When service is modified all interface id:s changes. Those new id's must be updated to package_gtfs table to ensure that change detection finds correct packages. When updating interface id:s there were filttering problem. Sql query didn't filter out json type interfaces and those id's were used in package_gtfs table.
Now fixed
   

