### PR TITLE
173657270 - Save interface original id to db when editing service data

### DIFF
--- a/database/src/main/resources/db/migration/V1_189__origina_interface_id.sql
+++ b/database/src/main/resources/db/migration/V1_189__origina_interface_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "external-interface-description"
+ ADD COLUMN "original-interface-id" INTEGER DEFAULT NULL;

--- a/ote/src/clj/ote/services/transport.clj
+++ b/ote/src/clj/ote/services/transport.clj
@@ -268,10 +268,7 @@
                   (map
                     (fn [row]
                       (let [url (:url row)
-                            original-id (::t-service/id (first (specql/fetch db ::t-service/external-interface-description
-                                                                             (specql/columns ::t-service/external-interface-description)
-                                                                             {::t-service/transport-service-id parent-id
-                                                                              ::t-service/external-interface {::t-service/url url}})))
+                            orig-interface-id (:original-interface-id row)
                             ;; Update download history
                             _ (specql/update! db ::t-service/external-interface-download-status
                                               {::t-service/external-interface-description-id (:id row)}
@@ -281,7 +278,7 @@
                             _ (specql/update! db :gtfs/package
                                               {:gtfs/external-interface-description-id (:id row)}
                                               {:gtfs/transport-service-id parent-id
-                                               :gtfs/external-interface-description-id original-id})]
+                                               :gtfs/external-interface-description-id orig-interface-id})]
                         (:id row)))
                     child-interface-id-list))
         ids (mapv #(::t-service/id %) child-interface-id-list)
@@ -501,6 +498,9 @@
                                               (fn [interface]
                                                 (-> interface
                                                     (assoc ::t-service/transport-service-id transport-service-id)
+                                                    ;; Save original id
+                                                    (assoc ::t-service/original-interface-id (::t-service/id interface))
+                                                    ;; Remove id so it can be saved to new service with different id
                                                     (dissoc ::t-service/id)))
                                               external-interfaces)
                     nil)

--- a/ote/src/clj/ote/services/transport.sql
+++ b/ote/src/clj/ote/services/transport.sql
@@ -36,7 +36,7 @@ UPDATE gtfs_package p SET "external-interface-description-id" = :new-interface-i
 select * from gtfs_package p WHERE p."transport-service-id" = :service-id AND p."external-interface-description-id" NOT IN (:ids);
 
 -- name: fetch-child-service-interfaces
-SELECT e.id, (e."external-interface").url as url
+SELECT e.id, (e."external-interface").url as url, "original-interface-id"
   FROM "external-interface-description" e
  WHERE e."transport-service-id" = :service-id
    AND 'route-and-schedule' = ANY(e."data-content");


### PR DESCRIPTION
# Fixed
* modify service - publish service: When transport service is moved to validation we make a duplicate of it. This process affects on gtfs_package table. To fix those package download issues, we need to update old interface id's with new one. This fixes this issue completely.
   

