### PR TITLE
172691911-Fix detection queries for services with multiple interfaces

### DIFF
--- a/ote/src/clj/ote/services/transit_visualization.clj
+++ b/ote/src/clj/ote/services/transit_visualization.clj
@@ -155,7 +155,7 @@
                                                                    :specql.core/order-direction :desc
                                                                    :specql.core/limit 1})))})))
 
-
+  ;; Colors and hashes for calendar
   ^{:unauthenticated false :format :transit}
   (GET "/transit-visualization/:service-id/route"
        {{:keys [service-id]} :params
@@ -186,7 +186,7 @@
   ^{:unauthenticated false :format :transit}
   (GET "/transit-visualization/:service-id/route-trips-for-date"
        {{service-id :service-id} :params
-        {:strs [date used-packages route-hash-id]} :query-params
+        {:strs [date used-packages route-hash-id detection-date]} :query-params
         user :user}
     (or (authorization/transit-authority-authorization-response user)
         (into []
@@ -196,6 +196,7 @@
                 {:service-id (Long/parseLong service-id)
                  :date (time/parse-date-iso-8601 date)
                  :used-packages (util-db/str-vec->str used-packages)
+                 :detection-date detection-date
                  :route-hash-id route-hash-id}))))
 
   ^{:unauthenticated false :format :transit}

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -123,11 +123,11 @@
          ;; Start from the beginning of last week
          start-date (time/days-from (time/beginning-of-week detection-date) -7)
          ;; Date in future up to where traffic should be analysed
-         end-date (time/days-from start-date (:detection-window-days (config-tc/config)))
+         end-date (time/days-from start-date  (:detection-window-days (config-tc/config)))
 
          ;; Convert to LocalDate instances
-         [start-date end-date today] (map (comp time/date-fields->date time/date-fields)
-                                          [start-date end-date detection-date])]
+         [start-date end-date today query-detection-date] (map (comp time/date-fields->date time/date-fields)
+                                          [start-date end-date detection-date detection-date])]
      (lock/try-with-lock
        db "gtfs-nightly-changes" lock-time-in-seconds
        (let [;; run detection only for given services or all
@@ -144,7 +144,7 @@
                                    :start-date start-date
                                    :end-date end-date}
                      _ (log/info "Detecting :: query-params" (pr-str query-params))
-                     packages-for-detection (detection/service-package-ids-for-date-range db query-params detection-date-in-the-past?)]
+                     packages-for-detection (detection/service-package-ids-for-date-range db query-params detection-date-in-the-past? query-detection-date)]
                  (detection/update-transit-changes!
                    db detection-date service-id
                    packages-for-detection

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -1039,9 +1039,10 @@
         headsign (:gtfs/trip-headsign x)]
     (str short "-" long "-" headsign)))
 
-(defn service-package-ids-for-date-range [db query-params detection-date-in-the-past?]
+(defn service-package-ids-for-date-range [db query-params detection-date-in-the-past? detection-date]
   (if detection-date-in-the-past?
-    (mapv :id (service-packages-for-detection-date db query-params))
+    (mapv :id (service-packages-for-detection-date db (merge {:detection-date detection-date}
+                                                             query-params)))
     (mapv :id (service-packages-for-date-range db query-params))))
 
 ;; This is only for local development

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -6,7 +6,8 @@ WITH dates AS (
 )
 SELECT x.date AS DATE, string_agg(x.hash,' ' ORDER BY x.eid asc) AS hash, x."route-hash-id" AS "route-hash-id"
 FROM (
-       SELECT d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign",
+       SELECT DISTINCT ON (concat(d.date, rh.hash)) concat(d.date, rh.hash) as ddd,
+                                                    d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign",
               COALESCE(rh."route-hash-id", :route-hash-id) as "route-hash-id", e.id as eid,
               string_agg(rh.hash::text, ' ' ORDER BY e.id ASC) as hash
          FROM dates d
@@ -17,9 +18,9 @@ FROM (
               LEFT JOIN gtfs_package p ON p.id = dh."package-id" AND p."deleted?" = FALSE
               LEFT JOIN "external-interface-description" e ON e.id = p."external-interface-description-id"
               LEFT JOIN LATERAL unnest(dh."route-hashes") AS rh ON rh."route-hash-id" = :route-hash-id
-        GROUP BY d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign", rh."route-hash-id" , eid
-        ORDER BY d.date) x
-GROUP BY x.date, x."route-hash-id";
+        GROUP BY d.date, rh."route-short-name", rh."route-long-name", rh."trip-headsign", rh."route-hash-id", rh.hash, eid) x
+GROUP BY x.date, x."route-hash-id"
+ORDER BY x.date asc;
 
 -- name: service-packages-for-date-range
 WITH dates AS (
@@ -36,54 +37,74 @@ WITH dates AS (
     FROM generate_series(0, :end-date::DATE - :start-date::DATE) s (d)
 )
 SELECT DISTINCT pids.id
-  FROM dates d
-       JOIN LATERAL unnest(gtfs_packages_for_detection(:service-id::INTEGER, d.date)) pids (id) ON TRUE;
+  FROM gtfs_package p,
+       dates d
+       JOIN LATERAL unnest(gtfs_packages_for_detection(:service-id::INTEGER, d.date)) pids (id) ON TRUE
+ WHERE p."transport-service-id" = :service-id::INTEGER
+   AND pids.id = p.id
+   AND p.created <= :detection-date::DATE;
 
 -- name: service-routes-with-date-range
 SELECT * FROM gtfs_routes_for_change_detection(:service-id::INTEGER, :detection-date::DATE);
 
 -- name: fetch-route-trips-for-date-in-detection
-WITH routes AS (
-    SELECT DISTINCT ON (dr."route-id") dr."route-id", id, "package-id", "route-hash-id"
-      FROM "detection-route" dr
-     WHERE dr."package-id" in (SELECT unnest(gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)))
-)
-SELECT t."package-id", trip."trip-id",
-       stoptime."stop-id", stoptime."departure-time", stoptime."stop-sequence",
-        stop."stop-name", stop."stop-lat", stop."stop-lon", stop."stop-fuzzy-lat", stop."stop-fuzzy-lon"
-  FROM routes r
-  JOIN "gtfs_package" p ON p.id = r."package-id" AND p."deleted?" = FALSE
-  JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
-  JOIN LATERAL unnest(t.trips) trip ON true
-  JOIN LATERAL unnest(trip."stop-times") as stoptime ON TRUE
-  JOIN "gtfs-stop" stop ON (stop."package-id" = r."package-id" AND stop."stop-id" = stoptime."stop-id")
- WHERE ROW(r."package-id", t."service-id")::service_ref IN
-       (SELECT * FROM gtfs_services_for_date(
-        (SELECT gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)), :date::DATE))
-   AND r."route-hash-id" = :route-hash-id
- ORDER BY p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence";
+SELECT x."package-id", x."route-id", x."trip-id",
+       x."stop-id", x."departure-time", x."stop-sequence",
+       x."stop-name", x."stop-lat", x."stop-lon", x."stop-fuzzy-lat", x."stop-fuzzy-lon"
+FROM (
+         WITH routes AS (
+             SELECT --DISTINCT ON (dr."route-id")
+                    dr."route-id",
+                    id, "package-id", "route-hash-id"
+             FROM "detection-route" dr
+             WHERE dr."package-id" in (SELECT unnest(gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)))
+         )
+         SELECT DISTINCT ON (concat(stoptime."stop-id",stoptime."departure-time", stoptime."stop-sequence"))
+             concat(stoptime."stop-id",stoptime."departure-time", stoptime."stop-sequence") as ddd,
+             t."package-id", r."route-id", trip."trip-id",
+             stoptime."stop-id", stoptime."departure-time", stoptime."stop-sequence",
+             stop."stop-name", stop."stop-lat", stop."stop-lon", stop."stop-fuzzy-lat", stop."stop-fuzzy-lon"
+         FROM routes r
+                  JOIN "gtfs_package" p ON p.id = r."package-id" AND p."deleted?" = FALSE
+                  JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
+                  JOIN LATERAL unnest(t.trips) trip ON true
+                  JOIN LATERAL unnest(trip."stop-times") as stoptime ON TRUE
+                  JOIN "gtfs-stop" stop ON (stop."package-id" = r."package-id" AND stop."stop-id" = stoptime."stop-id")
+         WHERE ROW(r."package-id", t."service-id")::service_ref IN
+               (SELECT * FROM gtfs_services_for_date(
+                       (SELECT gtfs_service_packages_for_date(:service-id::INTEGER, :date::DATE)), :date::DATE))
+           AND r."route-hash-id" = :route-hash-id
+         ORDER BY ddd,p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence") x
+order BY x."trip-id",  x."stop-sequence",  x."departure-time";
 
 -- name: fetch-route-trips-for-date-to-visualization
-WITH routes AS (
-    SELECT DISTINCT ON (dr."route-id") dr."route-id", id, "package-id", "route-hash-id"
-    FROM "detection-route" dr
-    WHERE dr."package-id" in (SELECT unnest(gtfs_service_packages_for_detection_date(:service-id::INTEGER, :date::DATE,:detection-date::DATE)))
-)
-SELECT t."package-id", trip."trip-id",
-       stoptime."stop-id", stoptime."departure-time", stoptime."stop-sequence",
-       stop."stop-name", stop."stop-lat", stop."stop-lon", stop."stop-fuzzy-lat", stop."stop-fuzzy-lon"
-FROM routes r
-         JOIN "gtfs_package" p ON p.id = r."package-id" AND p."deleted?" = FALSE
-         JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
-         JOIN LATERAL unnest(t.trips) trip ON true
-         JOIN LATERAL unnest(trip."stop-times") as stoptime ON TRUE
-         JOIN "gtfs-stop" stop ON (stop."package-id" = r."package-id" AND stop."stop-id" = stoptime."stop-id")
-WHERE ROW(r."package-id", t."service-id")::service_ref IN
-      (SELECT * FROM gtfs_services_for_date(
-              (SELECT gtfs_service_packages_for_detection_date(:service-id::INTEGER, :date::DATE, :detection-date::DATE)), :date::DATE))
-  AND r."route-hash-id" = :route-hash-id
-ORDER BY p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence";
-
+SELECT x."package-id", x."route-id", x."trip-id",
+       x."stop-id", x."departure-time", x."stop-sequence",
+       x."stop-name", x."stop-lat", x."stop-lon", x."stop-fuzzy-lat", x."stop-fuzzy-lon"
+FROM (
+    WITH routes AS (
+        SELECT --DISTINCT ON (dr."route-id")
+        dr."route-id", id, "package-id", "route-hash-id"
+        FROM "detection-route" dr
+        WHERE dr."package-id" in (SELECT unnest(gtfs_service_packages_for_detection_date(:service-id::INTEGER, :date::DATE,:detection-date::DATE)))
+    )
+    SELECT DISTINCT ON (concat(stoptime."stop-id",stoptime."departure-time", stoptime."stop-sequence"))
+        concat(stoptime."stop-id",stoptime."departure-time", stoptime."stop-sequence") as ddd,
+           t."package-id", r."route-id", trip."trip-id",
+           stoptime."stop-id", stoptime."departure-time", stoptime."stop-sequence",
+           stop."stop-name", stop."stop-lat", stop."stop-lon", stop."stop-fuzzy-lat", stop."stop-fuzzy-lon"
+    FROM routes r
+             JOIN "gtfs_package" p ON p.id = r."package-id" AND p."deleted?" = FALSE
+             JOIN "gtfs-trip" t ON (t."package-id" = r."package-id" AND r."route-id" = t."route-id")
+             JOIN LATERAL unnest(t.trips) trip ON true
+             JOIN LATERAL unnest(trip."stop-times") as stoptime ON TRUE
+             JOIN "gtfs-stop" stop ON (stop."package-id" = r."package-id" AND stop."stop-id" = stoptime."stop-id")
+    WHERE ROW(r."package-id", t."service-id")::service_ref IN
+          (SELECT * FROM gtfs_services_for_date(
+                  (SELECT gtfs_service_packages_for_detection_date(:service-id::INTEGER, :date::DATE, :detection-date::DATE)), :date::DATE))
+      AND r."route-hash-id" = :route-hash-id
+    ORDER BY ddd,p."external-interface-description-id", t."package-id", trip."trip-id", stoptime."stop-sequence") x
+ORDER BY x."trip-id",  x."stop-sequence",  x."departure-time";
 
 -- name: generate-date-hashes
 SELECT gtfs_generate_date_hashes(:package-id::INTEGER, :transport-service-id::INTEGER);


### PR DESCRIPTION
# Fixed
* transit change detection: Fixed db queries for services with multiple interfaces and identical traffic from all.
   

