### PR TITLE
174987587 mark interface deleted

### DIFF
--- a/database/src/main/resources/db/migration/V1_190__mark_interfaces_removed_for_packages.sql
+++ b/database/src/main/resources/db/migration/V1_190__mark_interfaces_removed_for_packages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "gtfs_package"
+    ADD COLUMN "interface-deleted?" BOOLEAN DEFAULT FALSE;

--- a/ote/src/clj/ote/services/transit_visualization.sql
+++ b/ote/src/clj/ote/services/transit_visualization.sql
@@ -202,3 +202,12 @@ SELECT h."change-detected", c."route-short-name", c."route-long-name", c."trip-h
        LEFT JOIN "detected-change-history" h ON h."transport-service-id" = c."transit-service-id" AND h."change-key" = c."change-key"
  WHERE c."transit-change-date" = :date
    AND c."transit-service-id" = :service-id;
+
+-- name: latest-transit-changes-for-visualization
+SELECT tc.date, tc."added-routes", tc."removed-routes", tc."changed-routes", tc."no-traffic-routes",
+       string_agg(concat(p.id::TEXT,',', p.created::TEXT,',', p."deleted?"::TEXT,',', p."interface-deleted?"::TEXT,',',ds.url::TEXT), ';') AS "package-info"
+  FROM "gtfs-transit-changes" tc
+        JOIN gtfs_package p ON p.id = ANY(tc."package-ids") AND p."transport-service-id" = :service-id
+        LEFT JOIN "external-interface-download-status" ds ON ds."external-interface-description-id" = p."external-interface-description-id"
+ WHERE tc."transport-service-id" = :service-id
+ GROUP BY tc.date,tc."added-routes", tc."removed-routes", tc."changed-routes", tc."no-traffic-routes";

--- a/ote/src/clj/ote/services/users.clj
+++ b/ote/src/clj/ote/services/users.clj
@@ -21,7 +21,6 @@
             [taoensso.timbre :as log]
             [ote.time :as time]
             [clj-time.core :as t]
-            [clj-time.coerce :as tc]
             [ote.util.throttle :as throttle]
             [clj-time.coerce :as tc])
   (:import (java.util UUID)))

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -149,7 +149,8 @@
                                    :start-date start-date
                                    :end-date end-date}
                      _ (log/info "Detecting :: query-params" (pr-str query-params))
-                     packages-for-detection (detection/service-package-ids-for-date-range db query-params detection-date-in-the-past? query-detection-date)]
+                     packages-for-detection (detection/service-package-ids-for-date-range db query-params detection-date-in-the-past? query-detection-date)
+                     _ (log/info "Detecting :: packages-for-detection " (pr-str packages-for-detection))]
                  (detection/update-transit-changes!
                    db detection-date service-id
                    packages-for-detection

--- a/ote/src/clj/ote/transit_changes/detection.clj
+++ b/ote/src/clj/ote/transit_changes/detection.clj
@@ -1050,7 +1050,7 @@
       (log/info "Getting package-ids for service. Using query that returns packages from deleted interface also.")
       (mapv :id (service-packages-for-date-range db query-params)))
     (do
-      (log/info "Getting package-ids for service. Using query that is optimated for newest detection date.")
+      (log/info "Getting package-ids for service. Using query that is optimized for newest detection date.")
       (mapv :id (service-packages-for-detection-date db (merge {:detection-date detection-date}
                                                                query-params))))))
 

--- a/ote/src/clj/ote/transit_changes/detection.sql
+++ b/ote/src/clj/ote/transit_changes/detection.sql
@@ -32,6 +32,8 @@ SELECT DISTINCT pids.id
   JOIN LATERAL unnest(gtfs_service_packages_for_date(:service-id::INTEGER, d.date)) pids (id) ON TRUE;
 
 -- name: service-packages-for-detection-date
+-- These packages are fetched for change detection. Change detection doesn't need
+-- packages that are fetched from interface that is deleted.
 WITH dates AS (
     SELECT :start-date::DATE + d AS date
     FROM generate_series(0, :end-date::DATE - :start-date::DATE) s (d)
@@ -42,6 +44,7 @@ SELECT DISTINCT pids.id
        JOIN LATERAL unnest(gtfs_packages_for_detection(:service-id::INTEGER, d.date)) pids (id) ON TRUE
  WHERE p."transport-service-id" = :service-id::INTEGER
    AND pids.id = p.id
+   AND p."interface-deleted?" = false
    AND p.created::DATE <= :detection-date::DATE;
 
 -- name: service-routes-with-date-range

--- a/ote/src/cljs/ote/app/controller/transit_visualization.cljs
+++ b/ote/src/cljs/ote/app/controller/transit_visualization.cljs
@@ -173,6 +173,12 @@
                              sorted-changes)]
     all-sorted-changes))
 
+(define-event OpenPackageInfoPackageIdLink [link-id]
+  {:path [:transit-visualization]}
+  (if (= (:package-id-link app) link-id)
+    (dissoc app :package-id-link)
+    (assoc app :package-id-link link-id)))
+
 (define-event RoutesForDatesResponse [routes dates]
   {:path [:transit-visualization :compare]}
   (if (= dates (select-keys app [:date1 :date2]))

--- a/ote/test/clj/ote/db/service_generators.clj
+++ b/ote/test/clj/ote/db/service_generators.clj
@@ -143,6 +143,14 @@
              :parking ::t-service/parking
              :rentals ::t-service/rentals) type-specific)))
 
+(defn service-sub-type-generator [service-sub-type]
+  (gen/let [common gen-transport-service-common
+            type (gen/return :passenger-transportation)]
+     (-> common
+           (assoc ::t-service/type type)
+           (assoc ::t-service/sub-type service-sub-type)
+           (assoc ::t-service/passenger-transportation (gen/generate gen-passenger-transportation)))))
+
 (def gen-transport-service
   (gen/frequency
    [[3 (service-type-generator :passenger-transportation)]

--- a/ote/test/clj/ote/services/transport_test.clj
+++ b/ote/test/clj/ote/services/transport_test.clj
@@ -240,5 +240,122 @@
 
     ;; Try to fetch now and it does not exist
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"status 404"
-         (http-get "normaluser" (str "transport-service/" id))))))
+          clojure.lang.ExceptionInfo #"status 404"
+          (http-get "normaluser" (str "transport-service/" id))))))
+
+(defn- create-new-package [db operator-id ts-id interface-id]
+  (let [new-gtfs-hash (gtfs-import/gtfs-hash "sdfsdf")]
+    (specql/insert! db :gtfs/package
+                    {:gtfs/sha256 new-gtfs-hash
+                     :gtfs/first_package true               ;;
+
+                     :gtfs/transport-operator-id operator-id
+                     :gtfs/transport-service-id ts-id
+                     :gtfs/created (time-coerce/to-sql-date (time/now))
+                     :gtfs/etag (str "etag-" ts-id)
+                     :gtfs/license "license"
+                     :gtfs/external-interface-description-id interface-id})))
+
+(defn- clean-service-for-printing [service]
+  (-> service
+      (dissoc :ote.db.transport-service/operation-area)
+      (dissoc :ote.db.transport-service/description)
+      (dissoc :ote.db.transport-service/contact-address)
+      (dissoc :ote.db.transport-service/homepage)
+      (dissoc :ote.db.transport-service/passenger-transportation)))
+
+(defn- clean-interfaces-for-printing [interfaces]
+  (map #(-> %
+            (update ::t-service/external-interface dissoc ::t-service/description)
+            (update ::t-service/external-interface dissoc ::t-service/format)
+            (update ::t-service/external-interface dissoc ::t-service/license))
+       interfaces))
+
+(deftest update-external-interface-url
+  (let [operator-id 2                                       ;; force operator id
+        db (:db ote.test/*ote*)
+        generated-service (gen/generate (s-generators/service-sub-type-generator :schedule))
+        ;; Generated interfaces cannot be trusted so create one with correct data
+        default-interface {::t-service/external-interface {::t-service/url "www.default.url"
+                                                           ::t-service/description [{::t-service/lang "FI",
+                                                                                     ::t-service/text "Default text"}]}
+                           ::t-service/data-content [:route-and-schedule]
+                           ::t-service/format ["GTFS"]
+                           ::t-service/license "jnppWN61pC0u77PG4ha0"}
+        generated-service (-> generated-service
+                              (assoc ::t-service/transport-operator-id operator-id)
+                              (dissoc ::t-service/external-interfaces)
+                              (assoc-in [::t-service/external-interfaces] [default-interface])
+                              ;; "move" to validation
+                              (assoc ::t-service/validate? (time-coerce/to-sql-date (time/now))))
+        saved-service (:transit (http-post (:user-id-normal @ote.test/user-db-ids-atom) "transport-service" generated-service))
+        service-id (::t-service/id saved-service)
+        saved-service (:transit (http-get "normaluser" (str "transport-service/" service-id)))
+        ;; Ensure that service is in validate state (admin must accept the service)
+        _ (is (not (nil? (::t-service/validate saved-service)))) ;; in validation
+        _ (is (nil? (::t-service/published saved-service))) ;; not published
+        _ (is (nil? (::t-service/re-edit saved-service)))   ;; not in re-edit
+
+        ;; Generated services are not published, publish this one
+        _ (http-post (:user-id-admin @ote.test/user-db-ids-atom) "admin/publish-service" {:id service-id})
+        ;; And fetch it
+        saved-service (:transit (http-get "normaluser" (str "transport-service/" service-id)))
+        ;; Ensure that service is in published state
+        _ (is (not (nil? (::t-service/published saved-service)))) ;; is published
+        _ (is (nil? (::t-service/validate saved-service)))  ;; not in validation
+        _ (is (nil? (::t-service/re-edit saved-service)))   ;; not in re-edit
+
+        ;; Create package with received interface-id
+        interfaces (::t-service/external-interfaces saved-service)
+        packages (doall (mapv
+                          (fn [interface]
+                            (create-new-package db operator-id service-id (::t-service/id interface)))
+                          interfaces))]
+    ;; Saved ok
+    (is (pos? service-id))
+
+    ;; Fetch and update
+    (let [;; Service must be changed to validate state to make changes to interfaces
+          v-service (assoc saved-service ::t-service/validate? (time-coerce/to-sql-date (time/now)))
+          ;; Edit interface -> if only url changes and id remains the same, everything should be as before
+          ;; That is why we "delete" and "create new interface" by changing the interface id to nil
+          v-service (-> v-service
+                        (update-in [::t-service/external-interfaces 0] dissoc ::t-service/id)
+                        (assoc-in [::t-service/external-interfaces 0 ::t-service/external-interface ::t-service/url] "first-change.com"))
+          v-service (:transit (http-post (:user-id-normal @ote.test/user-db-ids-atom) "transport-service" v-service))
+          v-service (:transit (http-get "normaluser" (str "transport-service/" (::t-service/id v-service))))
+          ;; Ensure that service is not in published state to make additional changes to it
+          _ (is (not (nil? (::t-service/validate v-service)))) ;;in validation
+          _ (is (nil? (::t-service/published v-service)))   ;; not published
+          _ (is (nil? (::t-service/re-edit v-service)))     ;;not in re-edit
+          _ (is (not (nil? (::t-service/parent-id v-service)))) ;;has parent-id
+          parent-id (::t-service/parent-id v-service)
+
+          ;; publish service again
+          _ (http-post (:user-id-admin @ote.test/user-db-ids-atom) "admin/publish-service" {:id (::t-service/id v-service)})
+          ;; fetch original service using parent-id
+          p-service (:transit (http-get "normaluser" (str "transport-service/" parent-id)))
+
+          ;; Ensure that service is in published state
+          _ (is (not (nil? (::t-service/published p-service))))
+          _ (is (nil? (::t-service/validate p-service)))    ;; not in validate
+          _ (is (nil? (::t-service/re-edit p-service)))     ;; not in re-edit
+          _ (is (nil? (::t-service/parent-id p-service)))   ;; is not child
+
+          ;; Get possibly changed packages
+          possibly-changed-packages (:transit
+                                      (http-get (:user-id-admin @ote.test/user-db-ids-atom) (str "admin/service-gtfs-packages/" parent-id)))]
+      ;; interface-id should be changed
+      (is (not= (:gtfs/external-interface-description-id (first packages)) (:gtfs/external-interface-description-id (first possibly-changed-packages))))
+      (is (= true (:gtfs/interface-deleted? (first possibly-changed-packages)))))
+
+    ;; Delete
+    (let [delete-response (http-post (:user-id-normal @ote.test/user-db-ids-atom)
+                                     "transport-service/delete"
+                                     {:id service-id})]
+      (is (= (:transit delete-response) service-id)))
+
+    ;; Try to fetch now and it does not exist
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo #"status 404"
+          (http-get "normaluser" (str "transport-service/" service-id))))))


### PR DESCRIPTION
# Fixed
* In change detection wasn't possible to identify which packages were downloaded from deleted interfaces and which weren't. Now gtfs_package table contains interface-deleted? boolean which is used when todays change-detection is run.
It won't affect if change detection is run in the past.
   
# Datamodel
* Add interface-deleted? column to gtfs_package table
   
